### PR TITLE
Fix nav issues and remove unnecessary version-related info

### DIFF
--- a/versions/v1.3/modules/en/nav.adoc
+++ b/versions/v1.3/modules/en/nav.adoc
@@ -114,18 +114,18 @@
 **** xref:integrations/rancher/node-driver/rke1-cluster.adoc[]
 **** xref:integrations/rancher/node-driver/rke2-cluster.adoc[]
 **** xref:integrations/rancher/node-driver/k3s-cluster.adoc[]
-** xref:integrations/rancher/cloud-provider.adoc[]
-** xref:integrations/rancher/csi-driver.adoc[]
-** xref:integrations/rancher/resource-quota.adoc[]
-** xref:integrations/rancher/rancher-terraform-provider.adoc[]
-** xref:integrations/rancher/import-harvester-vm.adoc[]
+*** xref:integrations/rancher/cloud-provider.adoc[]
+*** xref:integrations/rancher/csi-driver.adoc[]
+*** xref:integrations/rancher/resource-quota.adoc[]
+*** xref:integrations/rancher/rancher-terraform-provider.adoc[]
+*** xref:integrations/rancher/import-harvester-vm.adoc[]
 // Folder: integrations/terraform:
 ** xref:integrations/terraform/terraform-provider.adoc[]
 
 // Folder: troubleshooting:
 
 * Troubleshooting
-* xref:troubleshooting/faq.adoc[]
+** xref:troubleshooting/faq.adoc[]
 ** xref:troubleshooting/installation.adoc[]
 ** xref:troubleshooting/operating-system.adoc[]
 ** xref:troubleshooting/harvester-cluster.adoc[]

--- a/versions/v1.3/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,7 +1,5 @@
 = NVIDIA Driver Toolkit
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 [NOTE]

--- a/versions/v1.3/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,6 +1,4 @@
-= PCI Devices
-
-_Available as of v1.1.0_
+= PCI Devices Controller
 
 A `PCIDevice` in Harvester represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource,

--- a/versions/v1.3/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,7 +1,5 @@
 = Rancher Manager (Experimental)
 
-_Available as of v1.2.0_
-
 The `rancher-vcluster` addon allows you to run Rancher Manager as a workload on the underlying Harvester cluster and is implemented using https://www.vcluster.com/[vcluster].
 
 image::vm-import-controller/EnableAddon.png[]

--- a/versions/v1.3/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,6 +1,4 @@
-= Managed DHCP
-
-_Available as of v1.3.0_
+= VM DHCP Controller (Managed DHCP)
 
 Beginning with v1.3.0, you can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.3/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,6 +1,4 @@
-= VM Import
-
-_Available as of v1.1.0_
+= VM Import Controller
 
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.
 

--- a/versions/v1.3/modules/en/pages/developer/developer-mode-installation.adoc
+++ b/versions/v1.3/modules/en/pages/developer/developer-mode-installation.adoc
@@ -1,7 +1,6 @@
 = Developer Mode
 
 [CAUTION]
-.attention
 ====
 
 Developer mode is intended to be used for development and testing purposes. Usage of this mode in production environments is not supported.
