### PR TITLE
[v1.4] Add product name variables to topics in Introduction, Installation and Setup, and Hosts

### DIFF
--- a/versions/v1.3/antora.yml
+++ b/versions/v1.3/antora.yml
@@ -3,9 +3,20 @@ title: SUSE® Virtualization
 version: v1.3
 display_version: 'v1.3 (Latest)'
 start_page: en:introduction/overview.adoc
-asciidoc:
-  attributes:
-    product-name: "SUSE Virtualization"
-    product-name-legal: "SUSE® Virtualization"
 nav:
 - modules/en/nav.adoc
+asciidoc:
+  attributes:
+    harvester-product-name: "SUSE Virtualization"
+    harvester-product-name-tm: "SUSE® Virtualization"
+    longhorn-product-name: "SUSE Storage"
+    longhorn-product-name-tm: "SUSE® Storage"
+    neuvector-product-name: "SUSE® Security"
+    rancher-product-name: "SUSE Rancher Prime"
+    rancher-product-name-tm: "SUSE® Rancher Prime"
+    elemental-product-name: "SUSE® Rancher Prime: OS Manager"
+    k3s-product-name: "SUSE® Rancher Prime: K3s"
+    kubewarden-product-name: "SUSE® Rancher Prime: Admission Policy Manager"
+    rke2-product-name: "SUSE® Rancher Prime: RKE2"
+    fleet-product-name: "SUSE® Rancher Prime: Continous Delivery"
+    turtles-product-name: "SUSE® Rancher Prime: Cluster API"

--- a/versions/v1.3/antora.yml
+++ b/versions/v1.3/antora.yml
@@ -3,5 +3,9 @@ title: SUSE® Virtualization
 version: v1.3
 display_version: 'v1.3 (Latest)'
 start_page: en:introduction/overview.adoc
+asciidoc:
+  attributes:
+    product-name: "SUSE Virtualization"
+    product-name-legal: "SUSE® Virtualization"
 nav:
 - modules/en/nav.adoc

--- a/versions/v1.4/antora.yml
+++ b/versions/v1.4/antora.yml
@@ -3,9 +3,20 @@ title: SUSE® Virtualization
 version: v1.4
 display_version: v1.4 (Dev)
 start_page: en:introduction/overview.adoc
-asciidoc:
-  attributes:
-    product-name: "SUSE Virtualization"
-    product-name-legal: "SUSE® Virtualization"
 nav:
 - modules/en/nav.adoc
+asciidoc:
+  attributes:
+    harvester-product-name: "SUSE Virtualization"
+    harvester-product-name-tm: "SUSE® Virtualization"
+    longhorn-product-name: "SUSE Storage"
+    longhorn-product-name-tm: "SUSE® Storage"
+    neuvector-product-name: "SUSE® Security"
+    rancher-product-name: "SUSE Rancher Prime"
+    rancher-product-name-tm: "SUSE® Rancher Prime"
+    elemental-product-name: "SUSE® Rancher Prime: OS Manager"
+    k3s-product-name: "SUSE® Rancher Prime: K3s"
+    kubewarden-product-name: "SUSE® Rancher Prime: Admission Policy Manager"
+    rke2-product-name: "SUSE® Rancher Prime: RKE2"
+    fleet-product-name: "SUSE® Rancher Prime: Continous Delivery"
+    turtles-product-name: "SUSE® Rancher Prime: Cluster API"

--- a/versions/v1.4/antora.yml
+++ b/versions/v1.4/antora.yml
@@ -3,5 +3,9 @@ title: SUSE® Virtualization
 version: v1.4
 display_version: v1.4 (Dev)
 start_page: en:introduction/overview.adoc
+asciidoc:
+  attributes:
+    product-name: "SUSE Virtualization"
+    product-name-legal: "SUSE® Virtualization"
 nav:
 - modules/en/nav.adoc

--- a/versions/v1.4/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/hosts.adoc
@@ -1,10 +1,10 @@
 = Host Management
 
-Users can view and manage Harvester nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
+Users can view and manage {harvester-product-name} nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 
 [NOTE]
 ====
-Because Harvester is built on top of Kubernetes and uses etcd as its database, the maximum node fault toleration is one when there are three management nodes.
+Because {harvester-product-name} is built on top of Kubernetes and uses etcd as its database, the maximum node fault toleration is one when there are three management nodes.
 ====
 
 image::host/host.png[host.png]
@@ -36,9 +36,9 @@ image::host/cordon-nodes.png[cordon-node.png]
 
 [CAUTION]
 ====
-Before removing a node from a Harvester cluster, determine if the remaining nodes have enough computing and storage resources to take on the workload from the node to be removed. Check the following:
+Before removing a node from a {harvester-product-name} cluster, determine if the remaining nodes have enough computing and storage resources to take on the workload from the node to be removed. Check the following:
 
-* Current resource usage in the cluster (on the *Hosts* screen of the Harvester UI)
+* Current resource usage in the cluster (on the *Hosts* screen of the {harvester-product-name} UI)
 * Ability of the remaining nodes to maintain enough replicas for all volumes
 
 If the remaining nodes do not have enough resources, VMs might fail to migrate and volumes might degrade when you remove a node.
@@ -50,7 +50,7 @@ You can safely remove a control plane node depending on the quantity and availab
 
 * The cluster has three control plane nodes and one or more worker nodes.
 +
-When you remove a control plane node, a worker node will be promoted to control plane node. Harvester v1.3.0 allows you to assign a role to each node that joins a cluster. In earlier versions, worker nodes were randomly selected for promotion. If you prefer to promote specific nodes, see <<Role Management,Role Management>> and xref:../installation-setup/config/configuration-file.adoc#_install_role[Configuration File] for more information.
+When you remove a control plane node, a worker node will be promoted to control plane node. {harvester-product-name} allows you to assign a role to each node that joins a cluster. In earlier versions, worker nodes were randomly selected for promotion. If you prefer to promote specific nodes, see <<Role Management,Role Management>> and xref:../installation-setup/config/configuration-file.adoc#_install_role[Configuration File] for more information.
 
 * The cluster has three control plane nodes and no worker nodes.
 +
@@ -106,7 +106,7 @@ Create a backup or snapshot for each non-migratable VM before modifying the sett
 
 === 5. Evict workloads from the node to be removed.
 
-If your cluster is running Harvester v1.1.2 or later, you can enable <<Node Maintenance,Maintenance Mode>> on the node to automatically live-migrate VMs and workloads. You can also xref:../virtual-machines/live-migration.adoc#_starting_a_migration[manually live-migrate] VMs to other nodes.
+You can enable <<Node Maintenance,Maintenance Mode>> on the node to automatically live-migrate VMs and workloads. You can also xref:../virtual-machines/live-migration.adoc#_starting_a_migration[manually live-migrate] VMs to other nodes.
 
 All workloads have been successfully evicted if the node state is *Maintenance*.
 
@@ -114,7 +114,7 @@ image::host/node-maintain-completed.png[node-maintain-completed.png]
 
 [IMPORTANT]
 ====
-If a cluster has only two control plane nodes, Harvester does not allow you to enable Maintenance Mode on any node. You can manually drain the node to be removed using the following command:
+If a cluster has only two control plane nodes, {harvester-product-name} does not allow you to enable Maintenance Mode on any node. You can manually drain the node to be removed using the following command:
 
 ----
 kubectl drain <node_name> --force --ignore-daemonsets --delete-local-data --pod-selector='app!=csi-attacher,app!=csi-provisioner'
@@ -125,8 +125,8 @@ Again, removing a control plane node in this situation is *not recommended* beca
 
 === 6. Remove the node.
 
-. On the Harvester UI, go to the *Hosts* screen.
-. Locate the node that you want to remove, and then click *⋮ > Delete*.
+. On the {harvester-product-name} UI, go to the *Hosts* screen.
+. Locate the node that you want to remove, and then click *⋮ -> Delete*.
 
 image::host/delete-node.png[delete.png]
 
@@ -143,15 +143,15 @@ Once resolved, you can skip this step.
 
 == Role Management
 
-Hardware issues may force you to replace the management node. In earlier Harvester versions, accurately promoting a specific worker node to a management node was not easy. Harvester v1.3.0 improves the process by introducing the following roles:
+Hardware issues may force you to replace the management node. {harvester-product-name} improves the process by introducing the following roles:
 
-* *Management*: Allows a node to be prioritized when Harvester promotes nodes to management nodes.
+* *Management*: Allows a node to be prioritized when {harvester-product-name} promotes nodes to management nodes.
 * *Witness*: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
 * *Worker*: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 
 [CAUTION]
 ====
-Harvester currently allows only one witness node in the cluster.
+{harvester-product-name} currently allows only one witness node in the cluster.
 ====
 
 For more information about assigning roles to nodes, see xref:../installation-setup/methods/iso-install.adoc[ISO Installation].
@@ -163,7 +163,7 @@ For more information about assigning roles to nodes, see xref:../installation-se
 Users can view and add multiple disks as additional data volumes from the edit host page.
 
 . Go to the *Hosts* page.
-. On the node you want to modify, click *⋮ > Edit Config*.
+. On the node you want to modify, click *⋮ -> Edit Config*.
 +
 image::host/multidisk-mgmt-01.png[Edit Config]
 
@@ -173,7 +173,7 @@ image::host/multidisk-mgmt-02.png[Add Disks]
 +
 [CAUTION]
 ====
-As of Harvester v1.0.2, we no longer support adding partitions as additional disks. If you want to add it as an additional disk, be sure to delete all partitions first (e.g., using `fdisk`).
+{harvester-product-name} does not support adding partitions as additional disks. If you want to add it as an additional disk, be sure to delete all partitions first (e.g., using `fdisk`).
 ====
 
 . Select a provisioner for the disk.
@@ -202,13 +202,13 @@ image::host/multidisk-mgmt-07.png[Disk tag 02]
 
 [NOTE]
 ====
-In order for Harvester to identify the disks, each disk needs to have a unique https://en.wikipedia.org/wiki/World_Wide_Name[WWN]. Otherwise, Harvester will refuse to add the disk.
-If your disk does not have a WWN, you can format it with the `EXT4` filesystem to help Harvester recognize the disk.
+In order for {harvester-product-name} to identify the disks, each disk needs to have a unique https://en.wikipedia.org/wiki/World_Wide_Name[WWN]. Otherwise, {harvester-product-name} will refuse to add the disk.
+If your disk does not have a WWN, you can format it with the `EXT4` filesystem to help {harvester-product-name} recognize the disk.
 ====
 +
 [NOTE]
 ====
-If you are testing Harvester in a QEMU environment, you'll need to use QEMU v6.0 or later. Previous versions of QEMU will always generate the same WWN for NVMe disks emulation. This will cause Harvester to not add the additional disks, as explained above. However, you can still add a virtual disk with the SCSI controller. The WWN information could be added manually along with the disk attach operation. For more details, please refer to the https://github.com/harvester/vagrant-rancherd/blob/2782981b6017754d016f5b72d630dff4895f7ad6/scripts/attach-disk.sh#L75[script].
+If you are testing {harvester-product-name} in a QEMU environment, you'll need to use QEMU v6.0 or later. Previous versions of QEMU will always generate the same WWN for NVMe disks emulation. This will cause {harvester-product-name} to not add the additional disks, as explained above. However, you can still add a virtual disk with the SCSI controller. The WWN information could be added manually along with the disk attach operation. For more details, please refer to the https://github.com/harvester/vagrant-rancherd/blob/2782981b6017754d016f5b72d630dff4895f7ad6/scripts/attach-disk.sh#L75[script].
 ====
 
 === Storage Tags
@@ -219,7 +219,7 @@ This feature supports both disks and nodes.
 
 ==== Setup
 
-The tags can be set up through the Harvester UI on the host page:
+The tags can be set up through the {harvester-product-name} UI on the host page:
 
 . Click `Hosts` \-> `Edit Config` \-> `Storage`
 . Click `Add Host/Disk Tags` to start typing and hit enter to add new tags.
@@ -242,7 +242,7 @@ Before removing a disk, you must first evict Longhorn replicas on the disk.
 The replica data would be rebuilt to another disk automatically to keep the high availability.
 ====
 
-==== Identify the disk to remove (Harvester dashboard)
+==== Identify the disk to remove
 
 . Go to the *Hosts* page.
 . On the node containing the disk, select the node name and go to the *Storage* tab.
@@ -273,10 +273,10 @@ image::host/remove-disks-longhorn-nodes-evict-disk.png[Evict disk]
 +
 image::host/remove-disks-longhorn-wait-replicas.png[Wait replicas]
 
-==== Remove the disk (Harvester dashboard)
+==== Remove the disk
 
 . Go to the *Hosts* page.
-. On the node containing the disk, select *⋮ > Edit Config*.
+. On the node containing the disk, select *⋮ -> Edit Config*.
 . Go to the *Storage* tab and select *x*  to remove the disk.
 +
 image::host/remove-disks-harvester-remove.png[Remove disk]
@@ -285,7 +285,7 @@ image::host/remove-disks-harvester-remove.png[Remove disk]
 
 == Topology Spread Constraints
 
-https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#node-labels[Node labels] are used to identify the topology domains that each node is in. You can configure labels such as https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] on the Harvester UI.
+https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/#node-labels[Node labels] are used to identify the topology domains that each node is in. You can configure labels such as https://kubernetes.io/docs/reference/labels-annotations-taints/#topologykubernetesiozone[`topology.kubernetes.io/zone`] on the {harvester-product-name} UI.
 
 . Go to *Hosts*.
 +
@@ -304,14 +304,14 @@ Ksmtuned is a KSM automation tool deployed as a DaemonSet to run Ksmtuned on eac
 === Quick Run
 
 . Go to the *Hosts* page.
-. On the node you want to modify, click *⋮ > Edit Config*.
+. On the node you want to modify, click *⋮ -> Edit Config*.
 . Select the *Ksmtuned* tab and select *Run* in *Run Strategy*.
 . (Optional) You can modify *Threshold Coefficient* as needed.
 +
 image::host/edit-ksmtuned.png[Edit Ksmtuned]
 
 . Click *Save* to update.
-. Wait for about 1-2 minutes and you can check its *Statistics* by clicking **Your Node > Ksmtuned tab**.
+. Wait for about 1-2 minutes and you can check its *Statistics* by clicking *Your Node -> Ksmtuned tab*.
 +
 image::host/view-ksmtuned-statistics.png[View Ksmtuned Statistics]
 
@@ -393,11 +393,9 @@ KSM will stop when the available memory is above the *Threshold Coefficient*. If
 
 == NTP Configuration
 
-Time synchronization is an important aspect of distributed cluster architecture. Because of this, Harvester now provides a simpler way for configuring NTP settings.
+Time synchronization is an important aspect of distributed cluster architecture. Because of this, {harvester-product-name} provides a simpler way for configuring NTP settings.
 
-In previous Harvester versions, NTP settings were mainly configurable xref:../installation-setup/config/configuration-file.adoc#_osntp_servers[during the installation process]. To modify the settings, you needed to manually update the configuration file on each node.
-
-Beginning with version v1.2.0, Harvester is supporting NTP configuration on the Harvester UI Settings screen (*Advanced* > *Settings*). You can configure NTP settings for the entire Harvester cluster at any time, and the settings are applied to all nodes in the cluster.
+{harvester-product-name} supports NTP configuration on the {harvester-product-name} UI Settings screen (*Advanced* > *Settings*). You can configure NTP settings for the entire {harvester-product-name} cluster at any time, and the settings are applied to all nodes in the cluster.
 
 image::host/harvester-ntp-settings.png[]
 
@@ -417,26 +415,26 @@ You can check the settings in the `node.harvesterhci.io/ntp-service` annotation 
 ====
 
 
