### PR TITLE
Address GitHub issues (58 and 63)

### DIFF
--- a/versions/v1.3/antora.yml
+++ b/versions/v1.3/antora.yml
@@ -14,6 +14,7 @@ asciidoc:
     neuvector-product-name: "SUSE® Security"
     rancher-product-name: "SUSE Rancher Prime"
     rancher-product-name-tm: "SUSE® Rancher Prime"
+    rancher-short-name: "Rancher"
     elemental-product-name: "SUSE® Rancher Prime: OS Manager"
     k3s-product-name: "SUSE® Rancher Prime: K3s"
     kubewarden-product-name: "SUSE® Rancher Prime: Admission Policy Manager"

--- a/versions/v1.3/modules/en/nav.adoc
+++ b/versions/v1.3/modules/en/nav.adoc
@@ -36,6 +36,7 @@
 ** xref:upgrades/v1-2-1-to-v1-2-2.adoc[]
 ** xref:upgrades/v1-2-2-to-v1-3-1.adoc[]
 ** xref:upgrades/v1-3-1-to-v1-3-2.adoc[]
+** xref:upgrades/v1-3-2-to-v1-4-0.adoc[]
 ** xref:upgrades/troubleshooting.adoc[]
 
 // Folder: hosts:

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,45 +1,31 @@
-= Rancher Integration
+= {rancher-product-name} Integration
 
-https://github.com/rancher/rancher[Rancher] is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
+https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-Users can import and manage multiple Harvester clusters using the Rancher xref:./virtualization-management.adoc[Virtualization Management] feature. Leveraging the Rancher's https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/authentication-config[authentication] feature and https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/manage-role-based-access-control-rbac[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
-For a comprehensive overview of the support matrix, please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Harvester & Rancher Support Matrix].
-
-For the network requirements, please refer to the doc xref:../../installation-setup/requirements.adoc#_network_requirements[here].
+Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 
 +++<div class="text-center">++++++<iframe width="950" height="475" src="https://www.youtube.com/embed/fyxDm3HVwWI" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++
 
 image::rancher/virtualization-management.png[virtualization-management]
 
-== Deploying Rancher server
+== Deploying the {rancher-short-name} server
 
-To use Rancher with Harvester, please install Rancher on a separate server. If you want to try out the integration features, you can create a VM in Harvester and install the Rancher server by following the https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Helm CLI quick start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production setup, please use one of the following guides to deploy and provision Rancher and a Kubernetes cluster with the provider of your choice:
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-* https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/deploy-rancher-manager[AWS] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace[AWS Marketplace] (uses Amazon EKS)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/azure[Azure] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean[DigitalOcean] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/gcp[GCP] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud[Hetzner Cloud] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/vagrant[Vagrant]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal[Equinix Metal]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs[Outscale] (uses Terraform)
-
-If you prefer, the following guide will take you through the same process in individual steps. Use this if you want to run Rancher with a different provider, on prem, or if you want to see how easy it is.
-
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Manual Install]
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====
-*Do not install Rancher with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing Rancher in Docker should only be used for quick evaluation and testing purposes.
+*Do not install {rancher-short-name} with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing {rancher-short-name} in Docker should only be used for quick evaluation and testing purposes.
 ====
 
 == Virtualization management
 
-With Rancher's virtualization management feature, you can import and manage your Harvester cluster. By clicking one of the imported clusters, you can easily access and manage a range of Harvester cluster resources, including hosts, VMs, images, volumes, and more. Additionally, the virtualization management feature leverages Rancher's existing capabilities, such as authentication with various auth providers and multi-tenancy support.
+With {rancher-short-name}'s virtualization management feature, you can import and manage your {harvester-product-name} cluster. By clicking one of the imported clusters, you can easily access and manage a range of {harvester-product-name} cluster resources, including hosts, virtual machines, images, volumes, and more. Additionally, the virtualization management feature leverages {rancher-short-name}'s existing capabilities, such as authentication with various auth providers and multi-tenancy support.
 
 For in-depth insights, please refer to the xref:./virtualization-management.adoc[virtualization management] page.
 
