### PR TITLE
Mark v1.6 as prelease

### DIFF
--- a/versions/v1.6/antora.yml
+++ b/versions/v1.6/antora.yml
@@ -1,7 +1,7 @@
 name: virtualization
 title: SUSE® Virtualization
 version: v1.6
-display_version: v1.6 (Dev)
+prerelease: (Dev)
 start_page: en:introduction/overview.adoc
 nav:
 - modules/en/nav.adoc


### PR DESCRIPTION
Set v1.6 as a prerelease so that it's taken into consideration during Antora's routing calculations and the per-page "unreleased" banner is rendered.