### PR TITLE
Update product name in Introduction and Installation sections

### DIFF
--- a/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,16 +1,16 @@
 = CloudInit CRD
 
-You can use the `CloudInit` CRD to configure Harvester operating system settings either manually or using GitOps solutions.
+You can use the `CloudInit` CRD to configure SUSE® Virtualization operating system settings either manually or using GitOps solutions.
 
 == Background
 
-The Harvester operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
+The SUSE® Virtualization operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
 
-Settings configured during the Harvester installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the Harvester operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
+Settings configured during the installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
 
-The Harvester `CloudInit` CRD exposes the cloud-init file through a Kubernetes CRD. This allows you to modify node-specific settings after installation without needing to take steps to make the root filesystem writable.
+The `CloudInit` CRD exposes the cloud-init file through a Kubernetes CRD. This allows you to modify node-specific settings after installation without needing to take steps to make the root filesystem writable.
 
-In addition, the `CloudInit` CRD is persisted and synchronized with the underlying hosts so that changes made directly to the Harvester operating system are not lost whenever nodes are rebooted and upgraded.
+In addition, the `CloudInit` CRD is persisted and synchronized with the underlying hosts so that changes made directly to the operating system are not lost whenever nodes are rebooted and upgraded.
 
 [NOTE]
 ====
@@ -21,7 +21,7 @@ The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account 
 
 == Getting Started
 
-The following example adds SSH keys to all nodes in an existing Harvester cluster.
+The following example adds SSH keys to all nodes in an existing SUSE® Virtualization cluster.
 
 [,yaml]
 ----
@@ -46,14 +46,14 @@ spec:
 
 The `spec` field contains the following:
 
-* `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. `harvesterhci.io/managed: "true"` is a Harvester-specific label that you can use to select all nodes.
+* `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. You can use the `harvesterhci.io/managed: "true"` label to select all nodes.
 * `filename (required)`: Name of the file in `/oem`. cloud-init files in `/oem` are applied in alphabetical order. This can be used to ensure that file changes are applied during booting.
 * `content (required)`: Inline content for the Elemental cloud-init resource that is written to target nodes.
-* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The Harvester controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
+* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The SUSE® Virtualization controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
 
 Once the object is created, you can log in to the target nodes to verify the results.
 
-In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the Harvester controllers.
+In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the SUSE® Virtualization controllers.
 
 ----
 harvester-qhgd4:/oem # more 99-my-ssh-keys.yaml
@@ -66,7 +66,7 @@ stages:
         - ssh-rsa key2
 ----
 
-The `status` subresource can be used to track the rollout of a change to the underlying Harvester nodes.
+The `status` subresource can be used to track the rollout of a change to the underlying nodes.
 
 In the following example, the `status` values indicate that the change was applied to all three nodes in the cluster.
 
@@ -133,6 +133,6 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 ====
 
 
-Deleting the `CloudInit` CRD results in the removal of associated files from the underlying Harvester nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
+Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the Harvester operating system.
+You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the SUSE® Virtualization operating system.

--- a/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,8 +1,8 @@
-= Harvester Configuration
+= SUSE® Virtualization Configuration File
 
 == Configuration Example
 
-Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:
+A configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:
 
 [,yaml]
 ----
@@ -94,8 +94,8 @@ Below is a reference of all configuration keys.
 [NOTE]
 ====
 
-*Configuration Priority*: When you provide a remote Harvester Configuration file during the install of Harvester, the Harvester Configuration file will not overwrite the values for the inputs you had previously filled out and selected.  Priority is given to the values that you input during the guided install.
-For instance, if you have in your Harvester Configuration file specified `os.hostname` and during install you fill in the field of `hostname` when prompted, the value that you filled in will take priority over your Harvester Configuration's `os.hostname`.
+*Configuration Priority*: When you provide a remote configuration file during installation, the configuration file will not overwrite the values for the inputs you had previously filled out and selected.  Priority is given to the values that you input during the guided install.
+For instance, if you have in your configuration file specified `os.hostname` and during install you fill in the field of `hostname` when prompted, the value that you filled in will take priority over your configuration file's `os.hostname`.
 ====
 
 
@@ -105,13 +105,7 @@ For instance, if you have in your Harvester Configuration file specified `os.hos
 
 The version of scheme reserved for future configuration migration.
 
-This configuration is mandatory for migrating the configuration to a new scheme version. It tells Harvester the previous version and the need to migrate.
-
-[NOTE]
-====
-This field didn't take any effect in the current Harvester version.
-====
-
+This configuration is mandatory for migrating the configuration to a new scheme version. It specifies the previous version and the need to migrate.
 
 [CAUTION]
 ====
@@ -123,14 +117,14 @@ Make sure that your custom configuration always has the correct scheme version.
 
 ==== Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+`server_url` is the URL of the SUSE® Virtualization cluster, which is used for the new `node` to join the cluster.
 
 This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `+https://cluster-VIP:443+`.
 
 [NOTE]
 ====
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
+To ensure a high availability (HA) SUSE® Virtualization cluster, use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
 ====
 
 
@@ -150,7 +144,7 @@ install:
 The cluster secret or node token. If the value matches the format of a node token it will
 automatically be assumed to be a node token. Otherwise it is treated as a cluster secret.
 
-In order for a new node to join the Harvester cluster, the token should match what the server has.
+In order for a new node to join the cluster, the token should match what the server has.
 
 ==== Example
 
@@ -232,7 +226,7 @@ The `os.persistent_state_paths` option allows you to configure custom paths wher
 
 ==== Example
 
-Refer to the following example config for installing `rook-ceph` in Harvester:
+Refer to the following example config for installing `rook-ceph`:
 
 [,yaml]
 ----
@@ -253,7 +247,7 @@ You can add additional software packages with `after_install_chroot_commands`. T
 
 ==== Example
 
-Refer to the following example config for installing an RPM package in Harvester:
+Refer to the following example config for installing an RPM package in SUSE® Virtualization:
 
 [,yaml]
 ----
@@ -277,7 +271,7 @@ os:
 [NOTE]
 ====
 
-Upgrading Harvester causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading Harvester.
+Upgrading SUSE® Virtualization causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
 ====
 
 
@@ -368,8 +362,7 @@ The password for the default user, `rancher`. By default, there is no password f
 If you set a password at runtime it will be reset on the next boot. The
 value of the password can be clear text or an encrypted form. The easiest way to get this encrypted
 form is to change your password on a Linux system and copy the value of the second field from
-`/etc/shadow`. You can also encrypt a password using OpenSSL. For the encryption algorithms
-supported by Harvester, please refer to the table below.
+`/etc/shadow`. You can also encrypt a password using OpenSSL. For the supported encryption algorithms, refer to the table below.
 
 [cols="^,^,^"]
 |===
@@ -435,7 +428,7 @@ os:
 ====
 
 This example sets the HTTP(S) proxy for *foundational OS components*.
-To set up an HTTP(S) proxy for Harvester components such as fetching external images and backup to S3 services,
+To set up an HTTP(S) proxy for SUSE® Virtualization components such as fetching external images and backup to S3 services,
 see link:../advanced/settings.adoc#http-proxy[Settings/http-proxy].
 ====
 
@@ -461,7 +454,7 @@ os:
 
 ==== Definition
 
-Subsystem used to configure the OpenSSH Daemon (sshd). Harvester currently only supports `sftp`.
+Subsystem used to configure the OpenSSH Daemon (sshd). SUSE® Virtualization currently only supports `sftp`.
 
 ==== Example
 
@@ -478,7 +471,7 @@ os:
 
 === `install.addons`
 
-*Definition*: Setting that defines the default addon status. Harvester addons are disabled by default.
+*Definition*: Setting that defines the default add-on status. SUSE® Virtualization add-ons are disabled by default.
 
 *Supported values*:
 
@@ -528,7 +521,7 @@ install:
 
 === `install.device`
 
