### PR TITLE
Update branding for URL from suse-virtualization to virtualization

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Virtualization 
   url: /
-  start_page: v1.3@suse-virtualization:en:introduction/overview.adoc
+  start_page: v1.3@virtualization:en:introduction/overview.adoc
 content:
   sources:
   - url: ./

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Virtualization
   url: /
-  start_page: v1.3@suse-virtualization:en:introduction/overview.adoc
+  start_page: v1.3@virtualization:en:introduction/overview.adoc
   robots: disallow
 content:
   sources: 

--- a/versions/v1.3/antora.yml
+++ b/versions/v1.3/antora.yml
@@ -1,4 +1,4 @@
-name: suse-virtualization
+name: virtualization
 title: SUSE® Virtualization
 version: v1.3
 display_version: 'v1.3 (Latest)'

--- a/versions/v1.4/antora.yml
+++ b/versions/v1.4/antora.yml
@@ -1,4 +1,4 @@
-name: suse-virtualization
+name: virtualization
 title: SUSE® Virtualization
 version: v1.4
 display_version: v1.4 (Dev)


### PR DESCRIPTION
Update branding for URL from suse-virtualization to virtualization

<img width="485" alt="Screenshot 2024-09-26 at 4 02 53 PM" src="https://github.com/user-attachments/assets/52cfe85b-e69e-4cdf-8f05-b206e0e7d075">

<img width="675" alt="Screenshot 2024-09-26 at 4 01 43 PM" src="https://github.com/user-attachments/assets/53ac9205-ed56-44db-bc2b-2e31976c3864">
