### PR TITLE
Set unreleased version (1.5) as a prerelease

### DIFF
--- a/versions/v1.5/antora.yml
+++ b/versions/v1.5/antora.yml
@@ -1,7 +1,7 @@
 name: virtualization
 title: SUSE® Virtualization
 version: v1.5
-display_version: v1.5 (Dev)
+prerelease: (Dev)
 start_page: en:introduction/overview.adoc
 nav:
 - modules/en/nav.adoc


### PR DESCRIPTION
Use Antora's [prerelease](https://docs.antora.org/antora/latest/component-prerelease/) setting, so that proper routing rules are applied, for versions that haven't been released yet.