-. Do not modify the NTP configuration file on each node. Harvester will automatically sync the settings that you configured on the Harvester UI to the nodes.
-. If you upgraded Harvester from an earlier version, the *ntp-servers* list on the Settings screen will be empty (see screenshot). You must manually configure the NTP settings because Harvester is unaware of the previous settings and is unable to detect conflicts.
+. Do not modify the NTP configuration file on each node. {harvester-product-name} will automatically sync the settings that you configured on the {harvester-product-name} UI to the nodes.
+. If you upgraded {harvester-product-name} from an earlier version, the *ntp-servers* list on the Settings screen will be empty (see screenshot). You must manually configure the NTP settings because {harvester-product-name} is unaware of the previous settings and is unable to detect conflicts.
 ====
 
 image::host/harvester-ntp-settings-empty.png[]
 
 == Cloud-Native Node Configuration
 
-You may need to customize one or more nodes after installing Harvester. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
+You may need to customize one or more nodes after installing {harvester-product-name}. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
 
-In Harvester v1.3.0, these customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
+These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
 
 [WARNING]
 ====
-Misconfigurations might compromise the ability of a Harvester node to boot up, or even damage the overall stability of the cluster. You can prevent such issues by reading the Elemental toolkit documentation to learn how to https://rancher.github.io/elemental-toolkit/docs/customizing/[correctly customize Elemental].
+Misconfigurations might compromise the ability of a {harvester-product-name} node to boot up, or even damage the overall stability of the cluster. You can prevent such issues by reading the Elemental toolkit documentation to learn how to https://rancher.github.io/elemental-toolkit/docs/customizing/[correctly customize Elemental].
 ====
 
 === Creating a CloudInit Resource
 
-Harvester node customization is bounded only by your creativity and by what the Elemental toolkit markup can syntactically express. The documentation, therefore, cannot provide an exhaustive list of possible customizations and use cases.
+{harvester-product-name} node customization is bounded only by your creativity and by what the Elemental toolkit markup can syntactically express. The documentation, therefore, cannot provide an exhaustive list of possible customizations and use cases.
 
 *Example: You want to add an SSH authorized key for the default `rancher` user on all nodes.*
 
@@ -469,7 +467,7 @@ Apply this example using the command `kubectl apply -f ssh_access.yaml`.
 
 [TIP]
 ====
-Reboot the relevant Harvester nodes so that the Elemental toolkit executor can apply the new configuration at boot.
+Reboot the relevant {harvester-product-name} nodes so that the Elemental toolkit executor can apply the new configuration at boot.
 ====
 
 ==== CloudInit Resource Spec
@@ -529,7 +527,7 @@ You can use the command `kubectl edit` to update a CloudInit resource. However, 
 
 === Deleting a CloudInit Resource
 
-You can use the command `kubectl delete` to remove a CloudInit resource from the Harvester cluster.
+You can use the command `kubectl delete` to remove a CloudInit resource from the {harvester-product-name} cluster.
 
 [,console]
 ----
@@ -538,9 +536,9 @@ You can use the command `kubectl delete` to remove a CloudInit resource from the
 
 [NOTE]
 ====
-Harvester is unable to "roll back" previously described customizations because the CloudInit resource can describe anything that can be expressed as an Elemental toolkit customization, including arbitrary shell commands.
+{harvester-product-name} is unable to "roll back" previously described customizations because the CloudInit resource can describe anything that can be expressed as an Elemental toolkit customization, including arbitrary shell commands.
 
-In the <<Creating a CloudInit Resource>> example, the YAML file contains the `authorized_keys` stanza. This is an append-only action in the Elemental toolkit. When the resource is changed or deleted, the `authorized_keys` file in Rancher will still contain the old public key.
+In the <<Creating a CloudInit Resource>> example, the YAML file contains the `authorized_keys` stanza. This is an append-only action in the Elemental toolkit. When the resource is changed or deleted, the `authorized_keys` file in {rancher-product-name} will still contain the old public key.
 
 *You are responsible for amending or creating a CloudInit resource that rolls the changes back (if necessary) before you reboot the node.*
 ====
@@ -584,7 +582,7 @@ This pod is part of a daemonset, so it may be worth checking the pod that is run
 
 You can configure the URL of the console for remote server management. This console is particularly useful in environments where physical access is limited.
 
-. On the Harvester UI, go to *Hosts*.
+. On the {harvester-product-name} UI, go to *Hosts*.
 +
 . Locate the target host, and then select *⋮ -> Edit Config*.
 +

--- a/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,6 +1,6 @@
 = vGPU Support
 
-SUSE® Virtualization is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
+{harvester-product-name} is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
 
 To determine if your GPU supports SR-IOV, check the device documentation. For more information about creating an NVIDIA vGPU that supports SR-IOV, see the https://docs.nvidia.com/grid/15.0/grid-vgpu-user-guide/index.html#creating-sriov-vgpu-device-red-hat-el-kvm[NVIDIA documentation].
 
@@ -8,20 +8,20 @@ You must enable the xref:../add-ons/nvidia-driver-toolkit.adoc[nvidia-driver-too
 
 == Usage
 
-. On the UI, go to *Advanced* > *SR-IOV GPU Devices* and verify the following:
+. On the UI, go to *Advanced -> SR-IOV GPU Devices* and verify the following:
 +
 * GPU devices have been scanned.
 * An associated `sriovgpudevices.devices.harvesterhci.io` object has been created.
 +
 image::advanced/sriovgpudevices-disabled.png[]
 
-. Locate the device that you want to enable, and then select *:* > *Enable*.
+. Locate the device that you want to enable, and then select *⋮ -> Enable*.
 +
 image::advanced/sriovgpudevices-enabled.png[]
 
 . Go to the *vGPU Devices* screen and check the associated `vgpudevices.devices.harvesterhci.io` objects.
 +
-Allow some time for the pcidevices-controller to scan the vGPU devices and for the Harvester UI to display the device information.
+Allow some time for the pcidevices-controller to scan the vGPU devices and for the {harvester-product-name} UI to display the device information.
 +
 image::advanced/vgpudevicelist.png[]
 
@@ -47,7 +47,7 @@ Once a vGPU has been assigned to a VM, it may not be possible to disable the VM 
 
 === Limitations
 
-==== Attaching multiple vGPU's:
+==== Attaching Multiple vGPUs
 
 Attaching multiple vGPUs to a VM may fail for the following reasons:
 
@@ -78,7 +78,7 @@ If you select the `NVIDIA A2-4Q` profile, you can only configure 4 vGPU devices.
 
 image::advanced/nvidia-a2-example.png[]
 
-=== Technical Deep dive
+=== Technical Deep Dive
 
 pcidevices-controller introduces the following CRDs:
 

--- a/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
@@ -1,19 +1,19 @@
 = Witness Node
 
-SUSE® Virtualization clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in SUSE® Virtualization) to ensure that a quorum is maintained.
+{harvester-product-name} clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in {harvester-product-name}) to ensure that a quorum is maintained.
 
 Some situations may require you to avoid deploying workloads and user data to management nodes. In these situations, one cluster node can be assigned the _witness_ role, which limits it to functioning as an etcd cluster member. The witness node is responsible for establishing a member quorum (a majority of nodes), which must agree on updates to the cluster state.
 
 Witness nodes do not store any data, but the https://etcd.io/docs/v3.3/op-guide/hardware/[hardware recommendations] for etcd nodes must still be considered. Using hardware with limited resources significantly affects cluster performance, as described in the article https://www.suse.com/support/kb/doc/?id=000020100[Slow etcd performance (performance testing and optimization)].
 
-SUSE® Virtualization supports clusters with two management nodes and one witness node (and optionally, one or more worker nodes). For more information about node roles, see xref:../hosts/hosts.adoc#_role_management[Role Management].
+{harvester-product-name} supports clusters with two management nodes and one witness node (and optionally, one or more worker nodes). For more information about node roles, see xref:../hosts/hosts.adoc#_role_management[Role Management].
 
 [IMPORTANT]
 ====
 A node can be assigned the _witness_ role only at the time it joins a cluster. Each cluster can have only one witness node.
 ====
 
-== Creating a SUSE® Virtualization Cluster with a Witness Node
+== Creating a {harvester-product-name} Cluster with a Witness Node
 
 You can assign the _witness_ role to a node when it joins a newly created cluster.
 
@@ -45,9 +45,9 @@ The general upgrade requirements and procedures apply to clusters with a witness
 
 == Longhorn Replicas in Clusters with a Witness Node
 
-SUSE® Virtualization uses Longhorn, a distributed block storage system, for management of block device volumes. Longhorn is provisioned to management and worker nodes but not to witness nodes, which do not store any data.
+{harvester-product-name} uses Longhorn, a distributed block storage system, for management of block device volumes. Longhorn is provisioned to management and worker nodes but not to witness nodes, which do not store any data.
 
-Longhorn creates replicas of each volume to increase availability. Replicas contain a chain of snapshots of the volume, with each snapshot storing the change from a previous snapshot. In SUSE® Virtualization, the default StorageClass `harvester-longhorn` has a replica count value of `3`.
+Longhorn creates replicas of each volume to increase availability. Replicas contain a chain of snapshots of the volume, with each snapshot storing the change from a previous snapshot. In {harvester-product-name}, the default StorageClass `harvester-longhorn` has a replica count value of `3`.
 
 == Limitations
 
@@ -70,7 +70,7 @@ image::advanced/update-replica-2.png[update-replica-count-to-2]
 
 == Known Issues
 
-=== 1. When creating a cluster with a witness node, the *Network Config: Create* screen on the Harvester UI is unable to identify any NICs that can be used with all nodes.
+=== 1. When creating a cluster with a witness node, the *Network Config: Create* screen on the {harvester-product-name} UI is unable to identify any NICs that can be used with all nodes.
 
 image::advanced/create-policy-with-all-nodes.png[create network config with all nodes]
 