-*Definition*: Device on which the Harvester OS is installed.
+*Definition*: Device on which the SUSE® Virtualization operating system is installed.
 
 When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` to specify the storage device if the server contains multiple physical volumes.
 
@@ -542,9 +535,9 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 
 *Definition*: Setting that forces usage of MBR partitioning on BIOS systems.
 
-Harvester uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
+SUSE® Virtualization uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
 
-If you specify the same storage device for both `install.device` and `install.data_disk`, Harvester creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
+If you specify the same storage device for both `install.device` and `install.data_disk`, SUSE® Virtualization creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
 
 *Example*:
 
@@ -558,7 +551,7 @@ install:
 
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Engine Manager pod.
 
-Using the default value is recommended for high system availability. When deploying single-node Harvester clusters, you can specify a value less than 12.
+Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
 For more information about how to set the correct value, see https://longhorn.io/docs/archives/1.4.1/references/settings/#guaranteed-engine-manager-cpu[Guaranteed Engine Manager CPU] in the Longhorn documentation.
 
@@ -581,7 +574,7 @@ install:
 
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Replica Manager pod.
 
-Using the default value is recommended for high system availability. When deploying single-node Harvester clusters, you can specify a value less than 12.
+Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
 For more information about how to set the correct value, see https://longhorn.io/docs/archives/1.4.1/references/settings/#guaranteed-replica-manager-cpu[Guaranteed Replica Manager CPU] in the Longhorn documentation.
 
@@ -602,9 +595,9 @@ install:
 
 === `install.harvester.storage_class.replica_count`
 
-*Definition*: Replica count of the default Harvester StorageClass `harvester-longhorn`.
+*Definition*: Replica count of the default StorageClass `harvester-longhorn`.
 
-Using the default value is recommended for high storage availability. When deploying single-node Harvester clusters, you must set the value to 1.
+Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
 For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
 
@@ -624,18 +617,18 @@ install:
 
 === `install.iso_url`
 
-*Definition*: URL of ISO image to be downloaded and used to install Harvester when booting from the kernel or vmlinuz.
+*Definition*: URL of ISO image to be downloaded and used to install SUSE® Virtualization when booting from the kernel or vmlinuz.
 
 === `install.management_interface`
 
 *Definition*: Network interfaces for the host machine.
 
-Harvester uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
+SUSE® Virtualization uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
 
 *Fields*:
 
 * `method`: Method used to assign an IP to the network. Supported values:
- ** `dhcp`: Harvester requests an IP from the DHCP server.
+ ** `dhcp`: An IP is requested from the DHCP server.
  ** `static`: IP and gateway addresses are manually assigned.
 * `ip`: Static IP assigned to the network. This field is required when the value of `method` is `static`.
 * `subnet_mask`: Subnet mask of the network. This field is required when the value of `method` is `static`.
@@ -669,12 +662,12 @@ install:
 
 === `install.mode`
 
-*Definition*: Mode of installing Harvester.
+*Definition*: Mode of installation.
 
 *Supported values*:
 
-* `create`: Create a new Harvester installation.
-* `join`: Join an existing Harvester installation. You must specify the `server_url`.
+* `create`: Create a new SUSE® Virtualization cluster.
+* `join`: Join an existing SUSE® Virtualization cluster. You must specify the `server_url`.
 
 *Example*:
 
@@ -710,14 +703,14 @@ install:
 
 === `install.rawdiskimagepath`
 
-*Definition*: Setting that forces the installer to only install the Harvester hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
+*Definition*: Setting that forces the installer to only install the SUSE® Virtualization hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
 
 === `install.role`
 
-*Definition*: Role assigned to a node at the time of installation. When unspecified, Harvester assigns the `default` role.
+*Definition*: Role assigned to a node at the time of installation. When unspecified, the `default` role is assigned.
 
 * `default`: Allows a node to function as a management node or a worker node.
-* `management`: Allows a node to be prioritized when Harvester promotes nodes to management nodes.
+* `management`: Allows a node to be prioritized when SUSE® Virtualization promotes nodes to management nodes.
 * `worker`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 * `witness`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
 
@@ -759,9 +752,9 @@ install:
 
 === `install.vip`
 
-*Definition*: VIP of the Harvester management endpoint.
+*Definition*: VIP of the SUSE® Virtualization management endpoint.
 
-After installation, you can access the Harvester UI at `https://<VIP>`.
+After installation, you can access the UI at `https://<VIP>`.
 
 === `install.vip_mode`
 
@@ -769,8 +762,8 @@ After installation, you can access the Harvester UI at `https://<VIP>`.
 
 *Supported values*:
 
-* `dhcp`: Harvester sends DHCP requests to get the VIP. You must specify the hardware address using the `install.vip_hw_addr` field.
-* `static`: Harvester uses a static VIP.
+* `dhcp`: DHCP requests are sent to obtain the VIP. You must specify the hardware address using the `install.vip_hw_addr` field.
+* `static`: A static VIP is used.
 
 *Example*:
 
@@ -811,8 +804,8 @@ The installer sends HTTP requests to the specified URL. Multiple requests can be
  ** `FAILED`: The installation was unsuccessful.
 * `method`: HTTP method
 * `url`: URL to which HTTP requests are sent
-* `insecure`: When set to `true`, Harvester does not verify the server's certificate. The default value is `false`.
-* `basicAuth`: When set to `true`, Harvester uses the "Basic" HTTP authentication scheme.
+* `insecure`: When set to `true`, SUSE® Virtualization does not verify the server's certificate. The default value is `false`.
+* `basicAuth`: When set to `true`, the "Basic" HTTP authentication scheme is used.
 * `headers`: When set to `true`, custom headers are included in the HTTP requests. Headers such as `Content-Length` are automatically included.
 * `payload`*: When set to `true`, payload data is sent with the HTTP requests. You may need to set the correct Content-Type header in the `headers` field to ensure that the server accepts the request.
 
@@ -853,7 +846,7 @@ install:
 
 *Definition*: Setting that determines if images are pulled from the internet after installation.
 