@@ -98,7 +97,6 @@ If you are unable to locate the kubectl binary in `/usr/local/bin`, check `/var/
 +
 
 [IMPORTANT]
-.important
 ====
 Allow some time for all pods in the `cattle-system` namespace to reach the `Ready` state before proceeding to the next step.
 ====

--- a/versions/v1.3/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/hosts.adoc
@@ -67,7 +67,6 @@ Removing a control plane node in this situation is not recommended because etcd 
 . Go back to the *Node* screen and verify that *Replicas* value for the node to be removed is *0*.
 
 [IMPORTANT]
-.important
 ====
 Eviction cannot be completed if the remaining nodes cannot accept replicas from the node to be removed. In this case, some volumes will remain in the *Degraded* state until you add more nodes to the cluster.
 ====
@@ -103,7 +102,6 @@ All workloads have been successfully evicted if the node state is *Maintenance*.
 image::host/node-maintain-completed.png[node-maintain-completed.png]
 
 [IMPORTANT]
-.important
 ====
 If a cluster has only two control plane nodes, Harvester does not allow you to enable Maintenance Mode on any node. You can manually drain the node to be removed using the following command:
 

--- a/versions/v1.3/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/hosts.adoc
@@ -259,8 +259,6 @@ image::host/remove-disks-harvester-remove.png[Remove disk]
 
 == Ksmtuned Mode
 
-_Available as of v1.1.0_
-
 Ksmtuned is a KSM automation tool deployed as a DaemonSet to run Ksmtuned on each node. It will start or stop the KSM by watching the available memory percentage ratio (*i.e. Threshold Coefficient*). By default, you need to manually enable Ksmtuned on each node UI. You will be able to see the KSM statistics from the node UI after 1-2 minutes.(check https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html#ksm-daemon-sysfs-interface[KSM] for more details).
 
 === Quick Run

--- a/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
@@ -43,7 +43,6 @@ After you select the first profile, the NVIDIA driver automatically configures t
 image::advanced/vgpuattachment.png[]
 +
 [IMPORTANT]
-.important
 ====
 Once a vGPU has been assigned to a VM, it may not be possible to disable the VM until the vGPU is removed.
 ====

--- a/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,7 +1,5 @@
 = vGPU Support
 
-_Available as of v1.3.0_
-
 Harvester now offers the capability to share NVIDIA GPU's supporting SRIOV based virtualisation as vGPU devices.
 
 The additional capability is provided by the `pcidevices-controller` addon, and leverages `sriov-manage` to manage the gpu. Please refer the https://docs.nvidia.com/grid/15.0/grid-vgpu-user-guide/index.html#creating-sriov-vgpu-device-red-hat-el-kvm[Nvidia Documentation] and your GPU documentation to identify if the GPU is supported.

--- a/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
@@ -1,7 +1,5 @@
 = Witness Node
 
-_Available as of v1.3.0_
-
 Harvester clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in Harvester) to ensure that a quorum is maintained.
 
 Some situations may require you to avoid deploying workloads and user data to management nodes. In these situations, one cluster node can be assigned the _witness_ role, which limits it to functioning as an etcd cluster member. The witness node is responsible for establishing a member quorum (a majority of nodes), which must agree on updates to the cluster state.

--- a/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
@@ -11,7 +11,6 @@ Witness nodes do not store any data, but the https://etcd.io/docs/v3.3/op-guide/
 Harvester v1.3.0 supports clusters with two management nodes and one witness node (and optionally, one or more worker nodes). For more information about node roles in Harvester, see xref:../hosts/hosts.adoc#_role_management[Role Management].
 
 [IMPORTANT]
-.important
 ====
 A node can be assigned the _witness_ role only at the time it joins a cluster. Each cluster can have only one witness node.
 ====

--- a/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,7 +1,5 @@
 = CloudInit CRD
 
-_Available as of v1.3.0_
-
 You can use the `CloudInit` CRD to configure Harvester operating system settings either manually or using GitOps solutions.
 
 == Background

--- a/versions/v1.3/modules/en/pages/installation-setup/config/harvester-configuration.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/harvester-configuration.adoc
@@ -478,8 +478,6 @@ os:
 
 === `install.addons`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Setting that defines the default addon status. Harvester addons are disabled by default.
 
 *Supported values*:
@@ -509,8 +507,6 @@ install:
 When enabled, the configuration is either retrieved from the value of `harvester.install.config_url` or defined individually using kernel parameters.
 
 === `install.data_disk`
-
-*Versions*: v1.0.1 and later
 
 *Definition*: Default device for storing VM data.
 
@@ -560,8 +556,6 @@ install:
 
 === `install.harvester.longhorn.default_settings.guaranteedEngineManagerCPU`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Engine Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node Harvester clusters, you can specify a value less than 12.
@@ -585,8 +579,6 @@ install:
 
 === `install.harvester.longhorn.default_settings.guaranteedReplicaManagerCPU`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Replica Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node Harvester clusters, you can specify a value less than 12.
@@ -609,8 +601,6 @@ install:
 ----
 
 === `install.harvester.storage_class.replica_count`
-
-*Versions*: v1.1.2 and later
 
 *Definition*: Replica count of the default Harvester StorageClass `harvester-longhorn`.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
@@ -144,8 +144,6 @@ image::advanced/containerd-registry.png[containerd-registry]
 
 === `csi-driver-config`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Configuration necessary for using third-party CSI drivers installed in the Harvester cluster.
 
 You must configure the following information before using features related to backups and snapshots:
@@ -166,8 +164,6 @@ You must configure the following information before using features related to ba
 ----
 
 === `default-vm-termination-grace-period-seconds`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Number of seconds Harvester waits before forcibly shutting down a VM that was stopped using the Harvester UI.
 
@@ -242,8 +238,6 @@ debug
 ----
 
 === `ntp-servers`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: NTP servers for time synchronization on Harvester nodes.
 
@@ -405,8 +399,6 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 
 === `support-bundle-image`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Support bundle image, with various versions available in https://hub.docker.com/r/rancher/support-bundle-kit/tags[rancher/support-bundle-kit].
 
 *Default value*:
@@ -420,8 +412,6 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 ----
 
 === `support-bundle-namespaces`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Additional namespaces that you can use when xref:../../troubleshooting/harvester-cluster.adoc#_generate_a_support_bundle[generating a support bundle].
 
@@ -443,8 +433,6 @@ Namespaces that you select are appended to the predefined namespaces list.
 *Default value*: None
 
 === `support-bundle-timeout`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Number of minutes Harvester allows for the completion of the support bundle generation process.
 
@@ -549,8 +537,6 @@ When the node becomes unavailable or is powered off, the VM only restarts and do
 == UI Settings
 
 === `branding`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Setting allows you to globally rebrand the Harvester UI by customizing the product name, logos, and color scheme.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,7 +1,5 @@
 = Install Harvester Binaries Only
 
-_Available as of v1.2.0_
-
 The `Install Harvester binaries only` mode allows you to install and configure binaries only, making it ideal for cloud and edge use cases.
 
 image::install/choose-installation-mode.png[choose-installation-mode.png]

--- a/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
@@ -43,7 +43,6 @@ Harvester nodes have the following hardware requirements and recommendations for
 |===
 
 [IMPORTANT]
-.important
 ====
 
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. Harvester is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.

--- a/versions/v1.3/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -25,7 +25,6 @@ For a detailed support matrix, please refer to the *Harvester CCM & CSI Driver w
 * The Harvester virtual machine guests' hostnames match their corresponding Harvester virtual machine names. Guest cluster Harvester VMs can't have different hostnames than their Harvester VM names when using the Harvester CSI driver. We hope https://github.com/harvester/harvester/issues/4396[to remove this limitation] in a future release of Harvester.
 
 [IMPORTANT]
-.important
 ====
 Each Harvester VM must have the `macvlan` kernel module, which is required for the `LoadBalancer` services of the *DHCP* IPAM mode.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -44,8 +44,6 @@ image::rancher/create-k3s-harvester-cluster.png[create-k3s-harvester-cluster]
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules. This provides high availability and better resource utilization.
 
 Node affinity can be added to the machine pools during the cluster creation:

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -77,8 +77,6 @@ Click to learn xref:./k3s-cluster.adoc[how to create k3s Kubernetes Clusters].
 
 == Topology spread constraints
 
-_Available as of v1.0.3_
-
 Within your guest Kubernetes cluster, you can use https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[topology spread constraints] to manage how workloads are distributed across nodes, accounting for factors such as failure domains like regions and zones. This helps achieve high availability and efficient resource utilization of the Harvester cluster resources.
 
 For RKE2 versions before `v1.25.x`, the minimum required versions to support the topology label sync feature are as follows:

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -55,8 +55,6 @@ See https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/n
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules, which can provide high availability and better resource utilization.
 
 Node affinity can be added to the node template during the cluster creation, click `Add Node Template` or edit your existing node template via `RKE1 Configuration > Node Templates`:

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -76,8 +76,6 @@ image:rancher/create-rke2-harvester-cluster-3.png[create-rke2-harvester-cluster-
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules, which can provide high availability and better resource utilization.
 
 Node affinity can be added to the machine pools during the cluster creation:
@@ -101,8 +99,6 @@ values: us-east-1a
 image::rancher/affinity-rke2-add-rules.png[affinity-add-rules]
 
 === Add workload affinity
-
-_Available as of v1.2.0 + Rancher v2.7.6_
 
 The workload affinity rules allow you to constrain which nodes your machines can be scheduled on based on the labels of workloads (VMs and Pods) already running on these nodes, instead of the node labels.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -57,8 +57,6 @@ image::rancher/harvester-node-driver.png[harvester-node-driver]
 
 == Harvester baremetal container workload support (experimental)
 
-_Available as of Harvester v1.2.0 + Rancher v2.7.6_
-
 Starting with Rancher v2.7.6, Harvester introduces a new feature that enables you to deploy and manage container workloads directly to the underlying Harvester cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
 
 image::rancher/harvester-container-dashboard.png[harvester-container-dashboard]
@@ -95,8 +93,6 @@ With this feature enabled, your Harvester cluster does not appear on the *Contin
 ====
 
 == Fleet Support (Experimental)
-
-_Available as of Harvester v1.3.0 + Rancher v2.7.9_
 
 Starting with Rancher v2.7.9, you can leverage https://fleet.rancher.io/[Fleet] for managing container workloads and configuring Harvester with a GitOps-based approach.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -61,8 +61,6 @@ For more information on how the memory overhead is calculated in Kubevirt, refer
 
 When the allocated resource quota controlled by the `ResourceQuota` object reaches its limit, migrating a VM becomes unfeasible. The migration process automatically creates a new pod mirroring the resource requirements of the source VM. If these pod creation prerequisites surpass the defined quota, the migration operation cannot proceed.
 
-_Available as of v1.2.0_
-
 In Harvester, the `ResourceQuota` values will dynamically expand ahead of migration to accommodate the resource needs of the target virtual machine. After migration, the ResourceQuotas will be reinstated to their prior configurations.
 
 Please be aware of the following constrains of the automatic resizing of `ResourceQuota`:

--- a/versions/v1.3/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.3/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,4 @@
-= Harvester Network Best Practice
+= Harvester Networking Best Practices
 
 == Replace Ethernet NICs
 
@@ -161,7 +161,6 @@ The enabled NICs are detected.
 There are one or more xref:./cluster-network.adoc#_how_to_create_a_new_cluster_network[Network Config] under every xref:./cluster-network.adoc#_cluster_network[Cluster Network] on Harvester. Each `Network Config` is backed by a `VlanConfig` CRD object.
 
 [IMPORTANT]
-.important
 ====
 Updating the `Network Config` is *required* if the new NICs will be placed in different physical slots or will have different uplink parameters.
 ====
@@ -271,7 +270,6 @@ If you observe any abnormalities, generate a xref:../troubleshooting/harvester-c
 === (Optional) Update the Network Config Again
 
 [IMPORTANT]
-.important
 ====
 Updating the `Network Config` is *required* if the new NICs will be placed in different physical slots.
 ====

--- a/versions/v1.3/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/cluster-network.adoc
@@ -4,8 +4,6 @@
 
 === Cluster Network
 
-_Available as of v1.1.0_
-
 In Harvester v1.1.0, we introduced a new concept called cluster network for traffic isolation.
 
 The following diagram describes a typical network architecture that separates data-center (DC) traffic from out-of-band (OOB) traffic.

--- a/versions/v1.3/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.3/modules/en/pages/networking/ip-pool.adoc
@@ -1,7 +1,5 @@
 = IP Pool
 
-_Available as of v1.2.0_
-
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 
 == Features

--- a/versions/v1.3/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.3/modules/en/pages/networking/load-balancer.adoc
@@ -1,7 +1,5 @@
 = Load Balancer
 
-_Available as of v1.2.0_
-
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 
 == VM load balancer

--- a/versions/v1.3/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/vm-network.adoc
@@ -8,8 +8,6 @@ Harvester provides three types of networks for virtual machines (VMs), including
 
 The management network is usually used for VMs whose traffic only flows inside the cluster. If your VMs need to connect to the external network, use the VLAN network or untagged network.
 
-_Available as of v1.0.1_
-
 Harvester also introduced storage networking to separate the storage traffic from other cluster-wide workloads. Please refer to xref:./storage-network.adoc[the storage network document] for more details.
 
 == Management Network

--- a/versions/v1.3/modules/en/pages/observability/harvester-logging.adoc
+++ b/versions/v1.3/modules/en/pages/observability/harvester-logging.adoc
@@ -1,7 +1,5 @@
 = Logging
 
-_Available as of v1.2.0_
-
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 
 `Harvester` collects the `cluster running log`, kubernetes `audit` and `event` log right after the cluster is powered on, which is helpful for monitoring, logging, auditing and troubleshooting.

--- a/versions/v1.3/modules/en/pages/observability/harvester-monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/observability/harvester-monitoring.adoc
@@ -1,7 +1,5 @@
 = Monitoring
 
-_Available as of v1.2.0_
-
 The monitoring feature is now implemented with an addon and is disabled by default in new installations.
 
 Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.

--- a/versions/v1.3/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.3/modules/en/pages/storage/csidriver.adoc
@@ -1,7 +1,5 @@
 = Third-Party Storage Support
 
-_Available as of v1.2.0_
-
 Harvester now offers the capability to install a https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] in your Harvester cluster. This allows you to leverage external storage for the Virtual Machine's non-system data disk, allowing you to use different drivers tailored for specific needs, whether for performance optimization or seamless integration with your existing in-house storage solutions.
 
 [NOTE]

--- a/versions/v1.3/modules/en/pages/troubleshooting/harvester-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/harvester-cluster.adoc
@@ -280,8 +280,6 @@ For more information, see https://github.com/harvester/harvester/issues/3383[Iss
 
 == Access Embedded Rancher and Longhorn Dashboards
 
-_Available as of v1.1.0_
-
 You can now access the embedded Rancher and Longhorn dashboards directly on the `Support` page, but you must first go to the `Preferences` page and check the `Enable Extension developer features` box under `Advanced Features`.
 
 image::troubleshooting/support-access-embedded-ui.png[]

--- a/versions/v1.3/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/installation.adoc
@@ -108,7 +108,7 @@ Please include the following information in a bug report when reporting a failed
 
 * A failed installation screenshot.
 * System information and logs.
- ** Available as of v1.0.2
+
 +
 Please follow the guide in <<Logging into the Harvester Installer (a live OS)>> to log in. And run the command to generate a tarball that contains troubleshooting information:
 +

--- a/versions/v1.3/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -13,7 +13,6 @@ For air-gapped environments, see link:./automatic.adoc#prepare-an-air-gapped-upg
 === 1. Two-node cluster upgrade stuck after the first node is pre-drained
 
 [IMPORTANT]
-.important
 ====
 
 Shut down all workload VMs before upgrading *two-node clusters* to prevent data loss.

--- a/versions/v1.3/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/access-vm.adoc
@@ -34,8 +34,6 @@ ssh_authorized_keys:
 
 === Dynamic SSH Key Injection via Qemu guest agent
 
-_Available as of v1.0.1_
-
 Harvester supports dynamically injecting public ssh keys at run time through the use of the https://wiki.qemu.org/Features/GuestAgent[qemu guest agent]. This is achieved through the `qemuGuestAgent` propagation method.
 
 [NOTE]

--- a/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -2,8 +2,6 @@
 
 == VM Backup & Restore
 
-_Available as of v0.3.0_
-
 VM backups are created from the *Virtual Machines* page. The VM backup volumes will be stored in the *Backup Target* (an NFS or S3 server), and they can be used to either restore a new VM or replace an existing VM.
 
 image:vm/vm-backup.png[]
@@ -96,8 +94,6 @@ You can choose to either delete or retain the previous volumes. By default, all 
 image::vm/vm-restore-existing.png[]
 
 === Restore a new VM on another Harvester cluster
-
-_Available as of v1.0.0_
 
 Users can now restore a new VM on another cluster by leveraging the VM metadata & content backup feature.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -102,7 +102,6 @@ _Available as of v1.0.0_
 Users can now restore a new VM on another cluster by leveraging the VM metadata & content backup feature.
 
 [IMPORTANT]
-.prerequisites
 ====
 You must manually configure the virtual machine images with the same name on the new cluster first, otherwise the virtual machines will be failed to recover.
 ====

--- a/versions/v1.3/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,7 +1,5 @@
 = Clone VM
 
-_Available as of v1.1.0_
-
 VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 
 == Clone VM with volume data

--- a/versions/v1.3/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/create-vm.adoc
@@ -122,8 +122,6 @@ See the https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 
 === Run Strategy
 
-_Available as of v1.0.2_
-
 Prior to v1.0.2, Harvester used the `Running` (a boolean) field to determine if the VM instance should be running. However, a simple boolean value is not always sufficient to fully describe the user's desired behavior. For example, in some cases the user wants to be able to shut down the instance from inside the virtual machine. If the `running` field is used, the VM will be restarted immediately.
 
 In order to meet the scenario requirements of more users, the `RunStrategy` field is introduced. This is mutually exclusive with `Running` because their conditions overlap somewhat. There are currently four `RunStrategies` defined:
@@ -188,8 +186,6 @@ If your OS is openSUSE and the version is less than 15.3, please replace `qemu-g
 ====
 
 === TPM Device
