### PR TITLE
Use current branch as content source

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -5,7 +5,7 @@ site:
 content:
   sources:
   - url: ./
-    branches: [main]
+    branches: HEAD
     start_paths: [versions/v1.3, versions/v1.4, versions/v1.5]
 ui:
   bundle:


### PR DESCRIPTION
With `main` as the content source branch, the PR test workflow added in #43  fails since changes have not been made to main yet at that point.

Using HEAD has the content source branch also has the benefit of not having to switch branches/modifying the playbook temporarily for testing during local development. 

Ref: https://docs.antora.org/antora/latest/playbook/content-branches/#current-local-branch