-The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, Harvester does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
+The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, SUSE® Virtualization does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
 
 '''
 
@@ -863,15 +856,15 @@ The value of this field is typically derived from the kernel parameter `harveste
 
 ==== Definition
 
-You can overwrite the default Harvester system settings by configuring `system_settings`.
+You can overwrite the default system settings by configuring `system_settings`.
 See the xref:./settings.adoc[Settings] page for additional information and the list of all the options.
 
 [NOTE]
 ====
 
-Overwriting system settings only works when Harvester is installed in "create" mode.
-If you install Harvester in "join" mode, this setting is ignored.
-Installing in "join" mode will adopt the system settings from the existing Harvester system.
+Overwriting system settings only works when SUSE® Virtualization is installed in "create" mode.
+If you install SUSE® Virtualization in "join" mode, this setting is ignored.
+Installing in "join" mode will adopt the system settings from the existing system.
 ====
 
 

--- a/versions/v1.3/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/management-address.adoc
@@ -1,6 +1,6 @@
 = Management Address
 
-Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
+SUSE® Virtualization provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 
 [NOTE]
 ====
@@ -13,18 +13,18 @@ image::install/iso-installed.png[]
 == Requirements
 
 * The VIP and the node management interfaces must belong to the same subnet.
-* All Harvester node management interfaces must be on the same layer-2 network segment.
+* All SUSE® Virtualization node management interfaces must be on the same layer-2 network segment.
 
 Both are required because the VIP relies on the Address Resolution Protocol (ARP), which is a layer-2 protocol.
 
-The VIP can be assigned to any Harvester node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the Harvester cluster's management IP address (the VIP).
+The VIP can be assigned to any SUSE® Virtualization node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the SUSE® Virtualization cluster's management IP address (the VIP).
 
 [CAUTION]
 ====
 
-If you plan to host a Harvester cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, Harvester is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
+If you plan to host a SUSE® Virtualization cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, SUSE® Virtualization is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
 
-Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your Harvester nodes (for example, if your Harvester hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
+Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your SUSE® Virtualization nodes (for example, if your SUSE® Virtualization hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
 ====
 
 
@@ -46,7 +46,7 @@ Example of output:
 
 == Identifying the Node the VIP Is Assigned To
 
-You can use kubectl (either on your local machine with the Harvester kubeconfig file, or when using SSH to connect to any Harvester management node as a root user).
+You can use kubectl (either on your local machine with the SUSE® Virtualization kubeconfig file, or when using SSH to connect to any SUSE® Virtualization management node as a root user).
 
 [,console]
 ----
@@ -60,7 +60,7 @@ Example output:
 harvester-xzj76
 ----
 
-Alternatively, you can use SSH to connect to each Harvester management node and then run the command `ip address show mgmt-br`.
+Alternatively, you can use SSH to connect to each SUSE® Virtualization management node and then run the command `ip address show mgmt-br`.
 
 Example:
 
@@ -81,7 +81,7 @@ When the output includes both the VIP and the node address, the VIP is assigned 
 
 The management address:
 
-* Allows the access to the Harvester API/UI via `HTTPS` protocol.
+* Allows the access to the SUSE® Virtualization API/UI via `HTTPS` protocol.
 * Allows other nodes to join the cluster.
 +
 image:install/configure-management-address.png[]

--- a/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
@@ -1,14 +1,14 @@
 = Hardware and Network Requirements
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running SUSE® Virtualization.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
+A three-node cluster is required to fully realize the multi-node features. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
 
-Certain versions of Harvester support the deployment of https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters[single-node clusters]. Such clusters do not support high availability, multiple replicas, and live migration.
+The latest versions support the deployment of xref:./single-node-clusters.adoc[single-node clusters]. Such clusters do not support high availability, multiple replicas, and live migration.
 
 == Hardware Requirements
 
-Harvester nodes have the following hardware requirements and recommendations for installation and testing.
+SUSE® Virtualization nodes have the following hardware requirements and recommendations for installation and testing.
 
 |===
 | Hardware | Development/Testing | Production
@@ -45,16 +45,16 @@ Harvester nodes have the following hardware requirements and recommendations for
 [IMPORTANT]
 ====
 
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. Harvester is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. SUSE® Virtualization is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
-* Harvester has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the Harvester cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
+* SUSE® Virtualization has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
 ====
 
 
 === CPU Specifications
 
-xref:../virtual-machines/live-migration.adoc[Live Migration]functions correctly only if the CPUs of all physical servers in the xref:../introduction/glossary.adoc#_harvester_cluster[Harvester cluster] have the same specifications. This requirement applies to all operations that rely on Live Migration functionality, such as automatic VM migration when xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is enabled.
+xref:../virtual-machines/live-migration.adoc[Live Migration]functions correctly only if the CPUs of all physical servers in the cluster have the same specifications. This requirement applies to all operations that rely on Live Migration functionality, such as automatic VM migration when xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is enabled.
 
 Newer CPUs (even those from the same vendor, generation, and family) can have varying capabilities that may be exposed to VM operating systems. To ensure VM stability, Live Migration checks if the CPU capabilities are consistent, and blocks migration attempts when the source and destination are incompatible.
 
@@ -62,165 +62,165 @@ When creating clusters, adding more hosts to a cluster, and replacing hosts, alw
 
 == Network Requirements
 
-Harvester nodes have the following network requirements for installation.
+Nodes have the following network requirements for installation.
 
-=== Port Requirements for Harvester Nodes
+=== Port Requirements for SUSE® Virtualization Nodes
 
-Harvester nodes require the following port connections or inbound rules. Typically, all outbound traffic is allowed.
+Nodes require the following port connections or inbound rules. Typically, all outbound traffic is allowed.
 
 |===
 | Protocol | Port | Source | Description
 
 | TCP
 | 2379
-| Harvester management nodes
+| Management nodes
 | Etcd client port
 
 | TCP
 | 2381
-| Harvester management nodes
+| Management nodes
 | Etcd health checks
 
 | TCP
 | 2380
-| Harvester management nodes
+| Management nodes
 | Etcd peer port
 
 | TCP
 | 10010
-| Harvester management and compute nodes
+| Management and compute nodes
 | Containerd
 
 | TCP
 | 6443
-| Harvester management nodes
+| Management nodes
 | Kubernetes API
 
 | TCP
 | 9345
-| Harvester management nodes
+| Management nodes
 | Kubernetes API
 
 | TCP
 | 10252
-| Harvester management nodes
+| Management nodes
 | Kube-controller-manager health checks
 
 | TCP
 | 10257
-| Harvester management nodes
+| Management nodes
 | Kube-controller-manager secure port
 
 | TCP
 | 10251
-| Harvester management nodes
+| Management nodes
 | Kube-scheduler health checks
 
 | TCP
 | 10259
-| Harvester management nodes
+| Management nodes
 | Kube-scheduler secure port
 
 | TCP
 | 10250
-| Harvester management and compute nodes
+| Management and compute nodes
 | Kubelet
 
 | TCP
 | 10256
-| Harvester management and compute nodes
+| Management and compute nodes
 | Kube-proxy health checks
 
 | TCP
 | 10258
-| Harvester management nodes
+| Management nodes
 | Cloud-controller-manager
 
 | TCP
 | 9091
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal calico-node felix
 
 | TCP
 | 9099
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal CNI health checks
 
 | UDP
 | 8472
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal CNI with VxLAN
 
 | TCP
 | 2112
-| Harvester management nodes
+| Management nodes
 | Kube-vip
 
 | TCP
 | 6444
-| Harvester management and compute nodes
+| Management and compute nodes
 | RKE2 agent
 
 | TCP
 | 10246/10247/10248/10249
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx worker process
 
 | TCP
 | 8181
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 8444
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 10245
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 80
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx
 
 | TCP
 | 9796
-| Harvester management and compute nodes
+| Management and compute nodes
 | Node-exporter
 
 | TCP
 | 30000-32767
-| Harvester management and compute nodes
+| Management and compute nodes
 | NodePort port range
 
 | TCP
 | 22
-| Harvester management and compute nodes
+| Management and compute nodes
 | sshd
 
 | UDP
 | 68
-| Harvester management and compute nodes
+| Management and compute nodes
 | Wicked
 
 | TCP
 | 3260
-| Harvester management and compute nodes
+| Management and compute nodes
 | iscsid
 |===
 
-=== Port Requirements for Integrating Harvester with Rancher
+=== Port Requirements for Integrating SUSE® Virtualization with Rancher
 
-If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate Harvester with Rancher], you need to make sure that all Harvester nodes can connect to TCP port *443* of the Rancher load balancer.
+If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all SUSE® Virtualization nodes can connect to TCP port *443* of the Rancher load balancer.
 
-When provisioning VMs with Kubernetes clusters from Rancher into Harvester, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from Rancher into SUSE® Virtualization, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
-For the port requirements for guest clusters deployed inside Harvester VMs, refer to the following links:
+For the port requirements for guest clusters deployed inside SUSE® Virtualization VMs, refer to the following links:
 
 * https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
 * https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]

--- a/versions/v1.3/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a High-Availability Cluster
 
-A xref:./glossary.adoc#_harvester_cluster[Harvester cluster] with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host xref:./glossary.adoc#_guest_cluster_guest_kubernetes_cluster[guest clusters] and run custom workloads.
+This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-Harvester is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
-You can download the installation files from the https://github.com/harvester/harvester/releases[Harvester Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
+You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -42,29 +42,29 @@ You can download the installation files from the https://github.com/harvester/ha
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. Deploying the first node creates the cluster, and the first node is assigned the management node by default.
 
-During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
-Once installation is completed, the node restarts and then the Harvester console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
+Once installation is completed, the node restarts and then the console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
 
-== 5. Configure a strong password for the default `admin` user on the Harvester UI.
+== 5. Configure a strong password for the default `admin` user.
 
-Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[Harvester UI] using the management URL displayed on the console.
+Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[UI] using the management URL displayed on the console.
 
 == 6. Deploy the other nodes and join them to the cluster.
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. All other nodes join the cluster that was created when the first node was deployed.
 
-During installation, you must configure node settings, and specify the cluster management address (virtual IP) and the cluster token that you defined previously. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, and specify the cluster management address (virtual IP) and the cluster token that you defined previously. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
 When the cluster has three or more nodes, the two nodes added after the first node are automatically promoted to management nodes to form a high-availability (HA) cluster.
 
 == 7. Create a custom cluster network (optional) and a VM network (required).
 
-Networking in Harvester involves three major concepts:
+Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the Harvester cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the Harvester cluster) to which each Harvester node attaches with management NICs for cluster management purposes. Harvester also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -78,25 +78,25 @@ Before you create VMs, create the necessary networks. If more than one network i
 
 == 8. Import VM images.
 
-On the Harvester UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
+On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in Harvester. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the Harvester UI.
+You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of the following methods:
 
-* Harvester UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
+* UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
 * Kubernetes API: Create a `VirtualMachine` object.
-* xref:../integrations/terraform/terraform-provider.adoc[Harvester Terraform Provider]: Define a `harvester_virtualmachine` resource block.
+* xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the Harvester UI involves slightly different steps. Harvester provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with Harvester.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.3/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a Single-Node Cluster
 
-A xref:./glossary.adoc#_harvester_cluster[Harvester cluster] with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host xref:./glossary.adoc#_guest_cluster_guest_kubernetes_cluster[guest clusters] and run custom workloads.
+This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-Harvester is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
-You can download the installation files from the https://github.com/harvester/harvester/releases[Harvester Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
+You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -42,32 +42,32 @@ You can download the installation files from the https://github.com/harvester/ha
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. Deploying the node creates the cluster, and the node is assigned the management role by default.
 
-During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
-Once installation is completed, the node restarts and then the Harvester console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
+Once installation is completed, the node restarts and then the console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
 
-== 5. Configure a strong password for the default `admin` user on the Harvester UI.
+== 5. Configure a strong password for the default `admin` user on the UI.
 
-Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[Harvester UI] using the management URL displayed on the console.
+Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[UI] using the management URL displayed on the console.
 
 == 6. Configure the default StorageClass.
 
-Harvester uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+SUSE® Virtualization uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the Harvester UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
-* Change the xref:../installation-setup/config/harvester-configuration.adoc#_install_harvester_storage_class_replica_count[replica count] of `harvester-longhorn` to *1* using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+* Change the xref:../installation-setup/config/harvester-configuration.adoc#_install_harvester_storage_class_replica_count[replica count] of `harvester-longhorn` to *1* using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 * xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] with the *Number of Replicas* parameter set to *1*. Once created, locate the new StorageClass in the list and then select *⋮* > *Set as Default*.
 
 == 7. Create a custom cluster network and a VM network. (Optional)
 
-Networking in Harvester involves three major concepts:
+Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the Harvester cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the Harvester cluster) to which each Harvester node attaches with management NICs for cluster management purposes. Harvester also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -77,29 +77,29 @@ Each network configuration corresponds to a set of nodes with uniform network sp
 +
 Each VM network is linked to a specific cluster network, which is used for transmission of VM traffic. You can create either a xref:../networking/vm-network.adoc#_vlan_network[VLAN network] or an xref:../networking/vm-network.adoc#_untagged_network[untagged network] based on your requirements, such as traffic isolation, network segmentation, ease of management, or alignment with the external network environment.
 
-You can create a VM network that uses `mgmt` when testing Harvester with a single-node cluster.
+You can create a VM network that uses `mgmt` when testing SUSE® Virtualization with a single-node cluster.
 
 == 8. Import VM images.
 
-On the Harvester UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
+On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in Harvester. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the Harvester UI.
+You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of the following methods:
 
-* Harvester UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
+* UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
 * Kubernetes API: Create a `VirtualMachine` object.
-* xref:../integrations/terraform/terraform-provider.adoc[Harvester Terraform Provider]: Define a `harvester_virtualmachine` resource block.
+* xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the Harvester UI involves slightly different steps. Harvester provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with Harvester.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.3/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/glossary.adoc
@@ -2,11 +2,11 @@
 
 == *guest cluster* / *guest Kubernetes cluster*
 
-Group of integrated Kubernetes worker machines that run in VMs on top of a Harvester cluster.
+Group of integrated Kubernetes worker machines that run in VMs on top of a SUSE® Virtualization cluster.
 
-You can create RKE1, RKE2, and K3s guest clusters using the Harvester and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
+You can create RKE1, RKE2, and K3s guest clusters using the SUSE® Virtualization and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
 
-Guest clusters form the main infrastructure for running container workloads. Certain versions of Harvester and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to Harvester clusters] (with some limitations).
+Guest clusters form the main infrastructure for running container workloads. Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE® Virtualization clusters] (with some limitations).
 
 == *guest node* / *guest cluster node*
 
@@ -14,26 +14,26 @@ Kubernetes worker VM that uses guest cluster resources to run container workload
 
 Guest nodes are managed through a control plane that controls pod-related activity and maintains the desired cluster state.
 
-== *Harvester cluster*
+== *SUSE® Virtualization cluster*
 
-Group of integrated physical servers (hosts) on which the Harvester hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
+Group of integrated physical servers (hosts) on which the SUSE® Virtualization hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of SUSE® Virtualization, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-Harvester clusters can be imported into and managed by Rancher. Within the Rancher context, an imported Harvester cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
+SUSE® Virtualization clusters can be imported into and managed by Rancher. Within the Rancher context, an imported SUSE® Virtualization cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 
-Certain versions of Harvester and Rancher allow you to deploy container workloads directly to Harvester clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with VM workloads.
+Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads directly to SUSE® Virtualization clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with VM workloads.
 
-== *Harvester hypervisor*
+== *SUSE® Virtualization hypervisor*
 
-Specialized operating system and xref:./overview.adoc#_harvester_architecture[software stack] that runs on a single physical server.
+Specialized operating system and xref:./overview.adoc#_architecture[software stack] that runs on a single physical server.
 
-== *Harvester node*
+== *SUSE® Virtualization node*
 
-Physical server on which the Harvester hypervisor is installed.
+Physical server on which the SUSE® Virtualization hypervisor is installed.
 
-Each node that joins a Harvester cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All Harvester nodes process data but not all can store data.
+Each node that joins a SUSE® Virtualization cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All SUSE® Virtualization nodes process data but not all can store data.
 
-== *Harvester Node Driver*
+== *SUSE® Virtualization Node Driver*
 
-xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision VMs in a Harvester cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.
+xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision VMs in a SUSE® Virtualization cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.

--- a/versions/v1.3/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/overview.adoc
@@ -1,33 +1,33 @@
-= Harvester Overview
+= Overview
 
-https://harvesterhci.io/[Harvester] is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+SUSE® Virtualization is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. SUSE® Virtualization runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), SUSE® Virtualization supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
-== Harvester Architecture
+== Architecture
 
-The Harvester architecture consists of cutting-edge open-source technologies:
+The architecture consists of cutting-edge open-source technologies:
 
-* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.4 is at the core of Harvester and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
-* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and Harvester is an HCI solution with Kubernetes under the hood.
+* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.4 is at the core of SUSE® Virtualization and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
+* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and SUSE® Virtualization is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
 * *Storage management with Longhorn.* https://longhorn.io/[Longhorn] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
 
-== Harvester Features
+== Features
 
-Harvester is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features of Harvester include:
+SUSE® Virtualization is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since SUSE® Virtualization ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.
-* *Storage management.* Harvester supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
+* *Storage management.* SUSE® Virtualization supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
 * *Network management.* Supports using a virtual IP (VIP) and multiple Network Interface Cards (NICs). If your VMs need to connect to the external network, create a VLAN or untagged network.
-* *Integration with Rancher.* Access Harvester directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
+* *Integration with Rancher.* Access SUSE® Virtualization directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
 
-== Harvester UI
+== User Interface
 
-Harvester provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once you install Harvester, you can access the IP address for the Harvester UI from the node's terminal.
+SUSE® Virtualization provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
 
 +++<div class="text-center">++++++<iframe width="99%" height="450" src="https://www.youtube.com/embed/Ngsk7m6NYf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,16 +1,16 @@
 = CloudInit CRD
 
-You can use the `CloudInit` CRD to configure Harvester operating system settings either manually or using GitOps solutions.
+You can use the `CloudInit` CRD to configure SUSE® Virtualization operating system settings either manually or using GitOps solutions.
 
 == Background
 
-The Harvester operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
+The SUSE® Virtualization operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
 
-Settings configured during the Harvester installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the Harvester operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
+Settings configured during the installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
 
-The Harvester `CloudInit` CRD exposes the cloud-init file through a Kubernetes CRD. This allows you to modify node-specific settings after installation without needing to take steps to make the root filesystem writable.
+The `CloudInit` CRD exposes the cloud-init file through a Kubernetes CRD. This allows you to modify node-specific settings after installation without needing to take steps to make the root filesystem writable.
 
-In addition, the `CloudInit` CRD is persisted and synchronized with the underlying hosts so that changes made directly to the Harvester operating system are not lost whenever nodes are rebooted and upgraded.
+In addition, the `CloudInit` CRD is persisted and synchronized with the underlying hosts so that changes made directly to the operating system are not lost whenever nodes are rebooted and upgraded.
 
 [NOTE]
 ====
@@ -21,7 +21,7 @@ The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account 
 
 == Getting Started
 
-The following example adds SSH keys to all nodes in an existing Harvester cluster.
+The following example adds SSH keys to all nodes in an existing SUSE® Virtualization cluster.
 
 [,yaml]
 ----
@@ -46,14 +46,14 @@ spec:
 
 The `spec` field contains the following:
 
-* `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. `harvesterhci.io/managed: "true"` is a Harvester-specific label that you can use to select all nodes.
+* `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. You can use the `harvesterhci.io/managed: "true"` label to select all nodes.
 * `filename (required)`: Name of the file in `/oem`. cloud-init files in `/oem` are applied in alphabetical order. This can be used to ensure that file changes are applied during booting.
 * `content (required)`: Inline content for the Elemental cloud-init resource that is written to target nodes.
-* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The Harvester controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
+* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The SUSE® Virtualization controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
 
 Once the object is created, you can log in to the target nodes to verify the results.
 
-In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the Harvester controllers.
+In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the SUSE® Virtualization controllers.
 
 ----
 harvester-qhgd4:/oem # more 99-my-ssh-keys.yaml
@@ -66,7 +66,7 @@ stages:
         - ssh-rsa key2
 ----
 
-The `status` subresource can be used to track the rollout of a change to the underlying Harvester nodes.
+The `status` subresource can be used to track the rollout of a change to the underlying nodes.
 
 In the following example, the `status` values indicate that the change was applied to all three nodes in the cluster.
 
@@ -133,6 +133,6 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 ====
 
 
-Deleting the `CloudInit` CRD results in the removal of associated files from the underlying Harvester nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
+Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the Harvester operating system.
+You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the operating system.

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,8 +1,8 @@
-= Harvester Configuration
+= SUSE® Virtualization Configuration File
 
 == Configuration Example
 
-Harvester configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:
+A configuration file can be provided during manual or automatic installation to configure various settings. The following is a configuration example:
 
 [,yaml]
 ----
@@ -20,7 +20,7 @@ os:
     path: /etc/test.txt
     permissions: '0755'
   hostname: myhost
-  modules:
+  modules:SUSE® Virtualization
     - kvm
     - nvme
   sysctls:
@@ -92,8 +92,8 @@ Below is a reference of all configuration keys.
 
 [NOTE]
 ====
-*Configuration Priority*: When you provide a remote Harvester Configuration file during the install of Harvester, the Harvester Configuration file will not overwrite the values for the inputs you had previously filled out and selected.  Priority is given to the values that you input during the guided install.
-For instance, if you have in your Harvester Configuration file specified `os.hostname` and during install you fill in the field of `hostname` when prompted, the value that you filled in will take priority over your Harvester Configuration's `os.hostname`.
+*Configuration Priority*: When you provide a remote configuration file during installation, the configuration file will not overwrite the values for the inputs you had previously filled out and selected.  Priority is given to the values that you input during the guided install.
+For instance, if you have in your configuration file specified `os.hostname` and during install you fill in the field of `hostname` when prompted, the value that you filled in will take priority over your configuration file's `os.hostname`.
 ====
 
 
@@ -103,13 +103,7 @@ For instance, if you have in your Harvester Configuration file specified `os.hos
 
 The version of scheme reserved for future configuration migration.
 
-This configuration is mandatory for migrating the configuration to a new scheme version. It tells Harvester the previous version and the need to migrate.
-
-[NOTE]
-====
-This field didn't take any effect in the current Harvester version.
-====
-
+This configuration is mandatory for migrating the configuration to a new scheme version. It specifies the previous version and the need to migrate.
 
 [CAUTION]
 ====
@@ -121,14 +115,14 @@ Make sure that your custom configuration always has the correct scheme version.
 
 ==== Definition
 
-`server_url` is the URL of the Harvester cluster, which is used for the new `node` to join the cluster.
+`server_url` is the URL of the SUSE® Virtualization cluster, which is used for the new `node` to join the cluster.
 
 This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `+https://cluster-VIP:443+`.
 
 [NOTE]
 ====
 
-To ensure a high availability (HA) Harvester cluster, please use either the Harvester cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
+To ensure a high availability (HA) SUSE® Virtualization cluster, please use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
 ====
 
 
@@ -148,7 +142,7 @@ install:
 The cluster secret or node token. If the value matches the format of a node token it will
 automatically be assumed to be a node token. Otherwise it is treated as a cluster secret.
 
-In order for a new node to join the Harvester cluster, the token should match what the server has.
+In order for a new node to join the cluster, the token should match what the server has.
 
 ==== Example
 
@@ -230,7 +224,7 @@ The `os.persistent_state_paths` option allows you to configure custom paths wher
 
 ==== Example
 
-Refer to the following example config for installing `rook-ceph` in Harvester:
+Refer to the following example config for installing `rook-ceph`:
 
 [,yaml]
 ----
@@ -251,7 +245,7 @@ You can add additional software packages with `after_install_chroot_commands`. T
 
 ==== Example
 
-Refer to the following example config for installing an RPM package in Harvester:
+Refer to the following example config for installing an RPM package in SUSE® Virtualization:
 
 [,yaml]
 ----
@@ -275,7 +269,7 @@ os:
 [NOTE]
 ====
 
-Upgrading Harvester causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading Harvester.
+Upgrading SUSE® Virtualization causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
 ====
 
 
@@ -366,8 +360,7 @@ The password for the default user, `rancher`. By default, there is no password f
 If you set a password at runtime it will be reset on the next boot. The
 value of the password can be clear text or an encrypted form. The easiest way to get this encrypted
 form is to change your password on a Linux system and copy the value of the second field from
-`/etc/shadow`. You can also encrypt a password using OpenSSL. For the encryption algorithms
-supported by Harvester, please refer to the table below.
+`/etc/shadow`. You can also encrypt a password using OpenSSL. For the supported encryption algorithms, refer to the table below.
 
 [cols="^,^,^"]
 |===
@@ -433,7 +426,7 @@ os:
 ====
 
 This example sets the HTTP(S) proxy for *foundational OS components*.
-To set up an HTTP(S) proxy for Harvester components such as fetching external images and backup to S3 services,
+To set up an HTTP(S) proxy for SUSE® Virtualization components such as fetching external images and backup to S3 services,
 see link:../advanced/settings.adoc#http-proxy[Settings/http-proxy].
 ====
 
@@ -459,7 +452,7 @@ os:
 
 ==== Definition
 
-Subsystem used to configure the OpenSSH Daemon (sshd). Harvester currently only supports `sftp`.
+Subsystem used to configure the OpenSSH Daemon (sshd). SUSE® Virtualization currently only supports `sftp`.
 
 ==== Example
 
@@ -476,7 +469,7 @@ os:
 
 === `install.addons`
 
-*Definition*: Setting that defines the default addon status. Harvester addons are disabled by default.
+*Definition*: Setting that defines the default add-on status. SUSE® Virtualization add-ons are disabled by default.
 
 *Supported values*:
 
@@ -526,7 +519,7 @@ install:
 
 === `install.device`
 
-*Definition*: Device on which the Harvester OS is installed.
+*Definition*: Device on which the SUSE® Virtualization operating system is installed.
 
 When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` to specify the storage device if the server contains multiple physical volumes.
 
@@ -540,9 +533,9 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 
 *Definition*: Setting that forces usage of MBR partitioning on BIOS systems.
 
-Harvester uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
+SUSE® Virtualization uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
 
-If you specify the same storage device for both `install.device` and `install.data_disk`, Harvester creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
+If you specify the same storage device for both `install.device` and `install.data_disk`, SUSE® Virtualization creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
 
 *Example*:
 
@@ -558,7 +551,7 @@ install:
 
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Instance Manager pod.
 
-Using the default value is recommended for high system availability. When deploying single-node Harvester clusters, you can specify a value less than 12.
+Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
 For more information about how to set the correct value, see https://longhorn.io/docs/1.6.0/references/settings/#guaranteed-instance-manager-cpu[Guaranteed Instance Manager CPU] in the Longhorn documentation.
 
@@ -577,9 +570,9 @@ For more information about how to set the correct value, see https://longhorn.io
 
 === `install.harvester.storage_class.replica_count`
 
-*Definition*: Replica count of the default Harvester StorageClass `harvester-longhorn`.
+*Definition*: Replica count of the default StorageClass `harvester-longhorn`.
 
-Using the default value is recommended for high storage availability. When deploying single-node Harvester clusters, you must set the value to 1.
+Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
 For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
 
@@ -599,18 +592,18 @@ install:
 
 === `install.iso_url`
 
-*Definition*: URL of ISO image to be downloaded and used to install Harvester when booting from the kernel or vmlinuz.
+*Definition*: URL of ISO image to be downloaded and used to install SUSE® Virtualization when booting from the kernel or vmlinuz.
 
 === `install.management_interface`
 
 *Definition*: Network interfaces for the host machine.
 
-Harvester uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
+SUSE® Virtualization uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
 
 *Fields*:
 
 * `method`: Method used to assign an IP to the network. Supported values:
- ** `dhcp`: Harvester requests an IP from the DHCP server.
+ ** `dhcp`: An IP is requested from the DHCP server.
  ** `static`: IP and gateway addresses are manually assigned.
 * `ip`: Static IP assigned to the network. This field is required when the value of `method` is `static`.
 * `subnet_mask`: Subnet mask of the network. This field is required when the value of `method` is `static`.
@@ -644,12 +637,12 @@ install:
 
 === `install.mode`
 
-*Definition*: Mode of installing Harvester.
+*Definition*: Mode of installation.
 
 *Supported values*:
 
-* `create`: Create a new Harvester installation.
-* `join`: Join an existing Harvester installation. You must specify the `server_url`.
+* `create`: Create a new SUSE® Virtualization cluster.
+* `join`: Join an existing SUSE® Virtualization cluster. You must specify the `server_url`.
 
 *Example*:
 
@@ -685,14 +678,14 @@ install:
 
 === `install.rawdiskimagepath`
 
-*Definition*: Setting that forces the installer to only install the Harvester hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
+*Definition*: Setting that forces the installer to only install the SUSE® Virtualization hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
 
 === `install.role`
 
-*Definition*: Role assigned to a node at the time of installation. When unspecified, Harvester assigns the `default` role.
+*Definition*: Role assigned to a node at the time of installation. When unspecified, the `default` role is assigned.
 
 * `default`: Allows a node to function as a management node or a worker node.
-* `management`: Allows a node to be prioritized when Harvester promotes nodes to management nodes.
+* `management`: Allows a node to be prioritized when SUSE® Virtualization promotes nodes to management nodes.
 * `worker`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 * `witness`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
 
@@ -734,9 +727,9 @@ install:
 
 === `install.vip`
 
-*Definition*: VIP of the Harvester management endpoint.
+*Definition*: VIP of the SUSE® Virtualization management endpoint.
 
-After installation, you can access the Harvester UI at `https://<VIP>`.
+After installation, you can access the UI at `https://<VIP>`.
 
 === `install.vip_mode`
 
@@ -744,8 +737,8 @@ After installation, you can access the Harvester UI at `https://<VIP>`.
 
 *Supported values*:
 
-* `dhcp`: Harvester sends DHCP requests to get the VIP. You must specify the hardware address using the `install.vip_hw_addr` field.
-* `static`: Harvester uses a static VIP.
+* `dhcp`: DHCP requests are sent to obtain the VIP. You must specify the hardware address using the `install.vip_hw_addr` field.
+* `static`: A static VIP is used.
 
 *Example*:
 
@@ -786,8 +779,8 @@ The installer sends HTTP requests to the specified URL. Multiple requests can be
  ** `FAILED`: The installation was unsuccessful.
 * `method`: HTTP method
 * `url`: URL to which HTTP requests are sent
-* `insecure`: When set to `true`, Harvester does not verify the server's certificate. The default value is `false`.
-* `basicAuth`: When set to `true`, Harvester uses the "Basic" HTTP authentication scheme.
+* `insecure`: When set to `true`, SUSE® Virtualization does not verify the server's certificate. The default value is `false`.
+* `basicAuth`: When set to `true`, the "Basic" HTTP authentication scheme is used.
 * `headers`: When set to `true`, custom headers are included in the HTTP requests. Headers such as `Content-Length` are automatically included.
 * `payload`*: When set to `true`, payload data is sent with the HTTP requests. You may need to set the correct Content-Type header in the `headers` field to ensure that the server accepts the request.
 
@@ -828,7 +821,7 @@ install:
 
 *Definition*: Setting that determines if images are pulled from the internet after installation.
 
-The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, Harvester does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
+The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, SUSE® Virtualization does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
 
 '''
 