-
-_Available as of v1.2.0_
 
 https://en.wikipedia.org/wiki/Trusted_Platform_Module[Trusted Platform Module (TPM)] is a cryptoprocessor that secures hardware using cryptographic keys.
 

--- a/versions/v1.4/modules/en/nav.adoc
+++ b/versions/v1.4/modules/en/nav.adoc
@@ -115,18 +115,18 @@
 **** xref:integrations/rancher/node-driver/rke1-cluster.adoc[]
 **** xref:integrations/rancher/node-driver/rke2-cluster.adoc[]
 **** xref:integrations/rancher/node-driver/k3s-cluster.adoc[]
-** xref:integrations/rancher/cloud-provider.adoc[]
-** xref:integrations/rancher/csi-driver.adoc[]
-** xref:integrations/rancher/resource-quota.adoc[]
-** xref:integrations/rancher/rancher-terraform-provider.adoc[]
-** xref:integrations/rancher/import-harvester-vm.adoc[]
+*** xref:integrations/rancher/cloud-provider.adoc[]
+*** xref:integrations/rancher/csi-driver.adoc[]
+*** xref:integrations/rancher/resource-quota.adoc[]
+*** xref:integrations/rancher/rancher-terraform-provider.adoc[]
+*** xref:integrations/rancher/import-harvester-vm.adoc[]
 // Folder: integrations/terraform:
 ** xref:integrations/terraform/terraform-provider.adoc[]
 
 // Folder: troubleshooting:
 
 * Troubleshooting