@@ -47,17 +33,22 @@ image::rancher/import-harvester-cluster.png[import-cluster]
 
 == Creating Kubernetes clusters using the Harvester node driver
 
-You can launch a Kubernetes cluster from Rancher using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When Rancher deploys Kubernetes onto these nodes, you can choose between Rancher Kubernetes Engine (RKE) or RKE2 distributions.
+You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When {rancher-short-name} deploys Kubernetes onto these nodes, choose RKE2.
 
-One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, Rancher can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+[NOTE]
+====
+Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+====
 
-Starting from Rancher version `v2.6.1`, the Harvester node driver is included by default. You can refer to the xref:../../integrations/rancher/node-driver/node-driver.adoc[node-driver] page for more details.
+One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+
+The Harvester node driver is included in {rancher-short-name} by default. For more information, see xref:../../integrations/rancher/node-driver/node-driver.adoc[Node Driver].
 
 image::rancher/harvester-node-driver.png[harvester-node-driver]
 
-== Harvester baremetal container workload support (experimental)
+== Bare-metal container workload support (experimental)
 
-Starting with Rancher v2.7.6, Harvester introduces a new feature that enables you to deploy and manage container workloads directly to the underlying Harvester cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
+{harvester-product-name} introduces a new feature that enables you to deploy and manage container workloads directly to the underlying {harvester-product-name} cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
 
 image::rancher/harvester-container-dashboard.png[harvester-container-dashboard]
 
@@ -72,40 +63,33 @@ To enable this new feature flag, follow these steps:
 
 image::rancher/harvester-baremetal-container-workload-feature.png[harvester-baremetal-container-workload-feature]
 
-=== Key Features
+=== Key features
 
-*Unified Dashboard View:*
-Once you've enabled the feature, you can explore the dashboard view of the Harvester cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
+* *Unified Dashboard View*: Once you've enabled the feature, you can explore the dashboard view of the {harvester-product-name} cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
 
-*Deploy Custom Workloads:*
-This feature lets you deploy custom container workloads directly to the bare-metal Harvester cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and VM workloads in separate namespaces to ensure clarity and separation.
+* *Deploy Custom Workloads*: This feature lets you deploy custom container workloads directly to the bare-metal {harvester-product-name} cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and virtual machine workloads in separate namespaces to ensure clarity and separation.
 
 [NOTE]
 ====
-* Critical system components such as monitoring, logging, Rancher, KubeVirt, and Longhorn are all managed by the Harvester cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
+* Critical system components such as monitoring, logging, {rancher-short-name}, KubeVirt, and Longhorn are all managed by the {harvester-product-name} cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
 * It is essential not to deploy any workloads to the system namespaces `cattle-system`, `harvester-system`, or `longhorn-system`. Keeping your workloads in separate namespaces is crucial to maintaining clarity and preserving the integrity of the system components.
-* For best practices, we recommend deploying container and VM workloads in separate namespaces.
+* Deploying container and virtual machine workloads in separate namespaces is recommended.
 ====
 
-[NOTE]
-====
-With this feature enabled, your Harvester cluster does not appear on the *Continuous Delivery* page in the Rancher UI. Please check the issue https://github.com/harvester/harvester/issues/4482[#4482] for further updates.
-====
+== {fleet-product-name} support (Experimental)
 
-== Fleet Support (Experimental)
-
-Starting with Rancher v2.7.9, you can leverage https://fleet.rancher.io/[Fleet] for managing container workloads and configuring Harvester with a GitOps-based approach.
+You can leverage https://documentation.suse.com/cloudnative/continuous-delivery/index.html[{fleet-product-name}] for managing container workloads and configuring {harvester-product-name} with a GitOps-based approach.
 
 [IMPORTANT]
 ====