@@ -838,15 +831,15 @@ The value of this field is typically derived from the kernel parameter `harveste
 
 ==== Definition
 
-You can overwrite the default Harvester system settings by configuring `system_settings`.
+You can overwrite the default system settings by configuring `system_settings`.
 See the xref:./settings.adoc[Settings] page for additional information and the list of all the options.
 
 [NOTE]
 ====
 
-Overwriting system settings only works when Harvester is installed in "create" mode.
-If you install Harvester in "join" mode, this setting is ignored.
-Installing in "join" mode will adopt the system settings from the existing Harvester system.
+Overwriting system settings only works when SUSE® Virtualization is installed in "create" mode.
+If you install SUSE® Virtualization in "join" mode, this setting is ignored.
+Installing in "join" mode will adopt the system settings from the existing system.
 ====
 
 

--- a/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
@@ -1,6 +1,6 @@
 = Management Address
 
-Harvester provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
+SUSE® Virtualization provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 
 [NOTE]
 ====
@@ -13,18 +13,18 @@ image::install/iso-installed.png[]
 == Requirements
 
 * The VIP and the node management interfaces must belong to the same subnet.
-* All Harvester node management interfaces must be on the same layer-2 network segment.
+* All SUSE® Virtualization node management interfaces must be on the same layer-2 network segment.
 
 Both are required because the VIP relies on the Address Resolution Protocol (ARP), which is a layer-2 protocol.
 
-The VIP can be assigned to any Harvester node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the Harvester cluster's management IP address (the VIP).
+The VIP can be assigned to any SUSE® Virtualization node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the SUSE® Virtualization cluster's management IP address (the VIP).
 
 [CAUTION]
 ====
 
-If you plan to host a Harvester cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, Harvester is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
+If you plan to host a SUSE® Virtualization cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, SUSE® Virtualization is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
 
-Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your Harvester nodes (for example, if your Harvester hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
+Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your SUSE® Virtualization nodes (for example, if your SUSE® Virtualizationhosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
 ====
 
 
@@ -46,7 +46,7 @@ Example of output:
 
 == Identifying the Node the VIP Is Assigned To
 
-You can use kubectl (either on your local machine with the Harvester kubeconfig file, or when using SSH to connect to any Harvester management node as a root user).
+You can use kubectl (either on your local machine with the SUSE® Virtualization kubeconfig file, or when using SSH to connect to any SUSE® Virtualization management node as a root user).
 
 [,console]
 ----
@@ -60,7 +60,7 @@ Example output:
 harvester-xzj76
 ----
 
-Alternatively, you can use SSH to connect to each Harvester management node and then run the command `ip address show mgmt-br`.
+Alternatively, you can use SSH to connect to each SUSE® Virtualization management node and then run the command `ip address show mgmt-br`.
 
 Example:
 
@@ -81,7 +81,7 @@ When the output includes both the VIP and the node address, the VIP is assigned 
 
 The management address:
 
-* Allows the access to the Harvester API/UI via `HTTPS` protocol.
+* Allows the access to the SUSE® Virtualization API/UI via `HTTPS` protocol.
 * Allows other nodes to join the cluster.
 +
 image:install/configure-management-address.png[]

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -1,14 +1,14 @@
 = Hardware and Network Requirements
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running Harvester.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running SUSE® Virtualization.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
+A three-node cluster is required to fully realize the multi-node features. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
 
-Certain versions of Harvester support the deployment of https://docs.harvesterhci.io/v1.3/advanced/singlenodeclusters[single-node clusters]. Such clusters do not support high availability, multiple replicas, and live migration.
+The latest versions support the deployment of xref:./single-node-clusters.adoc[single-node clusters]. Such clusters do not support high availability, multiple replicas, and live migration.
 
 == Hardware Requirements
 
-Harvester nodes have the following hardware requirements and recommendations for installation and testing.
+SUSE® Virtualization nodes have the following hardware requirements and recommendations for installation and testing.
 
 |===
 | Hardware | Development/Testing | Production
@@ -45,16 +45,16 @@ Harvester nodes have the following hardware requirements and recommendations for
 [IMPORTANT]
 ====
 
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. Harvester is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. SUSE® Virtualization is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
-* Harvester has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the Harvester cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
+* SUSE® Virtualization has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
 ====
 
 
 === CPU Specifications
 
-xref:../virtual-machines/live-migration.adoc[Live Migration] functions correctly only if the CPUs of all physical servers in the xref:../introduction/glossary.adoc#_harvester_cluster[Harvester cluster] have the same specifications. This requirement applies to all operations that rely on Live Migration functionality, such as automatic VM migration when xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is enabled.
+xref:../virtual-machines/live-migration.adoc[Live Migration] functions correctly only if the CPUs of all physical servers in the cluster have the same specifications. This requirement applies to all operations that rely on Live Migration functionality, such as automatic VM migration when xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is enabled.
 
 Newer CPUs (even those from the same vendor, generation, and family) can have varying capabilities that may be exposed to VM operating systems. To ensure VM stability, Live Migration checks if the CPU capabilities are consistent, and blocks migration attempts when the source and destination are incompatible.
 
@@ -62,175 +62,175 @@ When creating clusters, adding more hosts to a cluster, and replacing hosts, alw
 
 == Network Requirements
 
-Harvester nodes have the following network requirements for installation.
+Nodes have the following network requirements for installation.
 
-=== Port Requirements for Harvester Nodes
+=== Port Requirements for SUSE® Virtualization Nodes
 
-Harvester nodes require the following port connections or inbound rules. Typically, all outbound traffic is allowed.
+Nodes require the following port connections or inbound rules. Typically, all outbound traffic is allowed.
 
 |===
 | Protocol | Port | Source | Description
 
 | TCP
 | 2379
-| Harvester management nodes
+| Management nodes
 | Etcd client port
 
 | TCP
 | 2381
-| Harvester management nodes
+| Management nodes
 | Etcd metrics collection
 
 | TCP
 | 2380
-| Harvester management nodes
+| Management nodes
 | Etcd peer port
 
 | TCP
 | 2382
-| Harvester management nodes
+| Management nodes
 | Etcd client port (HTTP only)
 
 | TCP
 | 10010
-| Harvester management and compute nodes
+| Management and compute nodes
 | Containerd
 
 | TCP
 | 6443
-| Harvester management nodes
+| Management nodes
 | Kubernetes API
 
 | TCP
 | 9345
-| Harvester management nodes
+| Management nodes
 | Kubernetes API
 
 | TCP
 | 10252
-| Harvester management nodes
+| Management nodes
 | Kube-controller-manager health checks
 
 | TCP
 | 10257
-| Harvester management nodes
+| Management nodes
 | Kube-controller-manager secure port
 
 | TCP
 | 10251
-| Harvester management nodes
+| Management nodes
 | Kube-scheduler health checks
 
 | TCP
 | 10259
-| Harvester management nodes
+| Management nodes
 | Kube-scheduler secure port
 
 | TCP
 | 10250
-| Harvester management and compute nodes
+| Management and compute nodes
 | Kubelet
 
 | TCP
 | 10256
-| Harvester management and compute nodes
+| Management and compute nodes
 | Kube-proxy health checks
 
 | TCP
 | 10258
-| Harvester management nodes
+| Management nodes
 | cloud-controller-manager
 
 | TCP
 | 10260
-| Harvester management nodes
+| Management nodes
 | cloud-controller-manager
 
 | TCP
 | 9091
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal calico-node felix
 
 | TCP
 | 9099
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal CNI health checks
 
 | UDP
 | 8472
-| Harvester management and compute nodes
+| Management and compute nodes
 | Canal CNI with VxLAN
 
 | TCP
 | 2112
-| Harvester management nodes
+| Management nodes
 | Kube-vip
 
 | TCP
 | 6444
-| Harvester management and compute nodes
+| Management and compute nodes
 | RKE2 agent
 
 | TCP
 | 10246/10247/10248/10249
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx worker process
 
 | TCP
 | 8181
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 8444
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 10245
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx-ingress-controller
 
 | TCP
 | 80
-| Harvester management and compute nodes
+| Management and compute nodes
 | Nginx
 
 | TCP
 | 9796
-| Harvester management and compute nodes
+| Management and compute nodes
 | Node-exporter
 
 | TCP
 | 30000-32767
-| Harvester management and compute nodes
+| Management and compute nodes
 | NodePort port range
 
 | TCP
 | 22
-| Harvester management and compute nodes
+| Management and compute nodes
 | sshd
 
 | UDP
 | 68
-| Harvester management and compute nodes
+| Management and compute nodes
 | Wicked
 
 | TCP
 | 3260
-| Harvester management and compute nodes
+| Management and compute nodes
 | iscsid
 |===
 
-=== Port Requirements for Integrating Harvester with Rancher
+=== Port Requirements for Integrating SUSE® Virtualization with Rancher
 
-If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate Harvester with Rancher], you need to make sure that all Harvester nodes can connect to TCP port *443* of the Rancher load balancer.
+If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all SUSE® Virtualization nodes can connect to TCP port *443* of the Rancher load balancer.
 
-When provisioning VMs with Kubernetes clusters from Rancher into Harvester, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from Rancher into SUSE® Virtualization, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
-For the port requirements for guest clusters deployed inside Harvester VMs, refer to the following links:
+For the port requirements for guest clusters deployed inside SUSE® Virtualization VMs, refer to the following links:
 
 * https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
 * https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a High-Availability Cluster
 
-A xref:./glossary.adoc#_harvester_cluster[Harvester cluster] with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host xref:./glossary.adoc#_guest_cluster_guest_kubernetes_cluster[guest clusters] and run custom workloads.
+This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-Harvester is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
-You can download the installation files from the https://github.com/harvester/harvester/releases[Harvester Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
+You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -42,29 +42,29 @@ You can download the installation files from the https://github.com/harvester/ha
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. Deploying the first node creates the cluster, and the first node is assigned the management node by default.
 
-During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
-Once installation is completed, the node restarts and then the Harvester console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
+Once installation is completed, the node restarts and then the console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
 
-== 5. Configure a strong password for the default `admin` user on the Harvester UI.
+== 5. Configure a strong password for the default `admin` user.
 
-Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[Harvester UI] using the management URL displayed on the console.
+Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[UI] using the management URL displayed on the console.
 
 == 6. Deploy the other nodes and join them to the cluster.
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. All other nodes join the cluster that was created when the first node was deployed.
 
-During installation, you must configure node settings, and specify the cluster management address (virtual IP) and the cluster token that you defined previously. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, and specify the cluster management address (virtual IP) and the cluster token that you defined previously. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
 When the cluster has three or more nodes, the two nodes added after the first node are automatically promoted to management nodes to form a high-availability (HA) cluster.
 
 == 7. Create a custom cluster network (optional) and a VM network (required).
 
-Networking in Harvester involves three major concepts:
+Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the Harvester cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the Harvester cluster) to which each Harvester node attaches with management NICs for cluster management purposes. Harvester also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -78,25 +78,25 @@ Before you create VMs, create the necessary networks. If more than one network i
 
 == 8. Import VM images.
 
-On the Harvester UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
+On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in Harvester. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the Harvester UI.
+You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of the following methods:
 
-* Harvester UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
+* UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
 * Kubernetes API: Create a `VirtualMachine` object.
-* xref:../integrations/terraform/terraform-provider.adoc[Harvester Terraform Provider]: Define a `harvester_virtualmachine` resource block.
+* xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the Harvester UI involves slightly different steps. Harvester provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with Harvester.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a Single-Node Cluster
 
-A xref:./glossary.adoc#_harvester_cluster[Harvester cluster] with three or more nodes is required to fully realize multi-node features such as high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host xref:./glossary.adoc#_guest_cluster_guest_kubernetes_cluster[guest clusters] and run custom workloads.
+This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-Harvester is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
-You can download the installation files from the https://github.com/harvester/harvester/releases[Harvester Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
+You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing Harvester behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -42,32 +42,32 @@ You can download the installation files from the https://github.com/harvester/ha
 
 Deployment involves installing the operating system and other components on the host, and then rebooting once installation is completed. Deploying the node creates the cluster, and the node is assigned the management role by default.
 
-During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+During installation, you must configure node settings, define the cluster management address (VIP) and the cluster token, and specify other information. If necessary, you can configure more settings using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 
-Once installation is completed, the node restarts and then the Harvester console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
+Once installation is completed, the node restarts and then the console appears. The console displays information about the cluster (management URL and status) and the node (hostname, IP address, and status). After the cluster is initialized and all services start running, the cluster status changes to *Ready*.
 
-== 5. Configure a strong password for the default `admin` user on the Harvester UI.
+== 5. Configure a strong password for the default `admin` user.
 
-Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[Harvester UI] using the management URL displayed on the console.
+Once the cluster status changes to *Ready*, you can access the xref:../installation-setup/authentication.adoc[UI] using the management URL displayed on the console.
 
 == 6. Configure the default StorageClass.
 
-Harvester uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+SUSE® Virtualization uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the Harvester UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
-* Change the xref:../installation-setup/config/harvester-configuration.adoc#_install_harvester_storage_class_replica_count[replica count] of `harvester-longhorn` to *1* using a xref:../installation-setup/config/harvester-configuration.adoc[Harvester configuration] file.
+* Change the xref:../installation-setup/config/harvester-configuration.adoc#_install_harvester_storage_class_replica_count[replica count] of `harvester-longhorn` to *1* using a xref:../installation-setup/config/harvester-configuration.adoc[configuration] file.
 * xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] with the *Number of Replicas* parameter set to *1*. Once created, locate the new StorageClass in the list and then select *⋮* > *Set as Default*.
 
 == 7. Create a custom cluster network and a VM network. (Optional)
 
-Networking in Harvester involves three major concepts:
+Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the Harvester cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the Harvester cluster) to which each Harvester node attaches with management NICs for cluster management purposes. Harvester also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -77,29 +77,29 @@ Each network configuration corresponds to a set of nodes with uniform network sp
 +
 Each VM network is linked to a specific cluster network, which is used for transmission of VM traffic. You can create either a xref:../networking/vm-network.adoc#_vlan_network[VLAN network] or an xref:../networking/vm-network.adoc#_untagged_network[untagged network] based on your requirements, such as traffic isolation, network segmentation, ease of management, or alignment with the external network environment.
 
-You can create a VM network that uses `mgmt` when testing Harvester with a single-node cluster.
+You can create a VM network that uses `mgmt` when testing SUSE® Virtualization with a single-node cluster.
 
 == 8. Import VM images.
 
-On the Harvester UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
+On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images/upload-image.adoc[images] by uploading an image from the local file system, or by specifying the URL of an image that can be accessed from the cluster.
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in Harvester. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the Harvester UI.
+You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of the following methods:
 
-* Harvester UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
+* UI: On the *Virtual Machines* screen, click *Create* and configure the settings on each tab.
 * Kubernetes API: Create a `VirtualMachine` object.
-* xref:../integrations/terraform/terraform-provider.adoc[Harvester Terraform Provider]: Define a `harvester_virtualmachine` resource block.
+* xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the Harvester UI involves slightly different steps. Harvester provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with Harvester.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/glossary.adoc
@@ -2,11 +2,11 @@
 
 == *guest cluster* / *guest Kubernetes cluster*
 
-Group of integrated Kubernetes worker machines that run in VMs on top of a Harvester cluster.
+Group of integrated Kubernetes worker machines that run in VMs on top of a SUSE® Virtualization cluster.
 
-You can create RKE1, RKE2, and K3s guest clusters using the Harvester and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
+You can create RKE1, RKE2, and K3s guest clusters using the SUSE® Virtualization and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
 
-Guest clusters form the main infrastructure for running container workloads. Certain versions of Harvester and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to Harvester clusters] (with some limitations).
+Guest clusters form the main infrastructure for running container workloads. Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE® Virtualization clusters] (with some limitations).
 
 == *guest node* / *guest cluster node*
 
@@ -14,26 +14,26 @@ Kubernetes worker VM that uses guest cluster resources to run container workload
 
 Guest nodes are managed through a control plane that controls pod-related activity and maintains the desired cluster state.
 
-== *Harvester cluster*
+== *SUSE® Virtualization cluster*
 
-Group of integrated physical servers (hosts) on which the Harvester hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
+Group of integrated physical servers (hosts) on which the SUSE® Virtualization hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
 
-A three-node cluster is required to fully realize the multi-node features of Harvester, particularly high availability. Certain versions of Harvester allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most Harvester features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of SUSE® Virtualization, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-Harvester clusters can be imported into and managed by Rancher. Within the Rancher context, an imported Harvester cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
+SUSE® Virtualization clusters can be imported into and managed by Rancher. Within the Rancher context, an imported SUSE® Virtualization cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 
-Certain versions of Harvester and Rancher allow you to deploy container workloads directly to Harvester clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with VM workloads.
+Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads directly to SUSE® Virtualization clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with VM workloads.
 
-== *Harvester hypervisor*
+== *SUSE® Virtualization hypervisor*
 
-Specialized operating system and xref:./overview.adoc#_harvester_architecture[software stack] that runs on a single physical server.
+Specialized operating system and xref:./overview.adoc#_architecture[software stack] that runs on a single physical server.
 
-== *Harvester node*
+== *SUSE® Virtualization node*
 
-Physical server on which the Harvester hypervisor is installed.
+Physical server on which the SUSE® Virtualization hypervisor is installed.
 
-Each node that joins a Harvester cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All Harvester nodes process data but not all can store data.
+Each node that joins a SUSE® Virtualization cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All SUSE® Virtualization nodes process data but not all can store data.
 
-== *Harvester Node Driver*
+== *SUSE® Virtualization Node Driver*
 
-xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision VMs in a Harvester cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.
+xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision VMs in a SUSE® Virtualization cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -1,33 +1,33 @@
-= Harvester Overview
+= Overview
 
-https://harvesterhci.io/[Harvester] is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. Harvester runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), Harvester supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+SUSE® Virtualization is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. SUSE® Virtualization runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), SUSE® Virtualization supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
-== Harvester Architecture
+== Architecture
 
-The Harvester architecture consists of cutting-edge open-source technologies:
+The architecture consists of cutting-edge open-source technologies:
 
-* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of Harvester and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
-* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and Harvester is an HCI solution with Kubernetes under the hood.
+* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of SUSE® Virtualization and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
+* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and SUSE® Virtualization is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
 * *Storage management with Longhorn.* https://longhorn.io/[Longhorn] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
 
-== Harvester Features
+== Features
 
-Harvester is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features of Harvester include:
+SUSE® Virtualization is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since Harvester ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since SUSE® Virtualization ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.
-* *Storage management.* Harvester supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
+* *Storage management.* SUSE® Virtualization supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
 * *Network management.* Supports using a virtual IP (VIP) and multiple Network Interface Cards (NICs). If your VMs need to connect to the external network, create a VLAN or untagged network.
-* *Integration with Rancher.* Access Harvester directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
+* *Integration with Rancher.* Access SUSE® Virtualization directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
 
-== Harvester UI
+== User Interface
 
-Harvester provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once you install Harvester, you can access the IP address for the Harvester UI from the node's terminal.
+SUSE® Virtualization provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
 
 +++<div class="text-center">++++++<iframe width="99%" height="450" src="https://www.youtube.com/embed/Ngsk7m6NYf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++


### PR DESCRIPTION
Change scope (v1.3 and v1.4):
- Introduction section: All files
- Installation and Setup: `requirements.adoc`, `management-address.adoc`, `cloudinitcrd.adoc`, `harvester-configuration.adoc` (renamed to `configuration-file.adoc`)