-* xref:troubleshooting/faq.adoc[]
+** xref:troubleshooting/faq.adoc[]
 ** xref:troubleshooting/installation.adoc[]
 ** xref:troubleshooting/operating-system.adoc[]
 ** xref:troubleshooting/harvester-cluster.adoc[]

--- a/versions/v1.4/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,7 +1,5 @@
 = NVIDIA Driver Toolkit
 
-_Available as of v1.3.0_
-
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing Harvester clusters.
 
 [NOTE]

--- a/versions/v1.4/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,6 +1,4 @@
-= PCI Devices
-
-_Available as of v1.1.0_
+= PCI Devices Controller
 
 A `PCIDevice` in Harvester represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource,

--- a/versions/v1.4/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,7 +1,5 @@
 = Rancher Manager (Experimental)
 
-_Available as of v1.2.0_
-
 The `rancher-vcluster` addon allows you to run Rancher Manager as a workload on the underlying Harvester cluster and is implemented using https://www.vcluster.com/[vcluster].
 
 image::vm-import-controller/EnableAddon.png[]

--- a/versions/v1.4/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,6 +1,4 @@
-= Managed DHCP
-
-_Available as of v1.3.0_
+= VM DHCP Controller (Managed DHCP)
 
 Beginning with v1.3.0, you can configure IP pool information and serve IP addresses to VMs running on Harvester clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.4/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,6 +1,4 @@