-The Rancher feature `harvester-baremetal-container-workload` must be enabled.
+The {rancher-short-name} feature `harvester-baremetal-container-workload` must be enabled.
 ====
 
-. On the Rancher UI, go to *☰* > *Continuous Delivery*.
+. On the {rancher-short-name} UI, go to *☰ -> Continuous Delivery*.
 +
 image::rancher/continuous-delivery-overview.png[]
 
-. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group Harvester clusters.
+. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group {harvester-product-name} clusters.
 +
 In this example, the label `location=private-dc` was added.
 +
@@ -119,7 +103,7 @@ In this example, the cluster group `private-dc-clusters` is created with a clust
 +
 image::rancher/create-cluster-group.png[]
 
-. On the *Git Repos* tab, create a Git repo named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repo], with the branch defined as `main`. You must define the following paths:
+. On the *Git Repos* tab, create a Git repository named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repository], with the branch defined as `main`. You must define the following paths:
 +
 * `keypair`
 * `vmimage`
@@ -128,7 +112,7 @@ image::rancher/create-cluster-group.png[]
 +
 image::rancher/gitrepo-definition.png[]
 
-. Click *Next*, and then define the Git repo targets. You can select all clusters, an individual cluster, or a group of clusters.
+. Click *Next*, and then define the Git repository targets. You can select all clusters, an individual cluster, or a group of clusters.
 +
 In this example, the cluster group named `private-dc-clusters` is used.
 +

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -37,7 +37,7 @@ You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../
 
 [NOTE]
 ====
-Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+Rancher Kubernetes Engine (RKE) will reach the end of its life on *July 31, 2025*. {harvester-product-name} *v1.6.0* and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
 ====
 
 One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -16,7 +16,7 @@ To use {rancher-short-name} with {harvester-product-name}, you must install {ran
 
 For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -14,7 +14,7 @@ image::rancher/virtualization-management.png[virtualization-management]
 
 To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
 If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -12,7 +12,7 @@ image::rancher/virtualization-management.png[virtualization-management]
 
 == Deploying the {rancher-short-name} server
 
-To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
 For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 

--- a/versions/v1.4/antora.yml
+++ b/versions/v1.4/antora.yml
@@ -14,6 +14,7 @@ asciidoc:
     neuvector-product-name: "SUSE® Security"
     rancher-product-name: "SUSE Rancher Prime"
     rancher-product-name-tm: "SUSE® Rancher Prime"
+    rancher-short-name: "Rancher"
     elemental-product-name: "SUSE® Rancher Prime: OS Manager"
     k3s-product-name: "SUSE® Rancher Prime: K3s"
     kubewarden-product-name: "SUSE® Rancher Prime: Admission Policy Manager"

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -14,7 +14,7 @@ image::rancher/virtualization-management.png[virtualization-management]
 
 To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
 If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -37,7 +37,7 @@ You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../
 
 [NOTE]
 ====
-Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+Rancher Kubernetes Engine (RKE) will reach the end of its life on *July 31, 2025*. {harvester-product-name} *v1.6.0* and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
 ====
 
 One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,45 +1,31 @@
-= Rancher Integration
+= {rancher-product-name} Integration
 
-https://github.com/rancher/rancher[Rancher] is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
+https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-Users can import and manage multiple Harvester clusters using the Rancher xref:./virtualization-management.adoc[Virtualization Management] feature. Leveraging the Rancher's https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/authentication-config[authentication] feature and https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/manage-role-based-access-control-rbac[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
-For a comprehensive overview of the support matrix, please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Harvester & Rancher Support Matrix].
-
-For the network requirements, please refer to the doc xref:../../installation-setup/requirements.adoc#_network_requirements[here].
+Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 
 +++<div class="text-center">++++++<iframe width="950" height="475" src="https://www.youtube.com/embed/fyxDm3HVwWI" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++
 
 image::rancher/virtualization-management.png[virtualization-management]
 
-== Deploying Rancher server
+== Deploying the {rancher-short-name} server
 
