### PR TITLE
Add workflow to test PRs

### DIFF
--- a/.github/workflows/test-deploy.yml
+++ b/.github/workflows/test-deploy.yml
@@ -1,0 +1,43 @@
+name: Test deployment
+
+on:
+  pull_request:
+    paths-ignore:
+      - '**/README.md'
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  test-deploy:
+    name: Test deployment
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 18
+      - name: Install Antora and dependencies
+        run: make environment
+      - name: Generate Site
+        run: |
+          npx antora --stacktrace \
+            --log-file local-build.log \
+            --log-format=pretty \
+            --log-level=info \
+            --log-failure-level=warn \
+            playbook-local.yml 2>&1 | tee local-build.log 2>&1
+            BUILD_STATUS=${PIPESTATUS[0]}
+            if grep "INFO (asciidoctor)" local-build.log; then
+              BUILD_STATUS=1
+            fi
+            echo "BUILD_STATUS=$BUILD_STATUS" >> $GITHUB_ENV
+      - name: Check for build errors
+        run: |
+          echo ${{ env.BUILD_STATUS }}
+          if [ ${{ env.BUILD_STATUS }} -eq "0" ]; then
+            exit 0
+          else
+            cat local-build.log
+            exit 1
+          fi


### PR DESCRIPTION
Note, Antora's [failure level option](https://docs.antora.org/antora/latest/playbook/runtime-log-failure-level/#failure-level-key) can't be to `info` so I've set it to `warn` and then check the build logs for `INFO (asciidoctor)` which is raised for invalid reference errors. 