-= VM Import
-
-_Available as of v1.1.0_
+= VM Import Controller
 
 Beginning with v1.1.0, users can import their virtual machines from VMWare and OpenStack into Harvester.
 

--- a/versions/v1.4/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/hosts.adoc
@@ -270,8 +270,6 @@ image::host/remove-disks-harvester-remove.png[Remove disk]
 
 == Ksmtuned Mode
 
-_Available as of v1.1.0_
-
 Ksmtuned is a KSM automation tool deployed as a DaemonSet to run Ksmtuned on each node. It will start or stop the KSM by watching the available memory percentage ratio (*i.e. Threshold Coefficient*). By default, you need to manually enable Ksmtuned on each node UI. You will be able to see the KSM statistics from the node UI after 1-2 minutes.(check https://www.kernel.org/doc/html/latest/admin-guide/mm/ksm.html#ksm-daemon-sysfs-interface[KSM] for more details).
 
 === Quick Run

--- a/versions/v1.4/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/hosts.adoc
@@ -78,7 +78,6 @@ Removing a control plane node in this situation is not recommended because etcd 
 . Go back to the *Node* screen and verify that *Replicas* value for the node to be removed is *0*.
 
 [IMPORTANT]
-.important
 ====
 Eviction cannot be completed if the remaining nodes cannot accept replicas from the node to be removed. In this case, some volumes will remain in the *Degraded* state until you add more nodes to the cluster.
 ====
@@ -114,7 +113,6 @@ All workloads have been successfully evicted if the node state is *Maintenance*.
 image::host/node-maintain-completed.png[node-maintain-completed.png]
 
 [IMPORTANT]
-.important
 ====
 If a cluster has only two control plane nodes, Harvester does not allow you to enable Maintenance Mode on any node. You can manually drain the node to be removed using the following command:
 

--- a/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
@@ -43,7 +43,6 @@ After you select the first profile, the NVIDIA driver automatically configures t
 image::advanced/vgpuattachment.png[]
 +
 [IMPORTANT]
-.important
 ====
 Once a vGPU has been assigned to a VM, it may not be possible to disable the VM until the vGPU is removed.
 ====

--- a/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,7 +1,5 @@
 = vGPU Support
 
-_Available as of v1.3.0_
-
 Harvester now offers the capability to share NVIDIA GPU's supporting SRIOV based virtualisation as vGPU devices.
 
 The additional capability is provided by the `pcidevices-controller` addon, and leverages `sriov-manage` to manage the gpu. Please refer the https://docs.nvidia.com/grid/15.0/grid-vgpu-user-guide/index.html#creating-sriov-vgpu-device-red-hat-el-kvm[Nvidia Documentation] and your GPU documentation to identify if the GPU is supported.

--- a/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
@@ -1,7 +1,5 @@
 = Witness Node
 
-_Available as of v1.3.0_
-
 Harvester clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in Harvester) to ensure that a quorum is maintained.
 
 Some situations may require you to avoid deploying workloads and user data to management nodes. In these situations, one cluster node can be assigned the _witness_ role, which limits it to functioning as an etcd cluster member. The witness node is responsible for establishing a member quorum (a majority of nodes), which must agree on updates to the cluster state.