-To use Rancher with Harvester, please install Rancher on a separate server. If you want to try out the integration features, you can create a VM in Harvester and install the Rancher server by following the https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Helm CLI quick start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production setup, please use one of the following guides to deploy and provision Rancher and a Kubernetes cluster with the provider of your choice:
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-* https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/deploy-rancher-manager[AWS] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace[AWS Marketplace] (uses Amazon EKS)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/azure[Azure] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean[DigitalOcean] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/gcp[GCP] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud[Hetzner Cloud] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/vagrant[Vagrant]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal[Equinix Metal]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs[Outscale] (uses Terraform)
-
-If you prefer, the following guide will take you through the same process in individual steps. Use this if you want to run Rancher with a different provider, on prem, or if you want to see how easy it is.
-
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Manual Install]
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====
-*Do not install Rancher with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing Rancher in Docker should only be used for quick evaluation and testing purposes.
+*Do not install {rancher-short-name} with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing {rancher-short-name} in Docker should only be used for quick evaluation and testing purposes.
 ====
 
 == Virtualization management
 
-With Rancher's virtualization management feature, you can import and manage your Harvester cluster. By clicking one of the imported clusters, you can easily access and manage a range of Harvester cluster resources, including hosts, VMs, images, volumes, and more. Additionally, the virtualization management feature leverages Rancher's existing capabilities, such as authentication with various auth providers and multi-tenancy support.
+With {rancher-short-name}'s virtualization management feature, you can import and manage your {harvester-product-name} cluster. By clicking one of the imported clusters, you can easily access and manage a range of {harvester-product-name} cluster resources, including hosts, virtual machines, images, volumes, and more. Additionally, the virtualization management feature leverages {rancher-short-name}'s existing capabilities, such as authentication with various auth providers and multi-tenancy support.
 
 For in-depth insights, please refer to the xref:./virtualization-management.adoc[virtualization management] page.
 
@@ -47,17 +33,22 @@ image::rancher/import-harvester-cluster.png[import-cluster]
 
 == Creating Kubernetes clusters using the Harvester node driver
 
-You can launch a Kubernetes cluster from Rancher using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When Rancher deploys Kubernetes onto these nodes, you can choose between Rancher Kubernetes Engine (RKE) or RKE2 distributions.
+You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When {rancher-short-name} deploys Kubernetes onto these nodes, choose RKE2.
 
-One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, Rancher can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+[NOTE]
+====
+Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+====
 
-Starting from Rancher version `v2.6.1`, the Harvester node driver is included by default. You can refer to the xref:../../integrations/rancher/node-driver/node-driver.adoc[node-driver] page for more details.
+One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+
+The Harvester node driver is included in {rancher-short-name} by default. For more information, see xref:../../integrations/rancher/node-driver/node-driver.adoc[Node Driver].
 
 image::rancher/harvester-node-driver.png[harvester-node-driver]
 
-== Harvester baremetal container workload support (experimental)
+== Bare-metal container workload support (Experimental)
 
-Starting with Rancher v2.7.6, Harvester introduces a new feature that enables you to deploy and manage container workloads directly to the underlying Harvester cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
+{harvester-product-name} enables you to deploy and manage container workloads directly to the underlying {harvester-product-name} cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
 
 image::rancher/harvester-container-dashboard.png[harvester-container-dashboard]
 
@@ -72,40 +63,33 @@ To enable this new feature flag, follow these steps:
 
 image::rancher/harvester-baremetal-container-workload-feature.png[harvester-baremetal-container-workload-feature]
 
-=== Key Features
+=== Key features
 
-*Unified Dashboard View:*
-Once you've enabled the feature, you can explore the dashboard view of the Harvester cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
+* *Unified Dashboard View*: Once you've enabled the feature, you can explore the dashboard view of the {harvester-product-name} cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
 