--- a/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use SUSE® Virtualization in an air gapped environment. Some use cases could be where SUSE® Virtualization will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {product-name} in an air gapped environment. Some use cases could be where {product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -26,7 +26,7 @@ image::proxy-setting.png[proxy-setting]
 
 [NOTE]
 ====
-SUSE® Virtualization appends necessary addresses to user configured `no-proxy` to ensure the internal traffic works.
+{product-name} appends necessary addresses to user configured `no-proxy` to ensure the internal traffic works.
 i.e., `localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`. `harvester-system` was added into the list since v1.1.2.
 
 When the nodes in the cluster do not use a proxy to communicate with each other, the CIDR needs to be added to `http-proxy.noProxy` after the first node is installed successfully. Please refer to xref:../troubleshooting/cluster.adoc#_fail_to_deploy_a_multi_node_cluster_due_to_incorrect_http_proxy_setting[fail to deploy a multi-node cluster].
@@ -34,11 +34,11 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 == Guest Cluster Images
 
-All necessary images to install and run SUSE® Virtualization are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A SUSE® Virtualization cluster manages them independently and effectively behind the scenes.
+All necessary images to install and run {product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a SUSE® Virtualization cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
 
-If the *Cloud Provider* option is configured to SUSE® Virtualization in a guest K8s cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 

--- a/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use {product-name} in an air gapped environment. Some use cases could be where {product-name} will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {harvester-product-name} in an air gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -26,7 +26,7 @@ image::proxy-setting.png[proxy-setting]
 
 [NOTE]
 ====
-{product-name} appends necessary addresses to user configured `no-proxy` to ensure the internal traffic works.
+{harvester-product-name} appends necessary addresses to user configured `no-proxy` to ensure the internal traffic works.
 i.e., `localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`. `harvester-system` was added into the list since v1.1.2.
 
 When the nodes in the cluster do not use a proxy to communicate with each other, the CIDR needs to be added to `http-proxy.noProxy` after the first node is installed successfully. Please refer to xref:../troubleshooting/cluster.adoc#_fail_to_deploy_a_multi_node_cluster_due_to_incorrect_http_proxy_setting[fail to deploy a multi-node cluster].
@@ -34,11 +34,11 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 == Guest Cluster Images
 
-All necessary images to install and run {product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {product-name} cluster manages them independently and effectively behind the scenes.
+All necessary images to install and run {harvester-product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {harvester-product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
 
-If the *Cloud Provider* option is configured to {product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 

--- a/versions/v1.4/modules/en/pages/installation-setup/authentication.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/authentication.adoc
@@ -6,5 +6,5 @@ image::install/first-time-login.png[auth]
 
 [NOTE]
 ====
-In the single cluster mode, only one default `admin` user is provided. Check out the xref:../integrations/rancher/rancher-integration.adoc[Rancher Integration] for multi-tenant management.
+In the single cluster mode, only one default `admin` user is provided. Check out xref:../integrations/rancher/rancher-integration.adoc[Rancher Integration] for multi-tenant management.
 ====

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,10 +1,10 @@
 = CloudInit CRD
 
-You can use the `CloudInit` CRD to configure {product-name} operating system settings either manually or using GitOps solutions.
+You can use the `CloudInit` CRD to configure {harvester-product-name} operating system settings either manually or using GitOps solutions.
 
 == Background
 
-The {product-name} operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
+The {harvester-product-name} operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
 
 Settings configured during the installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
 
@@ -21,7 +21,7 @@ The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account 
 
 == Getting Started
 
-The following example adds SSH keys to all nodes in an existing {product-name} cluster.
+The following example adds SSH keys to all nodes in an existing {harvester-product-name} cluster.
 
 [,yaml]
 ----
@@ -49,11 +49,11 @@ The `spec` field contains the following:
 * `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. You can use the `harvesterhci.io/managed: "true"` label to select all nodes.
 * `filename (required)`: Name of the file in `/oem`. cloud-init files in `/oem` are applied in alphabetical order. This can be used to ensure that file changes are applied during booting.
 * `content (required)`: Inline content for the Elemental cloud-init resource that is written to target nodes.
-* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The {product-name} controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
+* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The {harvester-product-name} controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
 
 Once the object is created, you can log in to the target nodes to verify the results.
 
-In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the {product-name} controllers.
+In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the {harvester-product-name} controllers.
 
 ----
 harvester-qhgd4:/oem # more 99-my-ssh-keys.yaml

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -15,7 +15,7 @@ In addition, the `CloudInit` CRD is persisted and synchronized with the underlyi
 [NOTE]
 ====
 
-The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account has the permissions required to access the resource (via Rancher role-based access control).
+The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account has the permissions required to access the resource (via {rancher-product-name} role-based access control).
 ====
 
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,10 +1,10 @@
 = CloudInit CRD
 
-You can use the `CloudInit` CRD to configure SUSE® Virtualization operating system settings either manually or using GitOps solutions.
+You can use the `CloudInit` CRD to configure {product-name} operating system settings either manually or using GitOps solutions.
 
 == Background
 
-The SUSE® Virtualization operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
+The {product-name} operating system uses the https://github.com/rancher/elemental-toolkit[elemental-toolkit], which has a unique form of https://rancher.github.io/elemental-toolkit/docs/reference/cloud_init/[cloud-init support].
 
 Settings configured during the installation process are written to the `elemental` cloud-init file in the `/oem` directory. Because the operating system is immutable, the cloud-init file ensures that node-specific settings are applied on each reboot.
 
@@ -21,7 +21,7 @@ The `CloudInit` CRD is a cluster-scoped resource. Ensure that your user account 
 
 == Getting Started
 
-The following example adds SSH keys to all nodes in an existing SUSE® Virtualization cluster.
+The following example adds SSH keys to all nodes in an existing {product-name} cluster.
 
 [,yaml]
 ----
@@ -49,11 +49,11 @@ The `spec` field contains the following:
 * `matchSelector (required)`: Label selector used to identify the nodes that the change must be applied to. You can use the `harvesterhci.io/managed: "true"` label to select all nodes.
 * `filename (required)`: Name of the file in `/oem`. cloud-init files in `/oem` are applied in alphabetical order. This can be used to ensure that file changes are applied during booting.
 * `content (required)`: Inline content for the Elemental cloud-init resource that is written to target nodes.
-* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The SUSE® Virtualization controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
+* `paused (optional)`: Used to pause `CloudInit` CRD reconciliation. The {product-name} controllers monitor Elemental cloud-init files that are managed by the `CloudInit` CRD. Direct changes made to these files are immediately reconciled back to the defined state unless the CRD is paused.
 
 Once the object is created, you can log in to the target nodes to verify the results.
 
-In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the SUSE® Virtualization controllers.
+In the following example, a file named `/oem/99-my-ssh-keys.yaml` is created and subsequently monitored by the {product-name} controllers.
 
 ----
 harvester-qhgd4:/oem # more 99-my-ssh-keys.yaml

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -20,7 +20,7 @@ os:
     path: /etc/test.txt
     permissions: '0755'
   hostname: myhost
-  modules:SUSE® Virtualization
+  modules:
     - kvm
     - nvme
   sysctls:
@@ -115,14 +115,14 @@ Make sure that your custom configuration always has the correct scheme version.
 
 ==== Definition
 
-`server_url` is the URL of the SUSE® Virtualization cluster, which is used for the new `node` to join the cluster.
+`server_url` is the URL of the {product-name} cluster, which is used for the new `node` to join the cluster.
 
 This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `+https://cluster-VIP:443+`.
 
 [NOTE]
 ====
 
-To ensure a high availability (HA) SUSE® Virtualization cluster, please use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
+To ensure a high availability (HA) {product-name} cluster, please use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
 ====
 
 
@@ -245,7 +245,7 @@ You can add additional software packages with `after_install_chroot_commands`. T
 
 ==== Example
 
-Refer to the following example config for installing an RPM package in SUSE® Virtualization:
+Refer to the following example config for installing an RPM package in {product-name}:
 
 [,yaml]
 ----
@@ -269,7 +269,7 @@ os:
 [NOTE]
 ====
 
-Upgrading SUSE® Virtualization causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
+Upgrading {product-name} causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
 ====
 
 
@@ -426,7 +426,7 @@ os:
 ====
 
 This example sets the HTTP(S) proxy for *foundational OS components*.
-To set up an HTTP(S) proxy for SUSE® Virtualization components such as fetching external images and backup to S3 services,
+To set up an HTTP(S) proxy for {product-name} components such as fetching external images and backup to S3 services,
 see link:../advanced/settings.adoc#http-proxy[Settings/http-proxy].
 ====
 
@@ -452,7 +452,7 @@ os:
 
 ==== Definition
 
-Subsystem used to configure the OpenSSH Daemon (sshd). SUSE® Virtualization currently only supports `sftp`.
+Subsystem used to configure the OpenSSH Daemon (sshd). {product-name} currently only supports `sftp`.
 
 ==== Example
 
@@ -469,7 +469,7 @@ os:
 
 === `install.addons`
 
-*Definition*: Setting that defines the default add-on status. SUSE® Virtualization add-ons are disabled by default.
+*Definition*: Setting that defines the default add-on status. {product-name} add-ons are disabled by default.
 
 *Supported values*:
 
@@ -519,7 +519,7 @@ install:
 
 === `install.device`
 
-*Definition*: Device on which the SUSE® Virtualization operating system is installed.
+*Definition*: Device on which the {product-name} operating system is installed.
 
 When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` to specify the storage device if the server contains multiple physical volumes.
 
@@ -533,9 +533,9 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 
 *Definition*: Setting that forces usage of MBR partitioning on BIOS systems.
 
-SUSE® Virtualization uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
+{product-name} uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
 
-If you specify the same storage device for both `install.device` and `install.data_disk`, SUSE® Virtualization creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
+If you specify the same storage device for both `install.device` and `install.data_disk`, {product-name} creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
 
 *Example*:
 
@@ -592,13 +592,13 @@ install:
 
 === `install.iso_url`
 
-*Definition*: URL of ISO image to be downloaded and used to install SUSE® Virtualization when booting from the kernel or vmlinuz.
+*Definition*: URL of ISO image to be downloaded and used to install {product-name} when booting from the kernel or vmlinuz.
 
 === `install.management_interface`
 
 *Definition*: Network interfaces for the host machine.
 
-SUSE® Virtualization uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
+{product-name} uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
 
 *Fields*:
 
@@ -641,8 +641,8 @@ install:
 
 *Supported values*:
 
-* `create`: Create a new SUSE® Virtualization cluster.
-* `join`: Join an existing SUSE® Virtualization cluster. You must specify the `server_url`.
+* `create`: Create a new {product-name} cluster.
+* `join`: Join an existing {product-name} cluster. You must specify the `server_url`.
 
 *Example*:
 
@@ -678,14 +678,14 @@ install:
 
 === `install.rawdiskimagepath`
 
-*Definition*: Setting that forces the installer to only install the SUSE® Virtualization hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
+*Definition*: Setting that forces the installer to only install the {product-name} hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
 
 === `install.role`
 
 *Definition*: Role assigned to a node at the time of installation. When unspecified, the `default` role is assigned.
 
 * `default`: Allows a node to function as a management node or a worker node.
-* `management`: Allows a node to be prioritized when SUSE® Virtualization promotes nodes to management nodes.
+* `management`: Allows a node to be prioritized when {product-name} promotes nodes to management nodes.
 * `worker`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 * `witness`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
 
@@ -727,7 +727,7 @@ install:
 
 === `install.vip`
 
-*Definition*: VIP of the SUSE® Virtualization management endpoint.
+*Definition*: VIP of the {product-name} management endpoint.
 
 After installation, you can access the UI at `https://<VIP>`.
 
@@ -779,7 +779,7 @@ The installer sends HTTP requests to the specified URL. Multiple requests can be
  ** `FAILED`: The installation was unsuccessful.
 * `method`: HTTP method
 * `url`: URL to which HTTP requests are sent
-* `insecure`: When set to `true`, SUSE® Virtualization does not verify the server's certificate. The default value is `false`.
+* `insecure`: When set to `true`, {product-name} does not verify the server's certificate. The default value is `false`.
 * `basicAuth`: When set to `true`, the "Basic" HTTP authentication scheme is used.
 * `headers`: When set to `true`, custom headers are included in the HTTP requests. Headers such as `Content-Length` are automatically included.
 * `payload`*: When set to `true`, payload data is sent with the HTTP requests. You may need to set the correct Content-Type header in the `headers` field to ensure that the server accepts the request.
@@ -821,7 +821,7 @@ install:
 
 *Definition*: Setting that determines if images are pulled from the internet after installation.
 
-The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, SUSE® Virtualization does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
+The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, {product-name} does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
 
 '''
 
@@ -837,8 +837,8 @@ See the xref:./settings.adoc[Settings] page for additional information and the l
 [NOTE]
 ====
 
-Overwriting system settings only works when SUSE® Virtualization is installed in "create" mode.
-If you install SUSE® Virtualization in "join" mode, this setting is ignored.
+Overwriting system settings only works when {product-name} is installed in "create" mode.
+If you install {product-name} in "join" mode, this setting is ignored.
 Installing in "join" mode will adopt the system settings from the existing system.
 ====
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -115,14 +115,14 @@ Make sure that your custom configuration always has the correct scheme version.
 
 ==== Definition
 
-`server_url` is the URL of the {product-name} cluster, which is used for the new `node` to join the cluster.
+`server_url` is the URL of the {harvester-product-name} cluster, which is used for the new `node` to join the cluster.
 
 This configuration is mandatory when the installation is in `JOIN` mode. The default format of `server_url` is `+https://cluster-VIP:443+`.
 
 [NOTE]
 ====
 
-To ensure a high availability (HA) {product-name} cluster, please use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
+To ensure a high availability (HA) {harvester-product-name} cluster, please use either the cluster <<`install.vip`,VIP>> or a domain name in `server_url`.
 ====
 
 
@@ -245,7 +245,7 @@ You can add additional software packages with `after_install_chroot_commands`. T
 
 ==== Example
 
-Refer to the following example config for installing an RPM package in {product-name}:
+Refer to the following example config for installing an RPM package in {harvester-product-name}:
 
 [,yaml]
 ----
@@ -269,7 +269,7 @@ os:
 [NOTE]
 ====
 
-Upgrading {product-name} causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
+Upgrading {harvester-product-name} causes the changes to the OS in the `after-install-chroot` stage to be lost. You must also configure the `after-upgrade-chroot` to make your changes persistent across an upgrade. Refer to https://rancher.github.io/elemental-toolkit/docs/customizing/runtime_persistent_changes/[Runtime persistent changes] before upgrading.
 ====
 
 
@@ -426,7 +426,7 @@ os:
 ====
 
 This example sets the HTTP(S) proxy for *foundational OS components*.
-To set up an HTTP(S) proxy for {product-name} components such as fetching external images and backup to S3 services,
+To set up an HTTP(S) proxy for {harvester-product-name} components such as fetching external images and backup to S3 services,
 see link:../advanced/settings.adoc#http-proxy[Settings/http-proxy].
 ====
 
@@ -452,7 +452,7 @@ os:
 
 ==== Definition
 
-Subsystem used to configure the OpenSSH Daemon (sshd). {product-name} currently only supports `sftp`.
+Subsystem used to configure the OpenSSH Daemon (sshd). {harvester-product-name} currently only supports `sftp`.
 
 ==== Example
 
@@ -469,7 +469,7 @@ os:
 
 === `install.addons`
 
-*Definition*: Setting that defines the default add-on status. {product-name} add-ons are disabled by default.
+*Definition*: Setting that defines the default add-on status. {harvester-product-name} add-ons are disabled by default.
 
 *Supported values*:
 
@@ -519,7 +519,7 @@ install:
 
 === `install.device`
 
-*Definition*: Device on which the {product-name} operating system is installed.
+*Definition*: Device on which the {harvester-product-name} operating system is installed.
 
 When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` to specify the storage device if the server contains multiple physical volumes.
 
@@ -533,9 +533,9 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 
 *Definition*: Setting that forces usage of MBR partitioning on BIOS systems.
 
-{product-name} uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
+{harvester-product-name} uses GPT partitioning on UEFI and BIOS systems by default. Compatibility issues may require you to use MBR partitioning instead.
 
-If you specify the same storage device for both `install.device` and `install.data_disk`, {product-name} creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
+If you specify the same storage device for both `install.device` and `install.data_disk`, {harvester-product-name} creates an additional partition for storing VM data. This additional partition is not created when you force usage of MBR partitioning. Instead, VM data is stored in a partition that stores OS data.
 
 *Example*:
 
@@ -592,13 +592,13 @@ install:
 
 === `install.iso_url`
 
-*Definition*: URL of ISO image to be downloaded and used to install {product-name} when booting from the kernel or vmlinuz.
+*Definition*: URL of ISO image to be downloaded and used to install {harvester-product-name} when booting from the kernel or vmlinuz.
 
 === `install.management_interface`
 
 *Definition*: Network interfaces for the host machine.
 
-{product-name} uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
+{harvester-product-name} uses the https://www.freedesktop.org/software/systemd/man/systemd.net-naming-scheme.html[systemd net naming scheme]. Ensure that the interface name is present on the target machine before installation.
 
 *Fields*:
 
@@ -641,8 +641,8 @@ install:
 
 *Supported values*:
 
-* `create`: Create a new {product-name} cluster.
-* `join`: Join an existing {product-name} cluster. You must specify the `server_url`.
+* `create`: Create a new {harvester-product-name} cluster.
+* `join`: Join an existing {harvester-product-name} cluster. You must specify the `server_url`.
 
 *Example*:
 
@@ -678,14 +678,14 @@ install:
 
 === `install.rawdiskimagepath`
 
-*Definition*: Setting that forces the installer to only install the {product-name} hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
+*Definition*: Setting that forces the installer to only install the {harvester-product-name} hypervisor (without any configuration). You must enable `harvester.install.automatic` to use this setting.
 
 === `install.role`
 
 *Definition*: Role assigned to a node at the time of installation. When unspecified, the `default` role is assigned.
 
 * `default`: Allows a node to function as a management node or a worker node.
-* `management`: Allows a node to be prioritized when {product-name} promotes nodes to management nodes.
+* `management`: Allows a node to be prioritized when {harvester-product-name} promotes nodes to management nodes.
 * `worker`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 * `witness`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
 
@@ -727,7 +727,7 @@ install:
 
 === `install.vip`
 
-*Definition*: VIP of the {product-name} management endpoint.
+*Definition*: VIP of the {harvester-product-name} management endpoint.
 
 After installation, you can access the UI at `https://<VIP>`.
 
@@ -779,7 +779,7 @@ The installer sends HTTP requests to the specified URL. Multiple requests can be
  ** `FAILED`: The installation was unsuccessful.
 * `method`: HTTP method
 * `url`: URL to which HTTP requests are sent
-* `insecure`: When set to `true`, {product-name} does not verify the server's certificate. The default value is `false`.
+* `insecure`: When set to `true`, {harvester-product-name} does not verify the server's certificate. The default value is `false`.
 * `basicAuth`: When set to `true`, the "Basic" HTTP authentication scheme is used.
 * `headers`: When set to `true`, custom headers are included in the HTTP requests. Headers such as `Content-Length` are automatically included.
 * `payload`*: When set to `true`, payload data is sent with the HTTP requests. You may need to set the correct Content-Type header in the `headers` field to ensure that the server accepts the request.
@@ -821,7 +821,7 @@ install:
 
 *Definition*: Setting that determines if images are pulled from the internet after installation.
 
-The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, {product-name} does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
+The value of this field is typically derived from the kernel parameter `harvester.install.with_net_images`. When the value is `true`, {harvester-product-name} does not preload images packaged in the installation medium, and instead pulls images from the internet when necessary.
 
 '''
 
@@ -837,8 +837,8 @@ See the xref:./settings.adoc[Settings] page for additional information and the l
 [NOTE]
 ====
 
-Overwriting system settings only works when {product-name} is installed in "create" mode.
-If you install {product-name} in "join" mode, this setting is ignored.
+Overwriting system settings only works when {harvester-product-name} is installed in "create" mode.
+If you install {harvester-product-name} in "join" mode, this setting is ignored.
 Installing in "join" mode will adopt the system settings from the existing system.
 ====
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -52,7 +52,7 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). The certificate is automatically replaced before the specified period ends.
 
-For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[Rancher] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
+For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[{rancher-product-name}] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
 
 *Default value*: `{"enable":false,"expiringInHours":240}`
 
@@ -88,14 +88,14 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 === `cluster-registration-url`
 
-*Definition*: URL used to import the {harvester-product-name} cluster into Rancher for multi-cluster management.
+*Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register {harvester-product-name} to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version] in the Rancher documentation.
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
 * {harvester-product-name} containerd-registry: You can configure a xref:_containerd_registry[private registry for the cluster].
-* Docker Hub (docker.io): This is the default option when you do not configure a private registry in Rancher.
+* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-product-name}.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
 
@@ -199,7 +199,7 @@ You must specify key information in the `noProxy` field if you configured the fo
 
 | `cluster-registration-url`
 | Host of `cluster-registration-url`
-| The host information allows you to access the cluster from Rancher.
+| The host information allows you to access the cluster from {rancher-product-name}.
 |===
 
 {harvester-product-name} appends necessary addresses to user-specified `noProxy` values (for example,`localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`). This ensures that internal traffic flows as expected.
@@ -784,7 +784,7 @@ Scenario 2: The value of `ui-index` points to a page that is unavailable or non-
 
 === `ui-plugin-index`
 
-*Definition*: JavaScript address for the plugin (when accessing {harvester-product-name} from Rancher).
+*Definition*: JavaScript address for the plugin (when accessing {harvester-product-name} from {rancher-product-name}).
 
 *Default value*: `+https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js+`
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -6,7 +6,7 @@ The following is a list of advanced settings that you can use. You can modify th
 
 === `additional-ca`
 
-*Definition*: Additional trusted CA certificates that enable SUSE® Virtualization to access external services.
+*Definition*: Additional trusted CA certificates that enable {product-name} to access external services.
 
 [CAUTION]
 ====
@@ -25,7 +25,7 @@ SOME-CA-CERTIFICATES
 
 === `auto-disk-provision-paths` [Experimental]
 
-*Definition*: Setting that allows SUSE® Virtualization to automatically add disks that match the specified glob pattern as VM storage.
+*Definition*: Setting that allows {product-name} to automatically add disks that match the specified glob pattern as VM storage.
 
 This setting only adds formatted disks that are mounted to the system. When specifying multiple patterns, separate values using commas.
 
@@ -88,13 +88,13 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 === `cluster-registration-url`
 
-*Definition*: URL used to import the SUSE® Virtualization cluster into Rancher for multi-cluster management.
+*Definition*: URL used to import the {product-name} cluster into Rancher for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the SUSE® Virtualization ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register SUSE® Virtualization to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version] in the Rancher documentation.
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {product-name} ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register {product-name} to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version] in the Rancher documentation.
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
-* SUSE® Virtualization containerd-registry: You can configure a xref:_containerd_registry[private registry for the cluster].
+* {product-name} containerd-registry: You can configure a xref:_containerd_registry[private registry for the cluster].
 * Docker Hub (docker.io): This is the default option when you do not configure a private registry in Rancher.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
@@ -109,11 +109,11 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 === `containerd-registry`
 
-*Definition*: Configuration of a private registry created for the SUSE® Virtualization cluster.
+*Definition*: Configuration of a private registry created for the {product-name} cluster.
 
 The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/containerd_registry_configuration[Containerd Registry Configuration] in the RKE2 documentation.
 
-For security purposes, SUSE® Virtualization automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
+For security purposes, {product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
 *Example*:
 
@@ -165,9 +165,9 @@ You must configure the following information before using features related to ba
 
 === `default-vm-termination-grace-period-seconds`
 
-*Definition*: Number of seconds SUSE® Virtualization waits before forcibly shutting down a VM that was stopped using the UI.
+*Definition*: Number of seconds {product-name} waits before forcibly shutting down a VM that was stopped using the UI.
 
-SUSE® Virtualization sends a graceful shutdown signal to any VM that is stopped using the UI. If the graceful shutdown process is not completed within the specified number of seconds, SUSE® Virtualization forcibly shuts down the VM.
+{product-name} sends a graceful shutdown signal to any VM that is stopped using the UI. If the graceful shutdown process is not completed within the specified number of seconds, {product-name} forcibly shuts down the VM.
 
 *Default value*: `120`
 
@@ -202,7 +202,7 @@ You must specify key information in the `noProxy` field if you configured the fo
 | The host information allows you to access the cluster from Rancher.
 |===
 
-SUSE® Virtualization appends necessary addresses to user-specified `noProxy` values (for example,`localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`). This ensures that internal traffic flows as expected.
+{product-name} appends necessary addresses to user-specified `noProxy` values (for example,`localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`). This ensures that internal traffic flows as expected.
 
 *Example*:
 
@@ -241,7 +241,7 @@ debug
 
 *Definition*: Setting that enables and disables the Longhorn V2 Data Engine.
 
-When set to `true`, Harvester automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
+When set to `true`, {product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
 
 Changing this setting automatically restarts RKE2 on all nodes but does not affect running virtual machine workloads.
 
@@ -301,7 +301,7 @@ With the default values, it would be possible to schedule the following:
 * 1.5x the amount of physical RAM on a host
 * 2x the amount of physical storage in Longhorn
 
-A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), SUSE® Virtualization only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
+A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
 *Example*:
 
@@ -318,7 +318,7 @@ A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume
 
 *Definition*: URL for downloading the software required for upgrades.
 
-SUSE® Virtualization retrieves the ISO URL and checksum value from the `+${URL}/${VERSION}/version.yaml+` file that is accessible through the configured URL.
+{product-name} retrieves the ISO URL and checksum value from the `+${URL}/${VERSION}/version.yaml+` file that is accessible through the configured URL.
 
 *Default value*: `+https://releases.rancher.com/harvester+`
 
@@ -337,7 +337,7 @@ spec:
 
 === `server-version`
 
-*Definition*: Version of SUSE® Virtualization that is installed on nodes.
+*Definition*: Version of {product-name} that is installed on nodes.
 
 *Example*:
 
@@ -386,7 +386,7 @@ If you misconfigure this setting and are unable to access the UI and API, see xr
 
 For more information about the supported options, see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-protocols[`ssl-protocols`] and https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers[`ssl-ciphers`] in the Ingress-Nginx Controller documentation.
 
-If you do not specify any values, SUSE® Virtualization uses `TLSv1.2` and `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
+If you do not specify any values, {product-name} uses `TLSv1.2` and `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
 
 *Example*:
 
@@ -427,7 +427,7 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 
 *Definition*: Support bundle image, with various versions available in https://hub.docker.com/r/rancher/support-bundle-kit/tags[`rancher/support-bundle-kit`].
 
-*Default value*: `support-bundle-kit` image that is packed into the Harvester ISO and is specific to each Harvester release.
+*Default value*: `support-bundle-kit` image that is packed into the {product-name} ISO and is specific to each {product-name} release.
 
 *Supported options and values*:
 
@@ -465,7 +465,7 @@ metadata:
 status: {}
 ```
 
-After some time, a newer image tag (`v0.0.36`) is specified in the `value` field using the Harvester UI.
+After some time, a newer image tag (`v0.0.36`) is specified in the `value` field using the UI.
 
 image::advanced/support-bundle-image-set-customized-value.png[]
 
@@ -513,7 +513,7 @@ metadata:
 status: {}
 ```
 
-The *Use the default value* button on the Harvester UI can be used to copy the contents of the `default` field to the `value` field.
+The *Use the default value* button on the UI can be used to copy the contents of the `default` field to the `value` field.
 
 image::advanced/support-bundle-image-set-use-default-value.png[]
 
@@ -534,17 +534,17 @@ When the cluster is upgraded in the future, the contents of the `value` field ma
 
 [NOTE]
 ====
-* The value of `tag` in the `default` field is always based on the image that is packed into the Harvester ISO. This field is automatically updated whenever the cluster is upgraded.
+* The value of `tag` in the `default` field is always based on the image that is packed into the {product-name} ISO. This field is automatically updated whenever the cluster is upgraded.
 +
-* The `default` field is used when the `value` field is not set or is left empty. Harvester checks if the default image is stored in the cluster and is up-to-date.
+* The `default` field is used when the `value` field is not set or is left empty. {product-name} checks if the default image is stored in the cluster and is up-to-date.
 +
 * Configuring this setting is not required. If you decide to specify a different image tag in the `value` field, remember that this tag may become outdated when the cluster is upgraded.
 +
 * Use the command `$ kubectl edit settings.harvesterhci.io support-bundle-image` to clear the `value` field.
 +
-* The *Use the default value* button on the Harvester UI only copies the contents of the `default` field to the `value` field. You may use this to replace an outdated image tag, but the copied tag will eventually become outdated as well (when the cluster is upgraded and the `default` field is updated).
+* The *Use the default value* button on the UI only copies the contents of the `default` field to the `value` field. You may use this to replace an outdated image tag, but the copied tag will eventually become outdated as well (when the cluster is upgraded and the `default` field is updated).
 +
-* If your cluster is in an air-gapped environment and you specified a non-default image tag in the `value` field, ensure that the image is available in the local containerd registry. Harvester is unable to xref:../../troubleshooting/operating-system.adoc#generate-a-support-bundle[generate a support bundle] if the image is not available.
+* If your cluster is in an air-gapped environment and you specified a non-default image tag in the `value` field, ensure that the image is available in the local containerd registry. {product-name} is unable to xref:../../troubleshooting/operating-system.adoc#generate-a-support-bundle[generate a support bundle] if the image is not available.
 ====
 
 === `support-bundle-namespaces`
@@ -570,9 +570,9 @@ Namespaces that you select are appended to the predefined namespaces list.
 
 === `support-bundle-timeout`
 
-*Definition*: Number of minutes SUSE® Virtualization allows for the completion of the support bundle generation process.
+*Definition*: Number of minutes {product-name} allows for the completion of the support bundle generation process.
 
-The process is considered to have failed when the data collection and file packing tasks are not completed within the configured number of minutes. SUSE® Virtualization does not continue or retry support bundle generation processes that have timed out. When the value is `0`, the timeout feature is disabled.
+The process is considered to have failed when the data collection and file packing tasks are not completed within the configured number of minutes. {product-name} does not continue or retry support bundle generation processes that have timed out. When the value is `0`, the timeout feature is disabled.
 
 *Default value*: `10`
 
@@ -580,9 +580,9 @@ The process is considered to have failed when the data collection and file packi
 
 *Versions*: v1.3.0 and later
 
-*Definition*: Number of minutes SUSE® Virtualization waits before deleting a support bundle that has been packaged but not downloaded (either deliberately or unsuccessfully) or retained.
+*Definition*: Number of minutes {product-name} waits before deleting a support bundle that has been packaged but not downloaded (either deliberately or unsuccessfully) or retained.
 
-You can specify a value greater than or equal to 0. When the value is 0, Harvester uses the default value.
+You can specify a value greater than or equal to 0. When the value is 0, {product-name} uses the default value.
 
 *Default value*: `30`
 
@@ -590,9 +590,9 @@ You can specify a value greater than or equal to 0. When the value is 0, Harvest
 
 *Versions*: v1.3.1 and later
 
-*Definition*: Number of minutes SUSE® Virtualization allows for collection of logs and configurations on the nodes for the support bundle.
+*Definition*: Number of minutes {product-name} allows for collection of logs and configurations on the nodes for the support bundle.
 
-If the collection process is not completed within the allotted time, SUSE® Virtualization still allows you to download the support bundle (without the uncollected data). You can specify a value greater than or equal to 0. When the value is 0, Harvester uses the default value.
+If the collection process is not completed within the allotted time, {product-name} still allows you to download the support bundle (without the uncollected data). You can specify a value greater than or equal to 0. When the value is 0, {product-name} uses the default value.
 
 *Default value*: `30`
 
@@ -632,7 +632,7 @@ https://your.upgrade.checker-url/v99/checkupgrade
 
 * `imagePreloadOption`: Options for the image preloading phase.
 +
-The full ISO contains the core operating system components and all required container images. SUSE® Virtualization can preload these container images to each node during installation and upgrades. When workloads are scheduled to management and worker nodes, the container images are ready to use.
+The full ISO contains the core operating system components and all required container images. {product-name} can preload these container images to each node during installation and upgrades. When workloads are scheduled to management and worker nodes, the container images are ready to use.
 +
 * `strategy`: Image preload strategy.
 +
@@ -660,10 +660,10 @@ The default value is `0`, which is equivalent to following the cluster's node co
 +
 [NOTE]
 ====
-SUSE® Virtualization deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the SUSE® Virtualization management network and the read speed of the default disk for Longhorn.
+{product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {product-name} management network and the read speed of the default disk for Longhorn.
 ====
 +
-* `restoreVM`: Option that enables SUSE® Virtualization to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, SUSE® Virtualization restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.
+* `restoreVM`: Option that enables {product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.
 
 *Example*:
 
@@ -784,7 +784,7 @@ Scenario 2: The value of `ui-index` points to a page that is unavailable or non-
 
 === `ui-plugin-index`
 
-*Definition*: JavaScript address for the plugin (when accessing SUSE® Virtualization from Rancher).
+*Definition*: JavaScript address for the plugin (when accessing {product-name} from Rancher).
 
 *Default value*: `+https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js+`
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -6,7 +6,7 @@ The following is a list of advanced settings that you can use. You can modify th
 
 === `additional-ca`
 
-*Definition*: Additional trusted CA certificates that enable {product-name} to access external services.
+*Definition*: Additional trusted CA certificates that enable {harvester-product-name} to access external services.
 
 [CAUTION]
 ====
@@ -25,7 +25,7 @@ SOME-CA-CERTIFICATES
 
 === `auto-disk-provision-paths` [Experimental]
 
-*Definition*: Setting that allows {product-name} to automatically add disks that match the specified glob pattern as VM storage.
+*Definition*: Setting that allows {harvester-product-name} to automatically add disks that match the specified glob pattern as VM storage.
 
 This setting only adds formatted disks that are mounted to the system. When specifying multiple patterns, separate values using commas.
 
@@ -88,13 +88,13 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 === `cluster-registration-url`
 
-*Definition*: URL used to import the {product-name} cluster into Rancher for multi-cluster management.
+*Definition*: URL used to import the {harvester-product-name} cluster into Rancher for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {product-name} ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register {product-name} to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version] in the Rancher documentation.
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by Rancher. The `related-version` is usually the same as the Rancher version. For example, when you register {harvester-product-name} to Rancher v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version] in the Rancher documentation.
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
-* {product-name} containerd-registry: You can configure a xref:_containerd_registry[private registry for the cluster].
+* {harvester-product-name} containerd-registry: You can configure a xref:_containerd_registry[private registry for the cluster].
 * Docker Hub (docker.io): This is the default option when you do not configure a private registry in Rancher.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
@@ -109,11 +109,11 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 === `containerd-registry`
 
-*Definition*: Configuration of a private registry created for the {product-name} cluster.
+*Definition*: Configuration of a private registry created for the {harvester-product-name} cluster.
 
 The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/containerd_registry_configuration[Containerd Registry Configuration] in the RKE2 documentation.
 
-For security purposes, {product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
+For security purposes, {harvester-product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
 *Example*:
 
@@ -165,9 +165,9 @@ You must configure the following information before using features related to ba
 
 === `default-vm-termination-grace-period-seconds`
 
-*Definition*: Number of seconds {product-name} waits before forcibly shutting down a VM that was stopped using the UI.
+*Definition*: Number of seconds {harvester-product-name} waits before forcibly shutting down a VM that was stopped using the UI.
 
-{product-name} sends a graceful shutdown signal to any VM that is stopped using the UI. If the graceful shutdown process is not completed within the specified number of seconds, {product-name} forcibly shuts down the VM.
+{harvester-product-name} sends a graceful shutdown signal to any VM that is stopped using the UI. If the graceful shutdown process is not completed within the specified number of seconds, {harvester-product-name} forcibly shuts down the VM.
 
 *Default value*: `120`
 
@@ -202,7 +202,7 @@ You must specify key information in the `noProxy` field if you configured the fo
 | The host information allows you to access the cluster from Rancher.
 |===
 
-{product-name} appends necessary addresses to user-specified `noProxy` values (for example,`localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`). This ensures that internal traffic flows as expected.
+{harvester-product-name} appends necessary addresses to user-specified `noProxy` values (for example,`localhost,127.0.0.1,0.0.0.0,10.0.0.0/8,longhorn-system,cattle-system,cattle-system.svc,harvester-system,.svc,.cluster.local`). This ensures that internal traffic flows as expected.
 
 *Example*:
 
@@ -241,7 +241,7 @@ debug
 
 *Definition*: Setting that enables and disables the Longhorn V2 Data Engine.
 
-When set to `true`, {product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
+When set to `true`, {harvester-product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
 
 Changing this setting automatically restarts RKE2 on all nodes but does not affect running virtual machine workloads.
 
@@ -301,7 +301,7 @@ With the default values, it would be possible to schedule the following:
 * 1.5x the amount of physical RAM on a host
 * 2x the amount of physical storage in Longhorn
 
-A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
+A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {harvester-product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
 *Example*:
 
@@ -318,7 +318,7 @@ A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume
 
 *Definition*: URL for downloading the software required for upgrades.
 
-{product-name} retrieves the ISO URL and checksum value from the `+${URL}/${VERSION}/version.yaml+` file that is accessible through the configured URL.
+{harvester-product-name} retrieves the ISO URL and checksum value from the `+${URL}/${VERSION}/version.yaml+` file that is accessible through the configured URL.
 
 *Default value*: `+https://releases.rancher.com/harvester+`
 
@@ -337,7 +337,7 @@ spec:
 
 === `server-version`
 
-*Definition*: Version of {product-name} that is installed on nodes.
+*Definition*: Version of {harvester-product-name} that is installed on nodes.
 
 *Example*:
 
@@ -386,7 +386,7 @@ If you misconfigure this setting and are unable to access the UI and API, see xr
 
 For more information about the supported options, see https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-protocols[`ssl-protocols`] and https://kubernetes.github.io/ingress-nginx/user-guide/nginx-configuration/configmap/#ssl-ciphers[`ssl-ciphers`] in the Ingress-Nginx Controller documentation.
 
-If you do not specify any values, {product-name} uses `TLSv1.2` and `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
+If you do not specify any values, {harvester-product-name} uses `TLSv1.2` and `ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-ECDSA-CHACHA20-POLY1305`.
 
 *Example*:
 
@@ -427,7 +427,7 @@ Specify an IP range in the IPv4 CIDR format. The number of IPs must be four time
 
 *Definition*: Support bundle image, with various versions available in https://hub.docker.com/r/rancher/support-bundle-kit/tags[`rancher/support-bundle-kit`].
 
-*Default value*: `support-bundle-kit` image that is packed into the {product-name} ISO and is specific to each {product-name} release.
+*Default value*: `support-bundle-kit` image that is packed into the {harvester-product-name} ISO and is specific to each {harvester-product-name} release.
 
 *Supported options and values*:
 
@@ -534,9 +534,9 @@ When the cluster is upgraded in the future, the contents of the `value` field ma
 
 [NOTE]
 ====
-* The value of `tag` in the `default` field is always based on the image that is packed into the {product-name} ISO. This field is automatically updated whenever the cluster is upgraded.
+* The value of `tag` in the `default` field is always based on the image that is packed into the {harvester-product-name} ISO. This field is automatically updated whenever the cluster is upgraded.
 +
-* The `default` field is used when the `value` field is not set or is left empty. {product-name} checks if the default image is stored in the cluster and is up-to-date.
+* The `default` field is used when the `value` field is not set or is left empty. {harvester-product-name} checks if the default image is stored in the cluster and is up-to-date.
 +
 * Configuring this setting is not required. If you decide to specify a different image tag in the `value` field, remember that this tag may become outdated when the cluster is upgraded.
 +
@@ -544,7 +544,7 @@ When the cluster is upgraded in the future, the contents of the `value` field ma
 +
 * The *Use the default value* button on the UI only copies the contents of the `default` field to the `value` field. You may use this to replace an outdated image tag, but the copied tag will eventually become outdated as well (when the cluster is upgraded and the `default` field is updated).
 +
-* If your cluster is in an air-gapped environment and you specified a non-default image tag in the `value` field, ensure that the image is available in the local containerd registry. {product-name} is unable to xref:../../troubleshooting/operating-system.adoc#generate-a-support-bundle[generate a support bundle] if the image is not available.
+* If your cluster is in an air-gapped environment and you specified a non-default image tag in the `value` field, ensure that the image is available in the local containerd registry. {harvester-product-name} is unable to xref:../../troubleshooting/operating-system.adoc#generate-a-support-bundle[generate a support bundle] if the image is not available.
 ====
 
 === `support-bundle-namespaces`
@@ -570,9 +570,9 @@ Namespaces that you select are appended to the predefined namespaces list.
 
 === `support-bundle-timeout`
 
-*Definition*: Number of minutes {product-name} allows for the completion of the support bundle generation process.
+*Definition*: Number of minutes {harvester-product-name} allows for the completion of the support bundle generation process.
 
-The process is considered to have failed when the data collection and file packing tasks are not completed within the configured number of minutes. {product-name} does not continue or retry support bundle generation processes that have timed out. When the value is `0`, the timeout feature is disabled.
+The process is considered to have failed when the data collection and file packing tasks are not completed within the configured number of minutes. {harvester-product-name} does not continue or retry support bundle generation processes that have timed out. When the value is `0`, the timeout feature is disabled.
 
 *Default value*: `10`
 
@@ -580,9 +580,9 @@ The process is considered to have failed when the data collection and file packi
 
 *Versions*: v1.3.0 and later
 
-*Definition*: Number of minutes {product-name} waits before deleting a support bundle that has been packaged but not downloaded (either deliberately or unsuccessfully) or retained.
+*Definition*: Number of minutes {harvester-product-name} waits before deleting a support bundle that has been packaged but not downloaded (either deliberately or unsuccessfully) or retained.
 
-You can specify a value greater than or equal to 0. When the value is 0, {product-name} uses the default value.
+You can specify a value greater than or equal to 0. When the value is 0, {harvester-product-name} uses the default value.
 
 *Default value*: `30`
 
@@ -590,9 +590,9 @@ You can specify a value greater than or equal to 0. When the value is 0, {produc
 
 *Versions*: v1.3.1 and later
 
-*Definition*: Number of minutes {product-name} allows for collection of logs and configurations on the nodes for the support bundle.
+*Definition*: Number of minutes {harvester-product-name} allows for collection of logs and configurations on the nodes for the support bundle.
 
-If the collection process is not completed within the allotted time, {product-name} still allows you to download the support bundle (without the uncollected data). You can specify a value greater than or equal to 0. When the value is 0, {product-name} uses the default value.
+If the collection process is not completed within the allotted time, {harvester-product-name} still allows you to download the support bundle (without the uncollected data). You can specify a value greater than or equal to 0. When the value is 0, {harvester-product-name} uses the default value.
 
 *Default value*: `30`
 
@@ -632,7 +632,7 @@ https://your.upgrade.checker-url/v99/checkupgrade
 
 * `imagePreloadOption`: Options for the image preloading phase.
 +
-The full ISO contains the core operating system components and all required container images. {product-name} can preload these container images to each node during installation and upgrades. When workloads are scheduled to management and worker nodes, the container images are ready to use.
+The full ISO contains the core operating system components and all required container images. {harvester-product-name} can preload these container images to each node during installation and upgrades. When workloads are scheduled to management and worker nodes, the container images are ready to use.
 +
 * `strategy`: Image preload strategy.
 +
@@ -660,10 +660,10 @@ The default value is `0`, which is equivalent to following the cluster's node co
 +
 [NOTE]
 ====
-{product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {product-name} management network and the read speed of the default disk for Longhorn.
+{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for Longhorn.
 ====
 +
-* `restoreVM`: Option that enables {product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.
+* `restoreVM`: Option that enables {harvester-product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {harvester-product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.
 
 *Example*:
 
@@ -784,7 +784,7 @@ Scenario 2: The value of `ui-index` points to a page that is unavailable or non-
 
 === `ui-plugin-index`
 
-*Definition*: JavaScript address for the plugin (when accessing {product-name} from Rancher).
+*Definition*: JavaScript address for the plugin (when accessing {harvester-product-name} from Rancher).
 
 *Default value*: `+https://releases.rancher.com/harvester-ui/plugin/harvester-latest/harvester-latest.umd.min.js+`
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,6 +1,6 @@
 = Update the Configuration After Installation
 
-The {product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
+The {harvester-product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 
 This page describes how to edit some of the most-requested configurations. To update a configuration, you must first update the runtime value in the system and then update configuration files to make the changes persistent between reboots.
 
@@ -37,9 +37,9 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 === Configuration persistence
 
-The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {product-name} now uses a newer version of Elemental, which creates the file during installation.
+The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {harvester-product-name} now uses a newer version of Elemental, which creates the file during installation.
 
-When upgrading from an earlier version, {product-name} retains the old file name (`/oem/99_custom.yaml`) to avoid confusion. You can manually rename the file to `/oem/90_custom.yaml` if necessary.
+When upgrading from an earlier version, {harvester-product-name} retains the old file name (`/oem/99_custom.yaml`) to avoid confusion. You can manually rename the file to `/oem/90_custom.yaml` if necessary.
 
 . Backup the elemental `cloud-init` file `/oem/90_custom.yaml` as follows:
 +
@@ -60,7 +60,7 @@ The following example adds a line to change the `NETCONFIG_DNS_STATIC_SERVERS` c
          - sed -i 's/^NETCONFIG_DNS_STATIC_SERVERS.*/NETCONFIG_DNS_STATIC_SERVERS="8.8.8.8 1.1.1.1"/' /etc/sysconfig/network/config
 ----
 +
-Replace the DNS server addresses and save the file. {product-name} sets up new servers after rebooting.
+Replace the DNS server addresses and save the file. {harvester-product-name} sets up new servers after rebooting.
 
 == NTP servers
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,6 +1,6 @@
 = Update the Configuration After Installation
 
-The SUSE® Virtualization operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
+The {product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 
 This page describes how to edit some of the most-requested configurations. To update a configuration, you must first update the runtime value in the system and then update configuration files to make the changes persistent between reboots.
 
@@ -37,9 +37,9 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 === Configuration persistence
 
-The persistent name of the cloud-init file is `/oem/90_custom.yaml`. SUSE® Virtualization now uses a newer version of Elemental, which creates the file during installation.
+The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {product-name} now uses a newer version of Elemental, which creates the file during installation.
 
-When upgrading from an earlier version, SUSE® Virtualization retains the old file name (`/oem/99_custom.yaml`) to avoid confusion. You can manually rename the file to `/oem/90_custom.yaml` if necessary.
+When upgrading from an earlier version, {product-name} retains the old file name (`/oem/99_custom.yaml`) to avoid confusion. You can manually rename the file to `/oem/90_custom.yaml` if necessary.
 
 . Backup the elemental `cloud-init` file `/oem/90_custom.yaml` as follows:
 +
@@ -60,7 +60,7 @@ The following example adds a line to change the `NETCONFIG_DNS_STATIC_SERVERS` c
          - sed -i 's/^NETCONFIG_DNS_STATIC_SERVERS.*/NETCONFIG_DNS_STATIC_SERVERS="8.8.8.8 1.1.1.1"/' /etc/sysconfig/network/config
 ----
 +
-Replace the DNS server addresses and save the file. SUSE® Virtualization sets up new servers after rebooting.
+Replace the DNS server addresses and save the file. {product-name} sets up new servers after rebooting.
 
 == NTP servers
 

--- a/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
@@ -2,9 +2,9 @@
 
 == Overview
 
-{product-name} can be installed on and booted from external disks. This is particularly useful in environments where hosts have NICs or HBA cards that support booting from external iSCSI devices or SAN storage arrays. Such diskless systems are common in large datacenters.
+{harvester-product-name} can be installed on and booted from external disks. This is particularly useful in environments where hosts have NICs or HBA cards that support booting from external iSCSI devices or SAN storage arrays. Such diskless systems are common in large datacenters.
 
-The following sections provide information about installing {product-name} on an external iSCSI device. The workflow for SAN arrays is similar, but a different set of kernel arguments may be needed to allow {product-name} to successfully boot from a SAN array.
+The following sections provide information about installing {harvester-product-name} on an external iSCSI device. The workflow for SAN arrays is similar, but a different set of kernel arguments may be needed to allow {harvester-product-name} to successfully boot from a SAN array.
 
 == iSCSI-Based Installation
 
@@ -33,9 +33,9 @@ Configuration tasks that you must perform include the following:
 
 See your system provider's documentation for more information about boot settings and firmware functions.
 
-=== Install {product-name}
+=== Install {harvester-product-name}
 
-You can load the {product-name} ISO using any of the standard methods. The installer should automatically detect the iSCSI device. Select this device when you are prompted to specify the installation disk.
+You can load the {harvester-product-name} ISO using any of the standard methods. The installer should automatically detect the iSCSI device. Select this device when you are prompted to specify the installation disk.
 
 The information displayed on the installer differs slightly when you select an iSCSI target.
 
@@ -66,7 +66,7 @@ os:
   additionalKernelArguments: "rd.iscsi.firmware vlan=enp4s0f0.2017:enp4s0f0 ip=10.115.48.10::10.115.55.254:255.255.248.0::enp4s0f0.2017:none"
 ----
 
-The test setup uses multiple tagged VLANs, such as VLAN 2017 (used for connecting with the iSCSI volume) and VLAN 2011 (used for the {product-name} management interface).
+The test setup uses multiple tagged VLANs, such as VLAN 2017 (used for connecting with the iSCSI volume) and VLAN 2011 (used for the {harvester-product-name} management interface).
 
 The kernel argument `vlan=enp4s0f0.2017:enp4s0f0 ip=10.115.48.10::10.115.55.254:255.255.248.0::enp4s0f0.2017:none` is necessary only if the iSCSI volume is accessible via an interface on a tagged VLAN. The arguments ensure that an additional tagged interface is created during boot and that a static address is allocated to the interface. See https://manpages.opensuse.org/Tumbleweed/dracut/dracut.cmdline.7.en.html[dracut.cmdline] for more information about configuring the kernel arguments to match your use case.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
@@ -2,9 +2,9 @@
 
 == Overview
 
-Harvester can be installed on and booted from external disks. This is particularly useful in environments where hosts have NICs or HBA cards that support booting from external iSCSI devices or SAN storage arrays. Such diskless systems are common in large datacenters.
+{product-name} can be installed on and booted from external disks. This is particularly useful in environments where hosts have NICs or HBA cards that support booting from external iSCSI devices or SAN storage arrays. Such diskless systems are common in large datacenters.
 
-The following sections provide information about installing Harvester on an external iSCSI device. The workflow for SAN arrays is similar, but a different set of kernel arguments may be needed to allow Harvester to successfully boot from a SAN array.
+The following sections provide information about installing {product-name} on an external iSCSI device. The workflow for SAN arrays is similar, but a different set of kernel arguments may be needed to allow {product-name} to successfully boot from a SAN array.
 
 == iSCSI-Based Installation
 
@@ -33,9 +33,9 @@ Configuration tasks that you must perform include the following:
 
 See your system provider's documentation for more information about boot settings and firmware functions.
 
-=== Install Harvester
+=== Install {product-name}
 
-You can load the Harvester ISO using any of the standard methods. The installer should automatically detect the iSCSI device. Select this device when you are prompted to specify the installation disk.
+You can load the {product-name} ISO using any of the standard methods. The installer should automatically detect the iSCSI device. Select this device when you are prompted to specify the installation disk.
 
 The information displayed on the installer differs slightly when you select an iSCSI target.
 
@@ -66,7 +66,7 @@ os:
   additionalKernelArguments: "rd.iscsi.firmware vlan=enp4s0f0.2017:enp4s0f0 ip=10.115.48.10::10.115.55.254:255.255.248.0::enp4s0f0.2017:none"
 ----
 
-The test setup uses multiple tagged VLANs, such as VLAN 2017 (used for connecting with the iSCSI volume) and VLAN 2011 (used for the Harvester management interface).
+The test setup uses multiple tagged VLANs, such as VLAN 2017 (used for connecting with the iSCSI volume) and VLAN 2011 (used for the {product-name} management interface).
 
 The kernel argument `vlan=enp4s0f0.2017:enp4s0f0 ip=10.115.48.10::10.115.55.254:255.255.248.0::enp4s0f0.2017:none` is necessary only if the iSCSI volume is accessible via an interface on a tagged VLAN. The arguments ensure that an additional tagged interface is created during boot and that a static address is allocated to the interface. See https://manpages.opensuse.org/Tumbleweed/dracut/dracut.cmdline.7.en.html[dracut.cmdline] for more information about configuring the kernel arguments to match your use case.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
@@ -1,6 +1,6 @@
 = Management Address
 
-SUSE® Virtualization provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
+{product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 
 [NOTE]
 ====
@@ -13,18 +13,18 @@ image::install/iso-installed.png[]
 == Requirements
 
 * The VIP and the node management interfaces must belong to the same subnet.
-* All SUSE® Virtualization node management interfaces must be on the same layer-2 network segment.
+* All {product-name} node management interfaces must be on the same layer-2 network segment.
 
 Both are required because the VIP relies on the Address Resolution Protocol (ARP), which is a layer-2 protocol.
 
-The VIP can be assigned to any SUSE® Virtualization node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the SUSE® Virtualization cluster's management IP address (the VIP).
+The VIP can be assigned to any {product-name} node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the {product-name} cluster's management IP address (the VIP).
 
 [CAUTION]
 ====
 
-If you plan to host a SUSE® Virtualization cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, SUSE® Virtualization is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
+If you plan to host a {product-name} cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, {product-name} is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
 
-Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your SUSE® Virtualization nodes (for example, if your SUSE® Virtualizationhosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
+Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your {product-name} nodes (for example, if your {product-name} hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
 ====
 
 
@@ -46,7 +46,7 @@ Example of output:
 
 == Identifying the Node the VIP Is Assigned To
 
-You can use kubectl (either on your local machine with the SUSE® Virtualization kubeconfig file, or when using SSH to connect to any SUSE® Virtualization management node as a root user).
+You can use kubectl (either on your local machine with the {product-name} kubeconfig file, or when using SSH to connect to any {product-name} management node as a root user).
 
 [,console]
 ----
@@ -60,7 +60,7 @@ Example output:
 harvester-xzj76
 ----
 
-Alternatively, you can use SSH to connect to each SUSE® Virtualization management node and then run the command `ip address show mgmt-br`.
+Alternatively, you can use SSH to connect to each {product-name} management node and then run the command `ip address show mgmt-br`.
 
 Example:
 
@@ -81,7 +81,7 @@ When the output includes both the VIP and the node address, the VIP is assigned 
 
 The management address:
 
-* Allows the access to the SUSE® Virtualization API/UI via `HTTPS` protocol.
+* Allows the access to the {product-name} API/UI via `HTTPS` protocol.
 * Allows other nodes to join the cluster.
 +
 image:install/configure-management-address.png[]

--- a/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
@@ -1,6 +1,6 @@
 = Management Address
 
-{product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
+{harvester-product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 
 [NOTE]
 ====
@@ -13,18 +13,18 @@ image::install/iso-installed.png[]
 == Requirements
 
 * The VIP and the node management interfaces must belong to the same subnet.
-* All {product-name} node management interfaces must be on the same layer-2 network segment.
+* All {harvester-product-name} node management interfaces must be on the same layer-2 network segment.
 
 Both are required because the VIP relies on the Address Resolution Protocol (ARP), which is a layer-2 protocol.
 
-The VIP can be assigned to any {product-name} node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the {product-name} cluster's management IP address (the VIP).
+The VIP can be assigned to any {harvester-product-name} node management interface and can change at any time (not only when node failure occurs). When the VIP changes hosts, _gratuitous ARPs_ are sent so that other hosts on the network know where to direct traffic intended for the {harvester-product-name} cluster's management IP address (the VIP).
 
 [CAUTION]
 ====
 
-If you plan to host a {product-name} cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, {product-name} is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
+If you plan to host a {harvester-product-name} cluster in a bare metal data center, the service provider will likely designate a "floating" or "reserved" IP address as the VIP that you can assign to one of your servers. Updating this assignment causes traffic to instantly start flowing to the new node it is assigned to. In these situations, {harvester-product-name} is unable to update the floating/reserved IP assignment in your provider's systems when the VIP changes hosts.
 
-Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your {product-name} nodes (for example, if your {product-name} hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
+Furthermore, the VIP's "gratuitous ARPs" may also be ineffective depending on your provider's networking setup between your {harvester-product-name} nodes (for example, if your {harvester-product-name} hosts are not on the same layer-2 network). You must update the floating/reserved IP assignment manually when the VIP changes hosts to ensure that the cluster functions properly. For more information, see <<Identifying the Node the VIP Is Assigned To,Finding which node the VIP is on>>.
 ====
 
 
@@ -46,7 +46,7 @@ Example of output:
 
 == Identifying the Node the VIP Is Assigned To
 
-You can use kubectl (either on your local machine with the {product-name} kubeconfig file, or when using SSH to connect to any {product-name} management node as a root user).
+You can use kubectl (either on your local machine with the {harvester-product-name} kubeconfig file, or when using SSH to connect to any {harvester-product-name} management node as a root user).
 
 [,console]
 ----
@@ -60,7 +60,7 @@ Example output:
 harvester-xzj76
 ----
 
-Alternatively, you can use SSH to connect to each {product-name} management node and then run the command `ip address show mgmt-br`.
+Alternatively, you can use SSH to connect to each {harvester-product-name} management node and then run the command `ip address show mgmt-br`.
 
 Example:
 
@@ -81,7 +81,7 @@ When the output includes both the VIP and the node address, the VIP is assigned 
 
 The management address:
 
-* Allows the access to the {product-name} API/UI via `HTTPS` protocol.
+* Allows the access to the {harvester-product-name} API/UI via `HTTPS` protocol.
 * Allows other nodes to join the cluster.
 +
 image:install/configure-management-address.png[]

--- a/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -17,11 +17,11 @@ If you choose `Install Harvester binaries only`, you will need to perform additi
 * Cluster token
 * Node password
 
-Then, the installer will apply the endpoint configuration and boot {product-name}. No further reboots will be required.
+Then, the installer will apply the endpoint configuration and boot {harvester-product-name}. No further reboots will be required.
 
 == Stream disk mode
 
-SUSE has published a raw image artifact for pre-installed {product-name}. The installer now allows streaming a pre-installed image directly to disk to support better integration with cloud providers.
+SUSE has published a raw image artifact for pre-installed {harvester-product-name}. The installer now allows streaming a pre-installed image directly to disk to support better integration with cloud providers.
 
 On `Equinix Metal`, you can use the following kernel arguments to use the streaming mode:
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -17,11 +17,11 @@ If you choose `Install Harvester binaries only`, you will need to perform additi
 * Cluster token
 * Node password
 
-Then, the installer will apply the endpoint configuration and boot SUSE® Virtualization. No further reboots will be required.
+Then, the installer will apply the endpoint configuration and boot {product-name}. No further reboots will be required.
 
 == Stream disk mode
 
-SUSE has published a raw image artifact for pre-installed SUSE® Virtualization. The installer now allows streaming a pre-installed image directly to disk to support better integration with cloud providers.
+SUSE has published a raw image artifact for pre-installed {product-name}. The installer now allows streaming a pre-installed image directly to disk to support better integration with cloud providers.
 
 On `Equinix Metal`, you can use the following kernel arguments to use the streaming mode:
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
@@ -5,16 +5,16 @@ The net install ISO is a minimal installation image that contains only the core 
 You can use the net install ISO in the following situations:
 
 * The virtual media implementation on a server is buggy or slow. Some users have reported that ISO redirection is too slow to preload all images onto a system. For more information, see https://github.com/harvester/harvester/issues/2651[Issue 2651].
-* You have a private registry that contains all SUSE® Virtualization images, as well as the knowledge and experience required to configure image mirrors for containerd.
+* You have a private registry that contains all {product-name} images, as well as the knowledge and experience required to configure image mirrors for containerd.
 
 [CAUTION]
 ====
-*You must always use the full ISO to bootstrap a SUSE® Virtualization cluster* (in other words, use the ISO without the `-net-install` suffix). The full ISO contains all required images, and the installer preloads those images during installation. You can easily reach the https://docs.docker.com/docker-hub/download-rate-limit/[Docker Hub rate limit] when using a net install ISO to bootstrap the cluster.
+*You must always use the full ISO to bootstrap a {product-name} cluster* (in other words, use the ISO without the `-net-install` suffix). The full ISO contains all required images, and the installer preloads those images during installation. You can easily reach the https://docs.docker.com/docker-hub/download-rate-limit/[Docker Hub rate limit] when using a net install ISO to bootstrap the cluster.
 ====
 
 == Usage
 
-Download the net install ISO from the GitHub https://github.com/harvester/harvester/releases[Releases] page, and then boot the ISO to install SUSE® Virtualization. Net install ISO file names have the suffix `net-install` (for example, https://releases.rancher.com/harvester/v1.3.0/harvester-v1.3.0-amd64-net-install.iso).
+Download the net install ISO from the GitHub https://github.com/harvester/harvester/releases[Releases] page, and then boot the ISO to install {product-name}. Net install ISO file names have the suffix `net-install` (for example, https://releases.rancher.com/harvester/v1.3.0/harvester-v1.3.0-amd64-net-install.iso).
 
 == PXE Installation
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
@@ -5,16 +5,16 @@ The net install ISO is a minimal installation image that contains only the core 
 You can use the net install ISO in the following situations:
 
 * The virtual media implementation on a server is buggy or slow. Some users have reported that ISO redirection is too slow to preload all images onto a system. For more information, see https://github.com/harvester/harvester/issues/2651[Issue 2651].
-* You have a private registry that contains all {product-name} images, as well as the knowledge and experience required to configure image mirrors for containerd.
+* You have a private registry that contains all {harvester-product-name} images, as well as the knowledge and experience required to configure image mirrors for containerd.
 
 [CAUTION]
 ====
-*You must always use the full ISO to bootstrap a {product-name} cluster* (in other words, use the ISO without the `-net-install` suffix). The full ISO contains all required images, and the installer preloads those images during installation. You can easily reach the https://docs.docker.com/docker-hub/download-rate-limit/[Docker Hub rate limit] when using a net install ISO to bootstrap the cluster.
+*You must always use the full ISO to bootstrap a {harvester-product-name} cluster* (in other words, use the ISO without the `-net-install` suffix). The full ISO contains all required images, and the installer preloads those images during installation. You can easily reach the https://docs.docker.com/docker-hub/download-rate-limit/[Docker Hub rate limit] when using a net install ISO to bootstrap the cluster.
 ====
 
 == Usage
 
-Download the net install ISO from the GitHub https://github.com/harvester/harvester/releases[Releases] page, and then boot the ISO to install {product-name}. Net install ISO file names have the suffix `net-install` (for example, https://releases.rancher.com/harvester/v1.3.0/harvester-v1.3.0-amd64-net-install.iso).
+Download the net install ISO from the GitHub https://github.com/harvester/harvester/releases[Releases] page, and then boot the ISO to install {harvester-product-name}. Net install ISO file names have the suffix `net-install` (for example, https://releases.rancher.com/harvester/v1.3.0/harvester-v1.3.0-amd64-net-install.iso).
 
 == PXE Installation
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,6 +1,6 @@
 = ISO Installation
 
-SUSE® Virtualization ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
+{product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 
 During the installation, you can either choose to *create a new cluster* or *join the node to an existing cluster*.
 
@@ -38,11 +38,11 @@ When there are 3 nodes, the other 2 nodes added first are automatically promoted
 image::install/select-role.png[choose-node-role.png]
 
  ** `Default Role`: Allows a node to function as a management node or a worker node. This role does not have any specific privileges or restrictions.
- ** `Management Role`: Allows a node to be prioritized when SUSE® Virtualization promotes nodes to management nodes.
+ ** `Management Role`: Allows a node to be prioritized when {product-name} promotes nodes to management nodes.
  ** `Witness Role`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
  ** `Worker Role`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 
-. Choose the installation disk you want to install the cluster on and the data disk you want to store VM data on. By default, SUSE® Virtualization uses https://en.wikipedia.org/wiki/GUID_Partition_Table[GUID Partition Table (GPT)] partitioning schema for both UEFI and BIOS. If you use the BIOS boot, then you will have the option to select https://en.wikipedia.org/wiki/Master_boot_record[Master boot record (MBR)].
+. Choose the installation disk you want to install the cluster on and the data disk you want to store VM data on. By default, {product-name} uses https://en.wikipedia.org/wiki/GUID_Partition_Table[GUID Partition Table (GPT)] partitioning schema for both UEFI and BIOS. If you use the BIOS boot, then you will have the option to select https://en.wikipedia.org/wiki/Master_boot_record[Master boot record (MBR)].
 +
 image::install/choose-installation-target-data-disk.png[choose-installation-target-data-disk.png]
 
@@ -54,7 +54,7 @@ image::install/choose-installation-target-data-disk.png[choose-installation-targ
 +
 image::install/config-hostname.png[config-hostname.png]
 
-. Configure network interface(s) for the management network. By default, SUSE® Virtualization creates a xref:../../installation-setup/requirements.adoc#_hardware_requirements[bonded NIC] named `mgmt-bo` for the xref:../../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network], and the IP address can be configured via DHCP or statically assigned.
+. Configure network interface(s) for the management network. By default, {product-name} creates a xref:../../installation-setup/requirements.adoc#_hardware_requirements[bonded NIC] named `mgmt-bo` for the xref:../../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network], and the IP address can be configured via DHCP or statically assigned.
 +
 image::install/config-network.png[config-network.png]
 +
@@ -114,7 +114,7 @@ image::install/import-ssh-keys.png[import-ssh-keys.png]
 +
 image::install/remote-config.png[remote-config.png]
 
-. Review and confirm your installation options. After confirming the installation options, SUSE® Virtualization will be installed to your host. The installation may take a few minutes to be complete.
+. Review and confirm your installation options. After confirming the installation options, {product-name} will be installed to your host. The installation may take a few minutes to be complete.
 +
 image::install/confirm-install.png[confirm-install.png]
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,6 +1,6 @@
 = ISO Installation
 
-{product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
+{harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 
 During the installation, you can either choose to *create a new cluster* or *join the node to an existing cluster*.
 
@@ -38,11 +38,11 @@ When there are 3 nodes, the other 2 nodes added first are automatically promoted
 image::install/select-role.png[choose-node-role.png]
 
  ** `Default Role`: Allows a node to function as a management node or a worker node. This role does not have any specific privileges or restrictions.
- ** `Management Role`: Allows a node to be prioritized when {product-name} promotes nodes to management nodes.
+ ** `Management Role`: Allows a node to be prioritized when {harvester-product-name} promotes nodes to management nodes.
  ** `Witness Role`: Restricts a node to being a witness node (only functions as an etcd node) in a specific cluster.
  ** `Worker Role`: Restricts a node to being a worker node (never promoted to management node) in a specific cluster.
 
-. Choose the installation disk you want to install the cluster on and the data disk you want to store VM data on. By default, {product-name} uses https://en.wikipedia.org/wiki/GUID_Partition_Table[GUID Partition Table (GPT)] partitioning schema for both UEFI and BIOS. If you use the BIOS boot, then you will have the option to select https://en.wikipedia.org/wiki/Master_boot_record[Master boot record (MBR)].
+. Choose the installation disk you want to install the cluster on and the data disk you want to store VM data on. By default, {harvester-product-name} uses https://en.wikipedia.org/wiki/GUID_Partition_Table[GUID Partition Table (GPT)] partitioning schema for both UEFI and BIOS. If you use the BIOS boot, then you will have the option to select https://en.wikipedia.org/wiki/Master_boot_record[Master boot record (MBR)].
 +
 image::install/choose-installation-target-data-disk.png[choose-installation-target-data-disk.png]
 
@@ -54,7 +54,7 @@ image::install/choose-installation-target-data-disk.png[choose-installation-targ
 +
 image::install/config-hostname.png[config-hostname.png]
 
-. Configure network interface(s) for the management network. By default, {product-name} creates a xref:../../installation-setup/requirements.adoc#_hardware_requirements[bonded NIC] named `mgmt-bo` for the xref:../../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network], and the IP address can be configured via DHCP or statically assigned.
+. Configure network interface(s) for the management network. By default, {harvester-product-name} creates a xref:../../installation-setup/requirements.adoc#_hardware_requirements[bonded NIC] named `mgmt-bo` for the xref:../../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network], and the IP address can be configured via DHCP or statically assigned.
 +
 image::install/config-network.png[config-network.png]
 +
@@ -114,7 +114,7 @@ image::install/import-ssh-keys.png[import-ssh-keys.png]
 +
 image::install/remote-config.png[remote-config.png]
 
-. Review and confirm your installation options. After confirming the installation options, {product-name} will be installed to your host. The installation may take a few minutes to be complete.
+. Review and confirm your installation options. After confirming the installation options, {harvester-product-name} will be installed to your host. The installation may take a few minutes to be complete.
 +
 image::install/confirm-install.png[confirm-install.png]
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,6 +1,6 @@
 = PXE Boot Installation
 
-Harvester can be installed automatically with PXE boot.
+{product-name} can be installed automatically with PXE boot.
 
 We recommend using https://ipxe.org/[iPXE] to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,6 +1,6 @@
 = PXE Boot Installation
 
-{product-name} can be installed automatically with PXE boot.
+{harvester-product-name} can be installed automatically with PXE boot.
 
 We recommend using https://ipxe.org/[iPXE] to perform the network boot. It has more features than the traditional PXE Boot program and is likely available in modern NIC cards. If the iPXE firmware is not available for your NIC card, the iPXE firmware images can be loaded from the TFTP server first.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -1,6 +1,6 @@
 = Hardware and Network Requirements
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running SUSE® Virtualization.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {product-name}.
 
 A three-node cluster is required to fully realize the multi-node features. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
 
@@ -8,7 +8,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 
 == Hardware Requirements
 
-SUSE® Virtualization nodes have the following hardware requirements and recommendations for installation and testing.
+{product-name} nodes have the following hardware requirements and recommendations for installation and testing.
 
 |===
 | Hardware | Development/Testing | Production
@@ -45,9 +45,9 @@ SUSE® Virtualization nodes have the following hardware requirements and recomme
 [IMPORTANT]
 ====
 
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. SUSE® Virtualization is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
-* SUSE® Virtualization has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
+* {product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
 ====
 
@@ -64,7 +64,7 @@ When creating clusters, adding more hosts to a cluster, and replacing hosts, alw
 
 Nodes have the following network requirements for installation.
 
-=== Port Requirements for SUSE® Virtualization Nodes
+=== Port Requirements for Nodes
 
 Nodes require the following port connections or inbound rules. Typically, all outbound traffic is allowed.
 
@@ -222,15 +222,15 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 | iscsid
 |===
 
-=== Port Requirements for Integrating SUSE® Virtualization with Rancher
+=== Port Requirements for Integrating SUSE Virtualization with Rancher
 
-If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all SUSE® Virtualization nodes can connect to TCP port *443* of the Rancher load balancer.
+If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all {product-name} nodes can connect to TCP port *443* of the Rancher load balancer.
 
-When provisioning VMs with Kubernetes clusters from Rancher into SUSE® Virtualization, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from Rancher into {product-name}, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
-For the port requirements for guest clusters deployed inside SUSE® Virtualization VMs, refer to the following links:
+For the port requirements for guest clusters deployed inside {product-name} VMs, refer to the following links:
 
 * https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
 * https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -222,11 +222,11 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 | iscsid
 |===
 
-=== Port Requirements for Integrating SUSE Virtualization with Rancher
+=== Port Requirements for Integrating with {rancher-product-name}
 
-If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the Rancher load balancer.
+If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with {rancher-product-name}], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the {rancher-product-name} load balancer.
 
-When provisioning VMs with Kubernetes clusters from Rancher into {harvester-product-name}, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -1,6 +1,6 @@
 = Hardware and Network Requirements
 
-As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {product-name}.
+As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
 
 A three-node cluster is required to fully realize the multi-node features. The first node that is added to the cluster is by default the management node. When the cluster has three or more nodes, the two nodes added after the first are automatically promoted to management nodes to form a high availability (HA) cluster.
 
@@ -8,7 +8,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 
 == Hardware Requirements
 
-{product-name} nodes have the following hardware requirements and recommendations for installation and testing.
+{harvester-product-name} nodes have the following hardware requirements and recommendations for installation and testing.
 
 |===
 | Hardware | Development/Testing | Production
@@ -26,8 +26,8 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 | 500 GB minimum
 
 | Disk performance
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet link:(https://www.suse.com/support/kb/doc/?id=000020100)[etcd] speed requirements. Only local disks and hardware RAID are supported.
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet link:(https://www.suse.com/support/kb/doc/?id=000020100)[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://www.suse.com/support/kb/doc/?id=000020100[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://www.suse.com/support/kb/doc/?id=000020100[etcd] speed requirements. Only local disks and hardware RAID are supported.
 
 | Network card count
 | Management cluster network: 1 NIC required, 2 NICs recommended; VM workload network: 1 NIC required, at least 2 NICs recommended (does not apply to the xref:../hosts/witness-node.adoc[witness node])
@@ -45,9 +45,9 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 [IMPORTANT]
 ====
 
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
-* {product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
+* {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
 ====
 
@@ -224,13 +224,13 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 
 === Port Requirements for Integrating SUSE Virtualization with Rancher
 
-If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all {product-name} nodes can connect to TCP port *443* of the Rancher load balancer.
+If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with Rancher], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the Rancher load balancer.
 
-When provisioning VMs with Kubernetes clusters from Rancher into {product-name}, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from Rancher into {harvester-product-name}, you need to be able to connect to TCP port *443* of the Rancher load balancer. Otherwise, the cluster won't be manageable by Rancher. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
-For the port requirements for guest clusters deployed inside {product-name} VMs, refer to the following links:
+For the port requirements for guest clusters deployed inside {harvester-product-name} VMs, refer to the following links:
 
 * https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
 * https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]

--- a/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,8 +1,8 @@
 = Single-Node Clusters
 
-Harvester supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:../installation-setup/methods/iso-install.adoc[ISO], xref:../installation-setup/methods/usb-install.adoc[USB], and xref:../installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
+{product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:../installation-setup/methods/iso-install.adoc[ISO], xref:../installation-setup/methods/usb-install.adoc[USB], and xref:../installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 
-Single-node clusters support most Harvester features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+Single-node clusters support most {product-name} features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
 
 * No high availability: Errors and updates that require rebooting of the node cause downtime to running virtual machines.
 * No live migration and zero-downtime support during upgrades.
@@ -11,14 +11,14 @@ Single-node clusters support most Harvester features, including the creation of 
 
 Before you begin deploying your single-node cluster, ensure that the following requirements are met.
 
-* Hardware: xref:../installation-setup/requirements.adoc#_hardware_requirements[Use server-class hardware] with sufficient resources to run Harvester and a production workload. Laptops and nested virtualization are not supported.
+* Hardware: xref:../installation-setup/requirements.adoc#_hardware_requirements[Use server-class hardware] with sufficient resources to run {product-name} and a production workload. Laptops and nested virtualization are not supported.
 * Network: xref:../installation-setup/requirements.adoc#_port_requirements_for_harvester-nodes[Configure ports] based on the type of traffic to be transmitted among virtual machines.
 
 == Replica Count of the Default StorageClass
 
-Harvester uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the Harvester UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
@@ -39,6 +39,6 @@ If you want Longhorn to create multiple replicas on a node with multiple disks, 
 
 == Upgrades and Maintenance
 
-Single-node clusters do not support xref:../virtual-machines/live-migration.adoc[Live Migration], so virtual machines become unavailable during cluster upgrades. Harvester forcibly shuts down all virtual machines before starting the upgrade process. You can configure Harvester to automatically restore running virtual machines using the `restoreVM` option of the xref:./config/settings.adoc#upgrade-config[`upgrade-config`] setting.
+Single-node clusters do not support xref:../virtual-machines/live-migration.adoc[Live Migration], so virtual machines become unavailable during cluster upgrades. {product-name} forcibly shuts down all virtual machines before starting the upgrade process. You can configure {product-name} to automatically restore running virtual machines using the `restoreVM` option of the xref:./config/settings.adoc#upgrade-config[`upgrade-config`] setting.
 
-Enabling xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is also not possible because that operation relies on Live Migration functionality, and Harvester cannot place the only control plane in Maintenance Mode.
+Enabling xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is also not possible because that operation relies on Live Migration functionality, and {product-name} cannot place the only control plane in Maintenance Mode.

--- a/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,8 +1,8 @@
 = Single-Node Clusters
 
-{product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:../installation-setup/methods/iso-install.adoc[ISO], xref:../installation-setup/methods/usb-install.adoc[USB], and xref:../installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
+{harvester-product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:../installation-setup/methods/iso-install.adoc[ISO], xref:../installation-setup/methods/usb-install.adoc[USB], and xref:../installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 
-Single-node clusters support most {product-name} features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
+Single-node clusters support most {harvester-product-name} features, including the creation of RKE2 clusters and node upgrades (with some limitations). However, this deployment type has the following key disadvantages:
 
 * No high availability: Errors and updates that require rebooting of the node cause downtime to running virtual machines.
 * No live migration and zero-downtime support during upgrades.
@@ -11,12 +11,12 @@ Single-node clusters support most {product-name} features, including the creatio
 
 Before you begin deploying your single-node cluster, ensure that the following requirements are met.
 
-* Hardware: xref:../installation-setup/requirements.adoc#_hardware_requirements[Use server-class hardware] with sufficient resources to run {product-name} and a production workload. Laptops and nested virtualization are not supported.
+* Hardware: xref:../installation-setup/requirements.adoc#_hardware_requirements[Use server-class hardware] with sufficient resources to run {harvester-product-name} and a production workload. Laptops and nested virtualization are not supported.
 * Network: xref:../installation-setup/requirements.adoc#_port_requirements_for_harvester-nodes[Configure ports] based on the type of traffic to be transmitted among virtual machines.
 
 == Replica Count of the Default StorageClass
 
-{product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
 The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
@@ -39,6 +39,6 @@ If you want Longhorn to create multiple replicas on a node with multiple disks, 
 
 == Upgrades and Maintenance
 
-Single-node clusters do not support xref:../virtual-machines/live-migration.adoc[Live Migration], so virtual machines become unavailable during cluster upgrades. {product-name} forcibly shuts down all virtual machines before starting the upgrade process. You can configure {product-name} to automatically restore running virtual machines using the `restoreVM` option of the xref:./config/settings.adoc#upgrade-config[`upgrade-config`] setting.
+Single-node clusters do not support xref:../virtual-machines/live-migration.adoc[Live Migration], so virtual machines become unavailable during cluster upgrades. {harvester-product-name} forcibly shuts down all virtual machines before starting the upgrade process. You can configure {harvester-product-name} to automatically restore running virtual machines using the `restoreVM` option of the xref:./config/settings.adoc#upgrade-config[`upgrade-config`] setting.
 
-Enabling xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is also not possible because that operation relies on Live Migration functionality, and {product-name} cannot place the only control plane in Maintenance Mode.
+Enabling xref:../hosts/hosts.adoc#_node_maintenance[Maintenance Mode] is also not possible because that operation relies on Live Migration functionality, and {harvester-product-name} cannot place the only control plane in Maintenance Mode.

--- a/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -96,8 +96,8 @@ Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI 
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {harvester-product-name}.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use {rancher-product-name} with {harvester-product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]
-* xref:../integrations/rancher/rancher-integration.adoc[Rancher Integration]
+* xref:../integrations/rancher/rancher-integration.adoc[{rancher-product-name} Integration]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a High-Availability Cluster
 
-A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A {product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
 This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+{product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
 You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {product-name} behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -62,9 +62,9 @@ When the cluster has three or more nodes, the two nodes added after the first no
 
 Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {product-name} cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -82,7 +82,7 @@ On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
+You can store SSH public keys in {product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
@@ -92,11 +92,11 @@ You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of t
 * Kubernetes API: Create a `VirtualMachine` object.
 * xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a High-Availability Cluster
 
-A {product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
 This guide walks you through the steps required to deploy a *high-availability cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-{product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+{harvester-product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
 You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {product-name} behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {harvester-product-name} behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -62,9 +62,9 @@ When the cluster has three or more nodes, the two nodes added after the first no
 
 Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {product-name} cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {harvester-product-name} cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {harvester-product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -82,7 +82,7 @@ On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in {product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
+You can store SSH public keys in {harvester-product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
@@ -92,11 +92,11 @@ You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of t
 * Kubernetes API: Create a `VirtualMachine` object.
 * xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {harvester-product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {product-name}.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {harvester-product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a Single-Node Cluster
 
-A SUSE® Virtualization cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A {product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
 This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-SUSE® Virtualization is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+{product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
 You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing SUSE® Virtualization behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {product-name} behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -52,7 +52,7 @@ Once the cluster status changes to *Ready*, you can access the xref:../installat
 
 == 6. Configure the default StorageClass.
 
-SUSE® Virtualization uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
 The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the UI.
 
@@ -65,9 +65,9 @@ To avoid this issue, you can perform either of the following actions:
 
 Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the SUSE® Virtualization cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {product-name} cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. SUSE® Virtualization also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -77,7 +77,7 @@ Each network configuration corresponds to a set of nodes with uniform network sp
 +
 Each VM network is linked to a specific cluster network, which is used for transmission of VM traffic. You can create either a xref:../networking/vm-network.adoc#_vlan_network[VLAN network] or an xref:../networking/vm-network.adoc#_untagged_network[untagged network] based on your requirements, such as traffic isolation, network segmentation, ease of management, or alignment with the external network environment.
 
-You can create a VM network that uses `mgmt` when testing SUSE® Virtualization with a single-node cluster.
+You can create a VM network that uses `mgmt` when testing {product-name} with a single-node cluster.
 
 == 8. Import VM images.
 
@@ -85,7 +85,7 @@ On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in SUSE® Virtualization. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
+You can store SSH public keys in {product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
@@ -95,11 +95,11 @@ You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of t
 * Kubernetes API: Create a `VirtualMachine` object.
 * xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. SUSE® Virtualization provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with SUSE® Virtualization.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -99,8 +99,8 @@ Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI 
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {harvester-product-name}.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use {rancher-product-name} with {harvester-product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]
-* xref:../integrations/rancher/rancher-integration.adoc[Rancher Integration]
+* xref:../integrations/rancher/rancher-integration.adoc[{rancher-product-name} Integration]

--- a/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,18 +1,18 @@
 = Deploy a Single-Node Cluster
 
-A {product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
 This guide walks you through the steps required to deploy a *single-node cluster* and virtual machines (VMs) that can host guest clusters and run custom workloads.
 
 == 1. Verify that the minimum hardware and network requirements are met.
 
-{product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
+{harvester-product-name} is built for bare metal servers using enterprise-grade open-source software components. The installer automatically checks the hardware and displays warning messages if the minimum xref:../installation-setup/requirements.adoc[requirements] are not met.
 
 == 2. Prepare the installation files based on the installation method that you want to use.
 
 You can download the installation files from the https://github.com/harvester/harvester/releases[Releases] page. The *Downloads* section of the release notes contains links to the ISO files and related artifacts. The following types of ISO files are available:
 
-* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {product-name} behind a firewall or proxy, and in environments without internet connectivity.
+* *Full ISO*: Contains the core operating system components and all required container images, which are preloaded during installation. You must use a full ISO when installing {harvester-product-name} behind a firewall or proxy, and in environments without internet connectivity.
 * xref:../installation-setup/media/net-install.adoc[*Net install ISO*]: Contains only the core operating system components. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 
 |===
@@ -52,7 +52,7 @@ Once the cluster status changes to *Ready*, you can access the xref:../installat
 
 == 6. Configure the default StorageClass.
 
-{product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
 The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the UI.
 
@@ -65,9 +65,9 @@ To avoid this issue, you can perform either of the following actions:
 
 Networking involves three major concepts:
 
-* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {product-name} cluster.
+* xref:../networking/cluster-network.adoc#_cluster_network[*Cluster network*]: Traffic-isolated forwarding path for transmission of network traffic in the {harvester-product-name} cluster.
 +
-During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
+During deployment, a cluster network called xref:../networking/cluster-network.adoc#_built_in_cluster_network[`mgmt`] is created for intra-cluster communications. `mgmt` allows VMs to be accessed from the infrastructure network (external to the cluster) to which each node attaches with management NICs for cluster management purposes. {harvester-product-name} also allows you to create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] that can be dedicated to VM traffic.
 
 * xref:../networking/cluster-network.adoc#_network_configuration[*Network configuration*]: Definition of how cluster nodes connect to a specific cluster network.
 +
@@ -77,7 +77,7 @@ Each network configuration corresponds to a set of nodes with uniform network sp
 +
 Each VM network is linked to a specific cluster network, which is used for transmission of VM traffic. You can create either a xref:../networking/vm-network.adoc#_vlan_network[VLAN network] or an xref:../networking/vm-network.adoc#_untagged_network[untagged network] based on your requirements, such as traffic isolation, network segmentation, ease of management, or alignment with the external network environment.
 
-You can create a VM network that uses `mgmt` when testing {product-name} with a single-node cluster.
+You can create a VM network that uses `mgmt` when testing {harvester-product-name} with a single-node cluster.
 
 == 8. Import VM images.
 
@@ -85,7 +85,7 @@ On the UI, you can import ISO, qcow2, and raw xref:../virtual-machines/vm-images
 
 == 9. Import SSH keys. (Recommended)
 
-You can store SSH public keys in {product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
+You can store SSH public keys in {harvester-product-name}. When a VM is launched, a stored key can be xref:../virtual-machines/access-vm.adoc#_ssh_access[injected] into the VM to allow secure access via SSH. Validated keys are displayed on the *SSH Keys* screen on the UI.
 
 == 10. Create VMs.
 
@@ -95,11 +95,11 @@ You can create xref:../virtual-machines/create-vm.adoc[Linux VMs] using one of t
 * Kubernetes API: Create a `VirtualMachine` object.
 * xref:../integrations/terraform/terraform-provider.adoc[Terraform Provider]: Define a `harvester_virtualmachine` resource block.
 
-Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
+Creating xref:../virtual-machines/create-windows-vm.adoc[Windows VMs] on the UI involves slightly different steps. {harvester-product-name} provides a VM template named `windows-iso-image-base-template` that adds a volume with the Virtio drivers for Windows, which streamlines the VM configuration process. If you require Virtio devices but choose to not use the template, you must add your own Virtio drivers for Windows to enable correct hardware detection.
 
 == What's Next
 
-The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {product-name}.
+The following sections provide guides that walk you through how to back up and restore VMs, manage hosts, and use Rancher with {harvester-product-name}.
 
 * xref:../virtual-machines/backup-restore.adoc[VM Backup, Snapshot & Restore]
 * xref:../hosts/hosts.adoc[Host Management]

--- a/versions/v1.4/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/glossary.adoc
@@ -4,9 +4,9 @@
 
 Group of integrated Kubernetes worker machines that run in virtual machines on top of a {harvester-product-name} cluster.
 
-You can create RKE1, RKE2, and K3s guest clusters using the {harvester-product-name} and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
+You can create RKE1, RKE2, and K3s guest clusters using the {harvester-product-name} and {rancher-product-name} interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
 
-Guest clusters form the main infrastructure for running container workloads. Certain versions of {harvester-product-name} and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE Virtualization clusters] (with some limitations).
+Guest clusters form the main infrastructure for running container workloads. Certain versions of {harvester-product-name} and {rancher-product-name} allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE Virtualization clusters] (with some limitations).
 
 == *guest node* / *guest cluster node*
 
@@ -20,9 +20,9 @@ Group of integrated physical servers (hosts) on which the {harvester-product-nam
 
 A three-node cluster is required to fully realize the multi-node features of {harvester-product-name}, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-{harvester-product-name} clusters can be imported into and managed by Rancher. Within the Rancher context, an imported {harvester-product-name} cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
+{harvester-product-name} clusters can be imported into and managed by {rancher-product-name}. Within this context, an imported {harvester-product-name} cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The term refers to any Kubernetes cluster that is connected to a {rancher-product-name} server.
 
-Certain versions of {harvester-product-name} and Rancher allow you to deploy container workloads directly to {harvester-product-name} clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with virtual machine workloads.
+Certain versions of {harvester-product-name} and {rancher-product-name} allow you to deploy container workloads directly to {harvester-product-name} clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with virtual machine workloads.
 
 == *SUSE Virtualization hypervisor*
 
@@ -36,4 +36,4 @@ Each node that joins a {harvester-product-name} cluster must be assigned a xref:
 
 == *Harvester Node Driver*
 
-xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision virtual machines in a {harvester-product-name} cluster, and to launch and manage guest Kubernetes clusters on top of those virtual machines.
+xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that {rancher-product-name} uses to provision virtual machines in a {harvester-product-name} cluster, and to launch and manage guest Kubernetes clusters on top of those virtual machines.

--- a/versions/v1.4/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/glossary.adoc
@@ -2,38 +2,38 @@
 
 == *guest cluster* / *guest Kubernetes cluster*
 
-Group of integrated Kubernetes worker machines that run in VMs on top of a SUSE® Virtualization cluster.
+Group of integrated Kubernetes worker machines that run in virtual machines on top of a {product-name} cluster.
 
-You can create RKE1, RKE2, and K3s guest clusters using the SUSE® Virtualization and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
+You can create RKE1, RKE2, and K3s guest clusters using the {product-name} and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
 
-Guest clusters form the main infrastructure for running container workloads. Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE® Virtualization clusters] (with some limitations).
+Guest clusters form the main infrastructure for running container workloads. Certain versions of {product-name} and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE Virtualization clusters] (with some limitations).
 
 == *guest node* / *guest cluster node*
 
-Kubernetes worker VM that uses guest cluster resources to run container workloads.
+Kubernetes worker virtual machine that uses guest cluster resources to run container workloads.
 
 Guest nodes are managed through a control plane that controls pod-related activity and maintains the desired cluster state.
 
-== *SUSE® Virtualization cluster*
+== *SUSE Virtualization cluster*
 
-Group of integrated physical servers (hosts) on which the SUSE® Virtualization hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running VMs.
+Group of integrated physical servers (hosts) on which the {product-name} hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running virtual machines.
 
-A three-node cluster is required to fully realize the multi-node features of SUSE® Virtualization, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of {product-name}, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-SUSE® Virtualization clusters can be imported into and managed by Rancher. Within the Rancher context, an imported SUSE® Virtualization cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
+{product-name} clusters can be imported into and managed by Rancher. Within the Rancher context, an imported {product-name} cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 
-Certain versions of SUSE® Virtualization and Rancher allow you to deploy container workloads directly to SUSE® Virtualization clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with VM workloads.
+Certain versions of {product-name} and Rancher allow you to deploy container workloads directly to {product-name} clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with virtual machine workloads.
 
-== *SUSE® Virtualization hypervisor*
+== *SUSE Virtualization hypervisor*
 
 Specialized operating system and xref:./overview.adoc#_architecture[software stack] that runs on a single physical server.
 
-== *SUSE® Virtualization node*
+== *SUSE Virtualization node*
 
-Physical server on which the SUSE® Virtualization hypervisor is installed.
+Physical server on which the {product-name} hypervisor is installed.
 
-Each node that joins a SUSE® Virtualization cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All SUSE® Virtualization nodes process data but not all can store data.
+Each node that joins a {product-name} cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All {product-name} nodes process data but not all can store data.
 
-== Harvester Node Driver*
+== *Harvester Node Driver*
 
-xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision VMs in a SUSE® Virtualization cluster, and to launch and manage guest Kubernetes clusters on top of those VMs.
+xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision virtual machines in a {product-name} cluster, and to launch and manage guest Kubernetes clusters on top of those virtual machines.

--- a/versions/v1.4/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/glossary.adoc
@@ -2,11 +2,11 @@
 
 == *guest cluster* / *guest Kubernetes cluster*
 
-Group of integrated Kubernetes worker machines that run in virtual machines on top of a {product-name} cluster.
+Group of integrated Kubernetes worker machines that run in virtual machines on top of a {harvester-product-name} cluster.
 
-You can create RKE1, RKE2, and K3s guest clusters using the {product-name} and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
+You can create RKE1, RKE2, and K3s guest clusters using the {harvester-product-name} and Rancher interfaces. Creating guest clusters involves pulling images from either the internet or a private registry.
 
-Guest clusters form the main infrastructure for running container workloads. Certain versions of {product-name} and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE Virtualization clusters] (with some limitations).
+Guest clusters form the main infrastructure for running container workloads. Certain versions of {harvester-product-name} and Rancher allow you to deploy container workloads xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[directly to SUSE Virtualization clusters] (with some limitations).
 
 == *guest node* / *guest cluster node*
 
@@ -16,13 +16,13 @@ Guest nodes are managed through a control plane that controls pod-related activi
 
 == *SUSE Virtualization cluster*
 
-Group of integrated physical servers (hosts) on which the {product-name} hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running virtual machines.
+Group of integrated physical servers (hosts) on which the {harvester-product-name} hypervisor is installed. These servers collectively manage compute, memory, and storage resources to provide an environment for running virtual machines.
 
-A three-node cluster is required to fully realize the multi-node features of {product-name}, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
+A three-node cluster is required to fully realize the multi-node features of {harvester-product-name}, particularly high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 
-{product-name} clusters can be imported into and managed by Rancher. Within the Rancher context, an imported {product-name} cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
+{harvester-product-name} clusters can be imported into and managed by Rancher. Within the Rancher context, an imported {harvester-product-name} cluster is known as a "managed cluster" or "downstream user cluster" (often abbreviated to "downstream cluster"). The Rancher term refers to any Kubernetes cluster that is connected to a Rancher server.
 
-Certain versions of {product-name} and Rancher allow you to deploy container workloads directly to {product-name} clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with virtual machine workloads.
+Certain versions of {harvester-product-name} and Rancher allow you to deploy container workloads directly to {harvester-product-name} clusters (with some limitations). When this xref:../integrations/rancher/rancher-integration.adoc#_harvester_baremetal_container_workload_support_experimental[experimental feature] is enabled, container workloads seamlessly interact with virtual machine workloads.
 
 == *SUSE Virtualization hypervisor*
 
@@ -30,10 +30,10 @@ Specialized operating system and xref:./overview.adoc#_architecture[software sta
 
 == *SUSE Virtualization node*
 
-Physical server on which the {product-name} hypervisor is installed.
+Physical server on which the {harvester-product-name} hypervisor is installed.
 
-Each node that joins a {product-name} cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All {product-name} nodes process data but not all can store data.
+Each node that joins a {harvester-product-name} cluster must be assigned a xref:../hosts/hosts.adoc#_role_management[role] that determines the functions the node can perform within the cluster. All {harvester-product-name} nodes process data but not all can store data.
 
 == *Harvester Node Driver*
 
-xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision virtual machines in a {product-name} cluster, and to launch and manage guest Kubernetes clusters on top of those virtual machines.
+xref:../integrations/rancher/node-driver/node-driver.adoc[Driver] that Rancher uses to provision virtual machines in a {harvester-product-name} cluster, and to launch and manage guest Kubernetes clusters on top of those virtual machines.

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -1,6 +1,6 @@
 = Overview
 
-{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
@@ -24,7 +24,7 @@ image::architecture.svg[]
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.
 * *Storage management.* {harvester-product-name} supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
 * *Network management.* Supports using a virtual IP (VIP) and multiple Network Interface Cards (NICs). If your VMs need to connect to the external network, create a VLAN or untagged network.
-* *Integration with Rancher.* Access {harvester-product-name} directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
+* *Integration with {rancher-product-name}.* Access {harvester-product-name} directly through {rancher-product-name}'s Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
 
 == User Interface
 

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -1,13 +1,13 @@
 = Overview
 
-{product-name-legal} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {product-name} supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
 The architecture consists of cutting-edge open-source technologies:
 
-* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of {product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
-* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {product-name} is an HCI solution with Kubernetes under the hood.
+* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
+* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
 * *Storage management with Longhorn.* https://longhorn.io/[Longhorn] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
@@ -16,18 +16,18 @@ image::architecture.svg[]
 
 == Features
 
-{product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
+{harvester-product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since {product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.
-* *Storage management.* {product-name} supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
+* *Storage management.* {harvester-product-name} supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
 * *Network management.* Supports using a virtual IP (VIP) and multiple Network Interface Cards (NICs). If your VMs need to connect to the external network, create a VLAN or untagged network.
-* *Integration with Rancher.* Access {product-name} directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
+* *Integration with Rancher.* Access {harvester-product-name} directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
 
 == User Interface
 
-{product-name} provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
+{harvester-product-name} provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
 
 +++<div class="text-center">++++++<iframe width="99%" height="450" src="https://www.youtube.com/embed/Ngsk7m6NYf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -1,13 +1,13 @@
 = Overview
 
-SUSE® Virtualization is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. SUSE® Virtualization runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), SUSE® Virtualization supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{product-name-legal} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {product-name} supports containerized environments automatically through integration with https://ranchermanager.docs.rancher.com/integrations-in-rancher/harvester[Rancher]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
 The architecture consists of cutting-edge open-source technologies:
 
-* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of SUSE® Virtualization and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
-* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and SUSE® Virtualization is an HCI solution with Kubernetes under the hood.
+* *Linux OS.* https://github.com/rancher/elemental-toolkit[Elemental] for SUSE Linux Enterprise Micro 5.5 is at the core of {product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
+* *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
 * *Storage management with Longhorn.* https://longhorn.io/[Longhorn] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
@@ -16,18 +16,18 @@ image::architecture.svg[]
 
 == Features
 
-SUSE® Virtualization is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
+{product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since SUSE® Virtualization ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.
-* *Storage management.* SUSE® Virtualization supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
+* *Storage management.* {product-name} supports distributed block storage and tiering. Volumes represent storage; you can easily create, edit, clone, or export a volume.
 * *Network management.* Supports using a virtual IP (VIP) and multiple Network Interface Cards (NICs). If your VMs need to connect to the external network, create a VLAN or untagged network.
-* *Integration with Rancher.* Access SUSE® Virtualization directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
+* *Integration with Rancher.* Access {product-name} directly within Rancher through Rancher's Virtualization Management page and manage your VM workloads alongside your Kubernetes clusters.
 
 == User Interface
 
-SUSE® Virtualization provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
+{product-name} provides a powerful and easy-to-use web-based interface for visualizing and managing your infrastructure. Once installed, you can access the IP address for the UI from the node's terminal.
 
 +++<div class="text-center">++++++<iframe width="99%" height="450" src="https://www.youtube.com/embed/Ngsk7m6NYf4" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++


### PR DESCRIPTION
Change log:
- Define variables in `antora.yml` files for v1.3 and v1.4
- Replace "Harvester" and "SUSE® Virtualization" with "{harvester-product-name}" (v1.4 - Introduction, Installation and Setup, Hosts)
- Replace "Rancher" with "{rancher-product-name}" (v1.4 - Introduction, Installation and Setup, Hosts) 