--- a/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
@@ -11,7 +11,6 @@ Witness nodes do not store any data, but the https://etcd.io/docs/v3.3/op-guide/
 Harvester v1.3.0 supports clusters with two management nodes and one witness node (and optionally, one or more worker nodes). For more information about node roles in Harvester, see xref:../hosts/hosts.adoc#_role_management[Role Management].
 
 [IMPORTANT]
-.important
 ====
 A node can be assigned the _witness_ role only at the time it joins a cluster. Each cluster can have only one witness node.
 ====

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,7 +1,5 @@
 = CloudInit CRD
 
-_Available as of v1.3.0_
-
 You can use the `CloudInit` CRD to configure Harvester operating system settings either manually or using GitOps solutions.
 
 == Background

--- a/versions/v1.4/modules/en/pages/installation-setup/config/harvester-configuration.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/harvester-configuration.adoc
@@ -476,8 +476,6 @@ os:
 
 === `install.addons`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Setting that defines the default addon status. Harvester addons are disabled by default.
 
 *Supported values*:
@@ -507,8 +505,6 @@ install:
 When enabled, the configuration is either retrieved from the value of `harvester.install.config_url` or defined individually using kernel parameters.
 
 === `install.data_disk`
-
-*Versions*: v1.0.1 and later
 
 *Definition*: Default device for storing VM data.
 
@@ -580,8 +576,6 @@ For more information about how to set the correct value, see https://longhorn.io
 ----
 
 === `install.harvester.storage_class.replica_count`
-
-*Versions*: v1.1.2 and later
 
 *Definition*: Replica count of the default Harvester StorageClass `harvester-longhorn`.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -144,8 +144,6 @@ image::advanced/containerd-registry.png[containerd-registry]
 
 === `csi-driver-config`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Configuration necessary for using third-party CSI drivers installed in the Harvester cluster.
 
 You must configure the following information before using features related to backups and snapshots:
@@ -166,8 +164,6 @@ You must configure the following information before using features related to ba
 ----
 
 === `default-vm-termination-grace-period-seconds`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Number of seconds Harvester waits before forcibly shutting down a VM that was stopped using the Harvester UI.
 
@@ -242,8 +238,6 @@ debug
 ----
 
 === `ntp-servers`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: NTP servers for time synchronization on Harvester nodes.
 
@@ -405,8 +399,6 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 
 === `support-bundle-image`
 
-*Versions*: v1.2.0 and later
-
 *Definition*: Support bundle image, with various versions available in https://hub.docker.com/r/rancher/support-bundle-kit/tags[rancher/support-bundle-kit].
 
 *Default value*:
@@ -420,8 +412,6 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 ----
 
 === `support-bundle-namespaces`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Additional namespaces that you can use when xref:../../troubleshooting/harvester-cluster.adoc#_generate_a_support_bundle[generating a support bundle].
 
@@ -443,8 +433,6 @@ Namespaces that you select are appended to the predefined namespaces list.
 *Default value*: None
 
 === `support-bundle-timeout`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Number of minutes Harvester allows for the completion of the support bundle generation process.
 
@@ -607,8 +595,6 @@ When the node becomes unavailable or is powered off, the VM only restarts and do
 == UI Settings
 
 === `branding`
-
-*Versions*: v1.2.0 and later
 
 *Definition*: Setting allows you to globally rebrand the Harvester UI by customizing the product name, logos, and color scheme.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,7 +1,5 @@
 = Install Harvester Binaries Only
 
-_Available as of v1.2.0_
-
 The `Install Harvester binaries only` mode allows you to install and configure binaries only, making it ideal for cloud and edge use cases.
 
 image::install/choose-installation-mode.png[choose-installation-mode.png]

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -43,7 +43,6 @@ Harvester nodes have the following hardware requirements and recommendations for
 |===
 
 [IMPORTANT]
-.important
 ====
 
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. Harvester is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.

--- a/versions/v1.4/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -25,7 +25,6 @@ For a detailed support matrix, please refer to the *Harvester CCM & CSI Driver w
 * The Harvester virtual machine guests' hostnames match their corresponding Harvester virtual machine names. Guest cluster Harvester VMs can't have different hostnames than their Harvester VM names when using the Harvester CSI driver. We hope https://github.com/harvester/harvester/issues/4396[to remove this limitation] in a future release of Harvester.
 
 [IMPORTANT]
-.important
 ====
 Each Harvester VM must have the `macvlan` kernel module, which is required for the `LoadBalancer` services of the *DHCP* IPAM mode.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -44,8 +44,6 @@ image::rancher/create-k3s-harvester-cluster.png[create-k3s-harvester-cluster]
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules. This provides high availability and better resource utilization.
 
 Node affinity can be added to the machine pools during the cluster creation:

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -77,8 +77,6 @@ Click to learn xref:./k3s-cluster.adoc[how to create k3s Kubernetes Clusters].
 
 == Topology spread constraints
 