-*Deploy Custom Workloads:*
-This feature lets you deploy custom container workloads directly to the bare-metal Harvester cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and VM workloads in separate namespaces to ensure clarity and separation.
+* *Deploy Custom Workloads*: This feature lets you deploy custom container workloads directly to the bare-metal {harvester-product-name} cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and virtual machine workloads in separate namespaces to ensure clarity and separation.
 
 [NOTE]
 ====
-* Critical system components such as monitoring, logging, Rancher, KubeVirt, and Longhorn are all managed by the Harvester cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
+* Critical system components such as monitoring, logging, {rancher-short-name}, KubeVirt, and Longhorn are all managed by the {harvester-product-name} cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
 * It is essential not to deploy any workloads to the system namespaces `cattle-system`, `harvester-system`, or `longhorn-system`. Keeping your workloads in separate namespaces is crucial to maintaining clarity and preserving the integrity of the system components.
-* For best practices, we recommend deploying container and VM workloads in separate namespaces.
+* Deploying container and virtual machine workloads in separate namespaces is recommended.
 ====
 
-[NOTE]
-====
-With this feature enabled, your Harvester cluster does not appear on the *Continuous Delivery* page in the Rancher UI. Please check the issue https://github.com/harvester/harvester/issues/4482[#4482] for further updates.
-====
+== {fleet-product-name} support (Experimental)
 
-== Fleet Support (Experimental)
-
-Starting with Rancher v2.7.9, you can leverage https://fleet.rancher.io/[Fleet] for managing container workloads and configuring Harvester with a GitOps-based approach.
+You can leverage https://documentation.suse.com/cloudnative/continuous-delivery/index.html[{fleet-product-name}] for managing container workloads and configuring {harvester-product-name} with a GitOps-based approach.
 
 [IMPORTANT]
 ====
-The Rancher feature `harvester-baremetal-container-workload` must be enabled.
+The {rancher-short-name} feature `harvester-baremetal-container-workload` must be enabled.
 ====
 
-. On the Rancher UI, go to *☰* > *Continuous Delivery*.
+. On the {rancher-short-name} UI, go to *☰ -> Continuous Delivery*.
 +
 image::rancher/continuous-delivery-overview.png[]
 
-. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group Harvester clusters.
+. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group {harvester-product-name} clusters.
 +
 In this example, the label `location=private-dc` was added.
 +
@@ -119,7 +103,7 @@ In this example, the cluster group `private-dc-clusters` is created with a clust
 +
 image::rancher/create-cluster-group.png[]
 
-. On the *Git Repos* tab, create a Git repo named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repo], with the branch defined as `main`. You must define the following paths:
+. On the *Git Repos* tab, create a Git repository named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repository], with the branch defined as `main`. You must define the following paths:
 +
 * `keypair`
 * `vmimage`
@@ -128,7 +112,7 @@ image::rancher/create-cluster-group.png[]
 +
 image::rancher/gitrepo-definition.png[]
 
-. Click *Next*, and then define the Git repo targets. You can select all clusters, an individual cluster, or a group of clusters.
+. Click *Next*, and then define the Git repository targets. You can select all clusters, an individual cluster, or a group of clusters.
 +
 In this example, the cluster group named `private-dc-clusters` is used.
 +

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -12,7 +12,7 @@ image::rancher/virtualization-management.png[virtualization-management]
 
 == Deploying the {rancher-short-name} server
 
