### PR TITLE
Update metadata to reflect release of v1.5

### DIFF
--- a/playbook-local.yml
+++ b/playbook-local.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Virtualization 
   url: /
-  start_page: v1.4@virtualization:en:introduction/overview.adoc
+  start_page: v1.5@virtualization:en:introduction/overview.adoc
 content:
   sources:
   - url: ./

--- a/playbook-remote.yml
+++ b/playbook-remote.yml
@@ -1,7 +1,7 @@
 site:
   title: SUSE® Virtualization
   url: /
-  start_page: v1.4@virtualization:en:introduction/overview.adoc
+  start_page: v1.5@virtualization:en:introduction/overview.adoc
   robots: disallow
 content:
   sources: 

--- a/versions/v1.4/antora.yml
+++ b/versions/v1.4/antora.yml
@@ -1,7 +1,7 @@
 name: virtualization
 title: SUSE® Virtualization
 version: v1.4
-display_version: v1.4 (Latest)
+display_version: v1.4
 start_page: en:introduction/overview.adoc
 nav:
 - modules/en/nav.adoc

--- a/versions/v1.5/antora.yml
+++ b/versions/v1.5/antora.yml
@@ -1,7 +1,7 @@
 name: virtualization
 title: SUSE® Virtualization
 version: v1.5
-prerelease: (Dev)
+display_version: v1.5 (Latest)
 start_page: en:introduction/overview.adoc
 nav:
 - modules/en/nav.adoc


### PR DESCRIPTION
[Harvester v1.5.0](https://github.com/harvester/harvester/releases/tag/v1.5.0) was released late April, but it's still designated as a dev/prerelease.