-_Available as of v1.0.3_
-
 Within your guest Kubernetes cluster, you can use https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/[topology spread constraints] to manage how workloads are distributed across nodes, accounting for factors such as failure domains like regions and zones. This helps achieve high availability and efficient resource utilization of the Harvester cluster resources.
 
 For RKE2 versions before `v1.25.x`, the minimum required versions to support the topology label sync feature are as follows:

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -55,8 +55,6 @@ See https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/n
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules, which can provide high availability and better resource utilization.
 
 Node affinity can be added to the node template during the cluster creation, click `Add Node Template` or edit your existing node template via `RKE1 Configuration > Node Templates`:

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -76,8 +76,6 @@ image:rancher/create-rke2-harvester-cluster-3.png[create-rke2-harvester-cluster-
 
 === Add node affinity
 
-_Available as of v1.0.3 + Rancher v2.6.7_
-
 The Harvester node driver now supports scheduling a group of machines to particular nodes through the node affinity rules, which can provide high availability and better resource utilization.
 
 Node affinity can be added to the machine pools during the cluster creation:
@@ -101,8 +99,6 @@ values: us-east-1a
 image::rancher/affinity-rke2-add-rules.png[affinity-add-rules]
 
 === Add workload affinity
-
-_Available as of v1.2.0 + Rancher v2.7.6_
 
 The workload affinity rules allow you to constrain which nodes your machines can be scheduled on based on the labels of workloads (VMs and Pods) already running on these nodes, instead of the node labels.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -57,8 +57,6 @@ image::rancher/harvester-node-driver.png[harvester-node-driver]
 
 == Harvester baremetal container workload support (experimental)
 
-_Available as of Harvester v1.2.0 + Rancher v2.7.6_
-
 Starting with Rancher v2.7.6, Harvester introduces a new feature that enables you to deploy and manage container workloads directly to the underlying Harvester cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
 
 image::rancher/harvester-container-dashboard.png[harvester-container-dashboard]
@@ -95,8 +93,6 @@ With this feature enabled, your Harvester cluster does not appear on the *Contin
 ====
 
 == Fleet Support (Experimental)
-
-_Available as of Harvester v1.3.0 + Rancher v2.7.9_
 
 Starting with Rancher v2.7.9, you can leverage https://fleet.rancher.io/[Fleet] for managing container workloads and configuring Harvester with a GitOps-based approach.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -63,8 +63,6 @@ For more information on how the memory overhead is calculated in Kubevirt, refer
 
 When the allocated resource quota controlled by the `ResourceQuota` object reaches its limit, migrating a VM becomes unfeasible. The migration process automatically creates a new pod mirroring the resource requirements of the source VM. If these pod creation prerequisites surpass the defined quota, the migration operation cannot proceed.
 
-_Available as of v1.2.0_
-
 In Harvester, the `ResourceQuota` values will dynamically expand ahead of migration to accommodate the resource needs of the target virtual machine. After migration, the ResourceQuotas will be reinstated to their prior configurations.
 
 Please be aware of the following constrains of the automatic resizing of `ResourceQuota`:

--- a/versions/v1.4/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.4/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,4 @@
-= Harvester Network Best Practice
+= Harvester Networking Best Practices
 
 == Replace Ethernet NICs
 
@@ -161,7 +161,6 @@ The enabled NICs are detected.
 There are one or more xref:./cluster-network.adoc#_how_to_create_a_new_cluster_network[Network Config] under every xref:./cluster-network.adoc#_cluster_network[Cluster Network] on Harvester. Each `Network Config` is backed by a `VlanConfig` CRD object.
 
 [IMPORTANT]
-.important
 ====
 Updating the `Network Config` is *required* if the new NICs will be placed in different physical slots or will have different uplink parameters.
 ====
@@ -271,7 +270,6 @@ If you observe any abnormalities, generate a xref:../troubleshooting/harvester-c
 === (Optional) Update the Network Config Again
 
 [IMPORTANT]
-.important
 ====
 Updating the `Network Config` is *required* if the new NICs will be placed in different physical slots.
 ====

--- a/versions/v1.4/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/cluster-network.adoc
@@ -4,8 +4,6 @@
 
 === Cluster Network
 
-_Available as of v1.1.0_
-
 In Harvester v1.1.0, we introduced a new concept called cluster network for traffic isolation.
 
 The following diagram describes a typical network architecture that separates data-center (DC) traffic from out-of-band (OOB) traffic.

--- a/versions/v1.4/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.4/modules/en/pages/networking/ip-pool.adoc
@@ -1,7 +1,5 @@
 = IP Pool
 
-_Available as of v1.2.0_
-
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 
 == Features

--- a/versions/v1.4/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.4/modules/en/pages/networking/load-balancer.adoc
@@ -1,7 +1,5 @@
 = Load Balancer
 
-_Available as of v1.2.0_
-
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 
 == VM load balancer

--- a/versions/v1.4/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/vm-network.adoc
@@ -8,8 +8,6 @@ Harvester provides three types of networks for virtual machines (VMs), including
 
 The management network is usually used for VMs whose traffic only flows inside the cluster. If your VMs need to connect to the external network, use the VLAN network or untagged network.
 
-_Available as of v1.0.1_
-
 Harvester also introduced storage networking to separate the storage traffic from other cluster-wide workloads. Please refer to xref:./storage-network.adoc[the storage network document] for more details.
 
 == Management Network

--- a/versions/v1.4/modules/en/pages/observability/harvester-logging.adoc
+++ b/versions/v1.4/modules/en/pages/observability/harvester-logging.adoc
@@ -1,7 +1,5 @@
 = Logging
 
-_Available as of v1.2.0_
-
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 
 `Harvester` collects the `cluster running log`, kubernetes `audit` and `event` log right after the cluster is powered on, which is helpful for monitoring, logging, auditing and troubleshooting.

--- a/versions/v1.4/modules/en/pages/observability/harvester-monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/observability/harvester-monitoring.adoc
@@ -1,7 +1,5 @@
 = Monitoring
 
-_Available as of v1.2.0_
-
 The monitoring feature is now implemented with an addon and is disabled by default in new installations.
 
 Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.

--- a/versions/v1.4/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.4/modules/en/pages/storage/csidriver.adoc
@@ -1,7 +1,5 @@
 = Third-Party Storage Support
 
-_Available as of v1.2.0_
-
 Harvester now offers the capability to install a https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] in your Harvester cluster. This allows you to leverage external storage for the Virtual Machine's non-system data disk, allowing you to use different drivers tailored for specific needs, whether for performance optimization or seamless integration with your existing in-house storage solutions.
 
 [NOTE]