-To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
 For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -16,7 +16,7 @@ To use {rancher-short-name} with {harvester-product-name}, you must install {ran
 
 For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====

--- a/versions/v1.5/antora.yml
+++ b/versions/v1.5/antora.yml
@@ -14,6 +14,7 @@ asciidoc:
     neuvector-product-name: "SUSE® Security"
     rancher-product-name: "SUSE Rancher Prime"
     rancher-product-name-tm: "SUSE® Rancher Prime"
+    rancher-short-name: "Rancher"
     elemental-product-name: "SUSE® Rancher Prime: OS Manager"
     k3s-product-name: "SUSE® Rancher Prime: K3s"
     kubewarden-product-name: "SUSE® Rancher Prime: Admission Policy Manager"

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,45 +1,31 @@
-= Rancher Integration
+= {rancher-product-name} Integration
 
-https://github.com/rancher/rancher[Rancher] is an open-source multi-cluster management platform. Starting with Rancher v2.6.1, Rancher has integrated Harvester by default to centrally manage VMs and containers.
+https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-Users can import and manage multiple Harvester clusters using the Rancher xref:./virtualization-management.adoc[Virtualization Management] feature. Leveraging the Rancher's https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/authentication-config[authentication] feature and https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/manage-role-based-access-control-rbac[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s' https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
-For a comprehensive overview of the support matrix, please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Harvester & Rancher Support Matrix].
-
-For the network requirements, please refer to the doc xref:../../installation-setup/requirements.adoc#_network_requirements[here].
+Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 
 +++<div class="text-center">++++++<iframe width="950" height="475" src="https://www.youtube.com/embed/fyxDm3HVwWI" title="YouTube video player" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen="">++++++</iframe>++++++</div>+++
 
 image::rancher/virtualization-management.png[virtualization-management]
 
-== Deploying Rancher server
+== Deploying the {rancher-short-name} server
 
-To use Rancher with Harvester, please install Rancher on a separate server. If you want to try out the integration features, you can create a VM in Harvester and install the Rancher server by following the https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Helm CLI quick start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production setup, please use one of the following guides to deploy and provision Rancher and a Kubernetes cluster with the provider of your choice:
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-* https://ranchermanager.docs.rancher.com/v2.7/pages-for-subheaders/deploy-rancher-manager[AWS] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/aws-marketplace[AWS Marketplace] (uses Amazon EKS)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/azure[Azure] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/digitalocean[DigitalOcean] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/gcp[GCP] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/hetzner-cloud[Hetzner Cloud] (uses Terraform)
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/vagrant[Vagrant]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/equinix-metal[Equinix Metal]
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/outscale-qs[Outscale] (uses Terraform)
-
-If you prefer, the following guide will take you through the same process in individual steps. Use this if you want to run Rancher with a different provider, on prem, or if you want to see how easy it is.
-
-* https://ranchermanager.docs.rancher.com/v2.7/getting-started/quick-start-guides/deploy-rancher-manager/helm-cli[Manual Install]
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====
-*Do not install Rancher with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing Rancher in Docker should only be used for quick evaluation and testing purposes.
+*Do not install {rancher-short-name} with Docker in production*. Otherwise, your environment may be damaged, and your cluster may not be able to be recovered. Installing {rancher-short-name} in Docker should only be used for quick evaluation and testing purposes.
 ====
 
 == Virtualization management
 
-With Rancher's virtualization management feature, you can import and manage your Harvester cluster. By clicking one of the imported clusters, you can easily access and manage a range of Harvester cluster resources, including hosts, VMs, images, volumes, and more. Additionally, the virtualization management feature leverages Rancher's existing capabilities, such as authentication with various auth providers and multi-tenancy support.
+With {rancher-short-name}'s virtualization management feature, you can import and manage your {harvester-product-name} cluster. By clicking one of the imported clusters, you can easily access and manage a range of {harvester-product-name} cluster resources, including hosts, virtual machines, images, volumes, and more. Additionally, the virtualization management feature leverages {rancher-short-name}'s existing capabilities, such as authentication with various auth providers and multi-tenancy support.
 
 For in-depth insights, please refer to the xref:./virtualization-management.adoc[virtualization management] page.
 
@@ -47,17 +33,22 @@ image::rancher/import-harvester-cluster.png[import-cluster]
 
 == Creating Kubernetes clusters using the Harvester node driver
 
-You can launch a Kubernetes cluster from Rancher using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When Rancher deploys Kubernetes onto these nodes, you can choose between Rancher Kubernetes Engine (RKE) or RKE2 distributions.
+You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver]. When {rancher-short-name} deploys Kubernetes onto these nodes, choose RKE2.
 
