### PR TITLE
Add missing 's' to start_paths

### DIFF
--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -7,7 +7,7 @@ content:
   sources: 
   - url: https://github.com/rancher/harvester-product-docs
     branches: [main]
-    start_path: [versions/v1.3, versions/v1.4, versions/v1.5]
+    start_paths: [versions/v1.3, versions/v1.4, versions/v1.5]
 ui: 
   bundle:
     url: https://github.com/rancher/product-docs-ui/blob/main/build/ui-bundle.zip?raw=true


### PR DESCRIPTION
This addresses the following build error: `WARN (@antora/content-classifier): Start page specified for site not found: v1.4@virtualization:en:introduction/overview.adoc`