--- a/versions/v1.4/modules/en/pages/troubleshooting/harvester-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/harvester-cluster.adoc
@@ -280,8 +280,6 @@ For more information, see https://github.com/harvester/harvester/issues/3383[Iss
 
 == Access Embedded Rancher and Longhorn Dashboards
 
-_Available as of v1.1.0_
-
 You can now access the embedded Rancher and Longhorn dashboards directly on the `Support` page, but you must first go to the `Preferences` page and check the `Enable Extension developer features` box under `Advanced Features`.
 
 image::troubleshooting/support-access-embedded-ui.png[]

--- a/versions/v1.4/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/installation.adoc
@@ -108,7 +108,7 @@ Please include the following information in a bug report when reporting a failed
 
 * A failed installation screenshot.
 * System information and logs.
- ** Available as of v1.0.2
+
 +
 Please follow the guide in <<Logging into the Harvester Installer (a live OS)>> to log in. And run the command to generate a tarball that contains troubleshooting information:
 +

--- a/versions/v1.4/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -13,7 +13,6 @@ For air-gapped environments, see link:./automatic.adoc#prepare-an-air-gapped-upg
 === 1. Two-node cluster upgrade stuck after the first node is pre-drained
 
 [IMPORTANT]
-.important
 ====
 
 Shut down all workload VMs before upgrading *two-node clusters* to prevent data loss.

--- a/versions/v1.4/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/access-vm.adoc
@@ -34,8 +34,6 @@ ssh_authorized_keys:
 
 === Dynamic SSH Key Injection via Qemu guest agent
 
-_Available as of v1.0.1_
-
 Harvester supports dynamically injecting public ssh keys at run time through the use of the https://wiki.qemu.org/Features/GuestAgent[qemu guest agent]. This is achieved through the `qemuGuestAgent` propagation method.
 
 [NOTE]

--- a/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -2,8 +2,6 @@
 
 == VM Backup & Restore
 
-_Available as of v0.3.0_
-
 VM backups are created from the *Virtual Machines* page. The VM backup volumes will be stored in the *Backup Target* (an NFS or S3 server), and they can be used to either restore a new VM or replace an existing VM.
 
 image:vm/vm-backup.png[]
@@ -96,8 +94,6 @@ You can choose to either delete or retain the previous volumes. By default, all 
 image::vm/vm-restore-existing.png[]
 
 === Restore a new VM on another Harvester cluster
-
-_Available as of v1.0.0_
 
 Users can now restore a new VM on another cluster by leveraging the VM metadata & content backup feature.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -102,7 +102,6 @@ _Available as of v1.0.0_
 Users can now restore a new VM on another cluster by leveraging the VM metadata & content backup feature.
 
 [IMPORTANT]
-.prerequisites
 ====
 You must manually configure the virtual machine images with the same name on the new cluster first, otherwise the virtual machines will be failed to recover.
 ====

--- a/versions/v1.4/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,7 +1,5 @@
 = Clone VM
 
-_Available as of v1.1.0_
-
 VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 
 == Clone VM with volume data

--- a/versions/v1.4/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/create-vm.adoc
@@ -221,8 +221,6 @@ See the https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
 
 === Run Strategy
 
-_Available as of v1.0.2_
-
 Prior to v1.0.2, Harvester used the `Running` (a boolean) field to determine if the VM instance should be running. However, a simple boolean value is not always sufficient to fully describe the user's desired behavior. For example, in some cases the user wants to be able to shut down the instance from inside the virtual machine. If the `running` field is used, the VM will be restarted immediately.
 
 In order to meet the scenario requirements of more users, the `RunStrategy` field is introduced. This is mutually exclusive with `Running` because their conditions overlap somewhat. There are currently four `RunStrategies` defined:
@@ -287,8 +285,6 @@ If your OS is openSUSE and the version is less than 15.3, please replace `qemu-g
 ====
 
 === TPM Device
-
-_Available as of v1.2.0_
 
 https://en.wikipedia.org/wiki/Trusted_Platform_Module[Trusted Platform Module (TPM)] is a cryptoprocessor that secures hardware using cryptographic keys.
 


### PR DESCRIPTION
Change scope (v1.3 and v1.4):
- Fix ordering issues in `nav.adoc`.
- Remove duplicated markup in certain admonitions.
- Remove `Available as of v1.x.x` lines. Engineers added such lines whenever they documented a new feature.
- Remove version information for specific config fields and settings (Example: `Versions: v1.1.0 and later`).