-One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, Rancher can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+[NOTE]
+====
+Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+====
 
-Starting from Rancher version `v2.6.1`, the Harvester node driver is included by default. You can refer to the xref:../../integrations/rancher/node-driver/node-driver.adoc[node-driver] page for more details.
+One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.
+
+The Harvester node driver is included in {rancher-short-name} by default. For more information, see xref:../../integrations/rancher/node-driver/node-driver.adoc[Node Driver].
 
 image::rancher/harvester-node-driver.png[harvester-node-driver]
 
-== Harvester baremetal container workload support (experimental)
+== Bare-metal container workload support (Experimental)
 
-Starting with Rancher v2.7.6, Harvester introduces a new feature that enables you to deploy and manage container workloads directly to the underlying Harvester cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
+{harvester-product-name} enables you to deploy and manage container workloads directly to the underlying {harvester-product-name} cluster. With this feature, you can seamlessly combine the power of virtual machines with the flexibility of containerization, allowing for a more versatile and efficient infrastructure setup.
 
 image::rancher/harvester-container-dashboard.png[harvester-container-dashboard]
 
@@ -72,40 +63,33 @@ To enable this new feature flag, follow these steps:
 
 image::rancher/harvester-baremetal-container-workload-feature.png[harvester-baremetal-container-workload-feature]
 
-=== Key Features
+=== Key features
 
-*Unified Dashboard View:*
-Once you've enabled the feature, you can explore the dashboard view of the Harvester cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
+* *Unified Dashboard View*: Once you've enabled the feature, you can explore the dashboard view of the {harvester-product-name} cluster, just like you would with other standard Kubernetes clusters. This unified experience simplifies the management and monitoring of both your virtual machines and container workloads from a single, user-friendly interface.
 
-*Deploy Custom Workloads:*
-This feature lets you deploy custom container workloads directly to the bare-metal Harvester cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and VM workloads in separate namespaces to ensure clarity and separation.
+* *Deploy Custom Workloads*: This feature lets you deploy custom container workloads directly to the bare-metal {harvester-product-name} cluster. While this functionality is experimental, it introduces exciting possibilities for optimizing your infrastructure. However, we recommend deploying container and virtual machine workloads in separate namespaces to ensure clarity and separation.
 
 [NOTE]
 ====
-* Critical system components such as monitoring, logging, Rancher, KubeVirt, and Longhorn are all managed by the Harvester cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
+* Critical system components such as monitoring, logging, {rancher-short-name}, KubeVirt, and Longhorn are all managed by the {harvester-product-name} cluster itself. You can't upgrade or modify these components. Therefore, exercise caution and avoid making changes to these critical system components.
 * It is essential not to deploy any workloads to the system namespaces `cattle-system`, `harvester-system`, or `longhorn-system`. Keeping your workloads in separate namespaces is crucial to maintaining clarity and preserving the integrity of the system components.
-* For best practices, we recommend deploying container and VM workloads in separate namespaces.
+* Deploying container and virtual machine workloads in separate namespaces is recommended.
 ====
 
-[NOTE]
-====
-With this feature enabled, your Harvester cluster does not appear on the *Continuous Delivery* page in the Rancher UI. Please check the issue https://github.com/harvester/harvester/issues/4482[#4482] for further updates.
-====
+== {fleet-product-name} support (Experimental)
 
-== Fleet Support (Experimental)
-
-Starting with Rancher v2.7.9, you can leverage https://fleet.rancher.io/[Fleet] for managing container workloads and configuring Harvester with a GitOps-based approach.
+You can leverage https://documentation.suse.com/cloudnative/continuous-delivery/index.html[{fleet-product-name}] for managing container workloads and configuring {harvester-product-name} with a GitOps-based approach.
 
 [IMPORTANT]
 ====
-The Rancher feature `harvester-baremetal-container-workload` must be enabled.
+The {rancher-short-name} feature `harvester-baremetal-container-workload` must be enabled.
 ====
 
-. On the Rancher UI, go to *☰* > *Continuous Delivery*.
+. On the {rancher-short-name} UI, go to *☰ -> Continuous Delivery*.
 +
 image::rancher/continuous-delivery-overview.png[]
 
-. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group Harvester clusters.
+. (Optional) On the *Clusters* tab, edit the Fleet cluster config to add labels that can be used to group {harvester-product-name} clusters.
 +
 In this example, the label `location=private-dc` was added.
 +
@@ -119,7 +103,7 @@ In this example, the cluster group `private-dc-clusters` is created with a clust
 +
 image::rancher/create-cluster-group.png[]
 
-. On the *Git Repos* tab, create a Git repo named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repo], with the branch defined as `main`. You must define the following paths:
+. On the *Git Repos* tab, create a Git repository named `harvester-config` that points to the https://github.com/harvester/harvester-fleet-examples[harvester-fleet-examples repository], with the branch defined as `main`. You must define the following paths:
 +
 * `keypair`
 * `vmimage`
@@ -128,7 +112,7 @@ image::rancher/create-cluster-group.png[]
 +
 image::rancher/gitrepo-definition.png[]
 
-. Click *Next*, and then define the Git repo targets. You can select all clusters, an individual cluster, or a group of clusters.
+. Click *Next*, and then define the Git repository targets. You can select all clusters, an individual cluster, or a group of clusters.
 +
 In this example, the cluster group named `private-dc-clusters` is used.
 +

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -2,7 +2,7 @@
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 
-You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/latest/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
+You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 
 Before performing any deployment steps, check the xref:../../installation-setup/requirements.adoc#_network_requirements[network requirements].
 
@@ -12,11 +12,11 @@ image::rancher/virtualization-management.png[virtualization-management]
 
 == Deploying the {rancher-short-name} server
 
-To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
+To use {rancher-short-name} with {harvester-product-name}, you must install {rancher-short-name} on a separate server. If you want to try the integration features, you can create a virtual machine in {harvester-product-name} and install the {rancher-short-name} server by following the https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/quick-start/deploy-rancher/helm-cli.html[Helm CLI Quick Start].
 
-For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
+For production environments, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/quick-start/deploy-rancher/deploy-rancher.html[deploy {rancher-short-name} and provision a Kubernetes cluster] in various cloud providers.
 
-If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/latest/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
+If you want to run {rancher-short-name} on-premises or with a provider not listed in the documentation, you can https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/http-proxy/install-rancher.html#_install_the_helm_cli[install the Helm CLI] and then install {rancher-short-name} using Helm.
 
 [CAUTION]
 ====

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -37,7 +37,7 @@ You can launch a Kubernetes cluster from {rancher-short-name} using the xref:../
 
 [NOTE]
 ====
-Rancher Kubernetes Engine (RKE) will reach the end of its life on **July 31, 2025**. {harvester-product-name} **v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
+Rancher Kubernetes Engine (RKE) will reach the end of its life on *July 31, 2025*. {harvester-product-name} *v1.6.0** and later versions will not support RKE. Using {rke2-product-name}, which provides a more secure and efficient environment, is recommended.
 ====
 
 One benefit of installing Kubernetes on node pools hosted by the node driver is that if a node loses connectivity with the cluster, {rancher-short-name} can automatically create another node to join the cluster to ensure that the count of the node pool is as expected.


### PR DESCRIPTION
Related issues: #58 and #63 
Scope: v1.3.0, v1.4.0, v1.5.0
Changes:
- `versions/v1.3/modules/en/nav.adoc`: Add `Upgrade from v.1.3.2 > v1.4.0` xref.
- `versions/v1.x/modules/en/pages/integrations/rancher/rancher-integration.adoc`: Replace community doc links. Replace project names with product name variables. Apply related changes from community PRs [767](https://github.com/harvester/docs/pull/767) and [768](https://github.com/harvester/docs/pull/768).
- `versions/v1.x/antora.yml`: Add `rancher-short-name`.