### PR TITLE
Replace community doc URLs and project names (Installation and Setup)

### DIFF
--- a/versions/v1.3/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use {harvester-product-name} in an air gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -36,17 +36,17 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 All necessary images to install and run {harvester-product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {harvester-product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest Kubernetes cluster (for example, a {rke2-product-name} cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester Node Driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/rancher-admin/global-configuration/global-default-private-registry.html#_configure_a_private_registry_with_credentials_when_creating_a_cluster[private registry].
 
-If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester Cloud Provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 
-As a result, we recommend monitoring each https://github.com/rancher/rke2/releases[RKE2 release] in your air gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-1-2/[Support Matrix page] for the best Harvester cloud provider and CSI driver capability support.
+As a result, we recommend monitoring each RKE2 release in your air-gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Support Matrix] for the best Harvester Cloud Provider and CSI driver capability support.
 
-== Integrate with an External Rancher
+== Integrate with an External {rancher-short-name}
 
-Rancher determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
+{rancher-short-name} determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
 
 [,bash]
 ----
@@ -63,13 +63,13 @@ sudo -i
 docker load -i /tmp/rancher-agent-<version>.tar
 ----
 
-== Harvester UI Extension with Rancher Integration
+== Harvester UI Extension with {rancher-short-name} Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the {harvester-product-name} UI in {rancher-short-name} v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 . Pull the image https://hub.docker.com/r/rancher/ui-plugin-catalog/tags[rancher/ui-plugin-catalog] with the newest tag.
 
-. On the Rancher UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
+. On the {rancher-short-name} UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-01.png[Rancher UI - Manage Extension Catalogs]
 
@@ -102,7 +102,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-03.png[Rancher UI - Extensi
 +
 image::air-gapped/air-gappted-harvester-ui-extension-04.png[Rancher UI - Available Extensions]
 
-. Select the version that matches the Harvester cluster, and then click *Install*.
+. Select the version that matches the {harvester-product-name} cluster, and then click *Install*.
 +
 For more information, see the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension Support Matrix].
 +
@@ -112,7 +112,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-06.png[Rancher UI - Harvest
 
 . Go to *Virtualization Management -> Harvester Clusters*.
 +
-You can now import Harvester clusters and access the Harvester UI.
+You can now import {harvester-product-name} clusters and access the {harvester-product-name} UI.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-07.png[Rancher UI - Harvester Clusters]
 
@@ -155,4 +155,4 @@ spec:
     endpoint: http://ui-plugin-catalog-svc.cattle-ui-plugin-system:8080/plugin/harvester-1.0.3
 ----
 
-Ensure that `svc.namespace` is accessible from Rancher. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.
+Ensure that `svc.namespace` is accessible from {rancher-short-name}. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.

--- a/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -135,4 +135,4 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 
 Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.
+You are encouraged to leverage https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.

--- a/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -549,8 +549,6 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://longhorn.io/docs/archives/1.4.1/references/settings/#guaranteed-engine-manager-cpu[Guaranteed Engine Manager CPU] in the Longhorn documentation.
-
 *Default value*: 12
 
 *Supported values*: 0 to 12. All other values are considered 12.
@@ -571,8 +569,6 @@ install:
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Replica Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
-
-For more information about how to set the correct value, see https://longhorn.io/docs/archives/1.4.1/references/settings/#guaranteed-replica-manager-cpu[Guaranteed Replica Manager CPU] in the Longhorn documentation.
 
 *Default value*: 12
 
@@ -595,7 +591,7 @@ install:
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
@@ -46,13 +46,11 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 === `auto-rotate-rke2-certs`
 
-*Versions*: v1.3.0 and later
-
-*Definition*: Setting that allows you to automatically rotate certificates for RKE2 services. This setting is disabled by default.
+*Definition*: Setting that allows you to automatically rotate certificates for {rke2-product-name} services. This setting is disabled by default.
 
 Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). The certificate is automatically replaced before the specified period ends.
 
-For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[{rancher-product-name}] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
+For more information, see the *Certificate Rotation* section of the https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/cluster-admin/manage-clusters/rotate-certificates.html[{rancher-product-name}] and https://documentation.suse.com/cloudnative/rke2/latest/en/advanced.html#_certificate_rotation[{rke2-product-name}] documentation.
 
 *Default value*: `{"enable":false,"expiringInHours":240}`
 
@@ -66,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://ranc
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-aws-s3-backupstore[Longhorn documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.7.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 
@@ -90,7 +88,7 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version].
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
@@ -111,7 +109,7 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 *Definition*: Configuration of a private registry created for the {harvester-product-name} cluster.
 
-The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/private_registry[Containerd Registry Configuration] in the RKE2 documentation.
+The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://documentation.suse.com/cloudnative/rke2/latest/en/install/containerd_registry_configuration.html[Containerd Registry Configuration] in the {rke2-product-name} documentation.
 
 For security purposes, {harvester-product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
@@ -273,7 +271,7 @@ With the default values, it would be possible to schedule the following:
 
 * 16x the number of physical CPUs on a host
 * 1.5x the amount of physical RAM on a host
-* 2x the amount of physical storage in Longhorn
+* 2x the amount of physical storage in {longhorn-product-name}
 
 A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {harvester-product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
@@ -373,9 +371,9 @@ If you do not specify any values, {harvester-product-name} uses `TLSv1.2` and `E
 
 === `storage-network`
 
-*Definition*: Segregated storage network for Longhorn traffic.
+*Definition*: Segregated storage network for {longhorn-product-name} traffic.
 
-By default, Longhorn uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate Longhorn in-cluster data traffic.
+By default, {longhorn-product-name} uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate {longhorn-product-name} in-cluster data traffic.
 
 [IMPORTANT]
 .important
@@ -557,8 +555,6 @@ You can specify a value greater than or equal to 0. When the value is 0, {harves
 *Default value*: `30`
 
 === `support-bundle-node-collection-timeout`
-
-*Versions*: v1.3.1 and later
 
 *Definition*: Number of minutes {harvester-product-name} allows for collection of logs and configurations on the nodes for the support bundle.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
@@ -46,7 +46,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 ====
 
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
-* Nested virtualization is not supported on virtual machines running on Harvester.
+* Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
@@ -217,12 +217,12 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 
 If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with {rancher-product-name}], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the {rancher-product-name} load balancer.
 
-When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/about-rancher/architecture/communicating-with-downstream-clusters.html[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
 For the port requirements for guest clusters deployed inside {harvester-product-name} VMs, refer to the following links:
 
-* https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
-* https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]
-* https://docs.rke2.io/install/requirements#networking[RKE2 Networking]
+* https://docs.k3s.io/installation/requirements#networking[K3s Networking]
+* https://rke.docs.rancher.com/os#ports[RKE Ports]
+* https://documentation.suse.com/cloudnative/rke2/latest/en/install/requirements.html#_networking[RKE2 Networking]

--- a/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -16,9 +16,9 @@ Before you begin deploying your single-node cluster, ensure that the following r
 
 == Replica Count of the Default StorageClass
 
-{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, {longhorn-product-name} is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
@@ -27,14 +27,14 @@ To avoid this issue, you can perform either of the following actions:
 
 == Multiple Replicas on a Node with Multiple Disks
 
-Longhorn creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
+{longhorn-product-name} creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
 
 In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redundancy. However, this same mechanism can cause volumes to become degraded in single-node clusters (since no other nodes are available for scheduling of new replicas).
 
-If you want Longhorn to create multiple replicas on a node with multiple disks, perform the following steps:
+If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://longhorn.io/docs/1.7.0/references/settings/#replica-node-level-soft-anti-affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, Longhorn schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://longhorn.io/docs/1.7.0/references/settings/#replica-disk-level-soft-anti-affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, Longhorn does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use {harvester-product-name} in an air gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -36,17 +36,17 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 All necessary images to install and run {harvester-product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {harvester-product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest Kubernetes cluster (for example, a {rke2-product-name} cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester Node Driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/rancher-admin/global-configuration/global-default-private-registry.html#_configure_a_private_registry_with_credentials_when_creating_a_cluster[private registry].
 
-If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester Cloud Provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 
-As a result, we recommend monitoring each https://github.com/rancher/rke2/releases[RKE2 release] in your air gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-1-2/[Support Matrix page] for the best Harvester cloud provider and CSI driver capability support.
+As a result, we recommend monitoring each RKE2 release in your air-gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Support Matrix] for the best Harvester Cloud Provider and CSI driver capability support.
 
-== Integrate with an External Rancher
+== Integrate with an External {rancher-short-name}
 
-Rancher determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
+{rancher-short-name} determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
 
 [,bash]
 ----
@@ -63,13 +63,13 @@ sudo -i
 docker load -i /tmp/rancher-agent-<version>.tar
 ----
 
-== Harvester UI Extension with Rancher Integration
+== Harvester UI Extension with {rancher-short-name} Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the {harvester-product-name} UI in {rancher-short-name} v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 . Pull the image https://hub.docker.com/r/rancher/ui-plugin-catalog/tags[rancher/ui-plugin-catalog] with the newest tag.
 
-. On the Rancher UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
+. On the {rancher-short-name} UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-01.png[Rancher UI - Manage Extension Catalogs]
 
@@ -102,7 +102,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-03.png[Rancher UI - Extensi
 +
 image::air-gapped/air-gappted-harvester-ui-extension-04.png[Rancher UI - Available Extensions]
 
-. Select the version that matches the Harvester cluster, and then click *Install*.
+. Select the version that matches the {harvester-product-name} cluster, and then click *Install*.
 +
 For more information, see the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension Support Matrix].
 +
@@ -112,7 +112,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-06.png[Rancher UI - Harvest
 
 . Go to *Virtualization Management -> Harvester Clusters*.
 +
-You can now import Harvester clusters and access the Harvester UI.
+You can now import {harvester-product-name} clusters and access the {harvester-product-name} UI.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-07.png[Rancher UI - Harvester Clusters]
 
@@ -163,4 +163,4 @@ spec:
     endpoint: http://ui-plugin-catalog-svc.cattle-ui-plugin-system:8080/plugin/harvester-1.0.3
 ----
 
-Ensure that `svc.namespace` is accessible from Rancher. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.
+Ensure that `svc.namespace` is accessible from {rancher-short-name}. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -135,4 +135,4 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 
 Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.
+You are encouraged to leverage https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -545,13 +545,11 @@ install:
 
 === `install.harvester.longhorn.default_settings.guaranteedInstanceManagerCPU`
 
-*Versions*: v1.4.0 and later
-
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Instance Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://longhorn.io/docs/1.6.0/references/settings/#guaranteed-instance-manager-cpu[Guaranteed Instance Manager CPU] in the Longhorn documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -572,7 +570,7 @@ For more information about how to set the correct value, see https://longhorn.io
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -46,13 +46,11 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 === `auto-rotate-rke2-certs`
 
-*Versions*: v1.3.0 and later
-
-*Definition*: Setting that allows you to automatically rotate certificates for RKE2 services. This setting is disabled by default.
+*Definition*: Setting that allows you to automatically rotate certificates for {rke2-product-name} services. This setting is disabled by default.
 
 Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). The certificate is automatically replaced before the specified period ends.
 
-For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[{rancher-product-name}] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
+For more information, see the *Certificate Rotation* section of the https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/cluster-admin/manage-clusters/rotate-certificates.html[{rancher-product-name}] and https://documentation.suse.com/cloudnative/rke2/latest/en/advanced.html#_certificate_rotation[{rke2-product-name}] documentation.
 
 *Default value*: `{"enable":false,"expiringInHours":240}`
 
@@ -66,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://ranc
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-aws-s3-backupstore[Longhorn documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.7.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 
@@ -90,7 +88,7 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version].
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
@@ -111,7 +109,7 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 *Definition*: Configuration of a private registry created for the {harvester-product-name} cluster.
 
-The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/private_registry[Containerd Registry Configuration] in the RKE2 documentation.
+The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://documentation.suse.com/cloudnative/rke2/latest/en/install/containerd_registry_configuration.html[Containerd Registry Configuration] in the {rke2-product-name} documentation.
 
 For security purposes, {harvester-product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
@@ -245,7 +243,7 @@ debug
 
 When set to `true`, {harvester-product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
 
-Changing this setting automatically restarts RKE2 on all nodes but does not affect running virtual machine workloads.
+Changing this setting automatically restarts {rke2-product-name} on all nodes but does not affect running virtual machine workloads.
 
 [TIP]
 ====
@@ -301,7 +299,7 @@ With the default values, it would be possible to schedule the following:
 
 * 16x the number of physical CPUs on a host
 * 1.5x the amount of physical RAM on a host
-* 2x the amount of physical storage in Longhorn
+* 2x the amount of physical storage in {longhorn-product-name}
 
 A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {harvester-product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
@@ -401,9 +399,9 @@ If you do not specify any values, {harvester-product-name} uses `TLSv1.2` and `E
 
 === `storage-network`
 
-*Definition*: Segregated storage network for Longhorn traffic.
+*Definition*: Segregated storage network for {longhorn-product-name} traffic.
 
-By default, Longhorn uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate Longhorn in-cluster data traffic.
+By default, {longhorn-product-name} uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate {longhorn-product-name} in-cluster data traffic.
 
 [IMPORTANT]
 .important
@@ -656,7 +654,7 @@ The default value is `0`, which is equivalent to following the cluster's node co
 +
 [NOTE]
 ====
-{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for Longhorn.
+{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for {longhorn-product-name}.
 ====
 +
 * `restoreVM`: Option that enables {harvester-product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {harvester-product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -46,7 +46,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 ====
 
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
-* Nested virtualization is not supported on virtual machines running on Harvester.
+* Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
@@ -228,15 +228,15 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 
 If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with {rancher-product-name}], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the {rancher-product-name} load balancer.
 
-When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/about-rancher/architecture/communicating-with-downstream-clusters.html[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
 For the port requirements for guest clusters deployed inside {harvester-product-name} VMs, refer to the following links:
 
-* https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
-* https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]
-* https://docs.rke2.io/install/requirements#networking[RKE2 Networking]
+* https://docs.k3s.io/installation/requirements#networking[K3s Networking]
+* https://rke.docs.rancher.com/os#ports[RKE Ports]
+* https://documentation.suse.com/cloudnative/rke2/latest/en/install/requirements.html#_networking[RKE2 Networking]
 
 == Time Requirements
 

--- a/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -16,9 +16,9 @@ Before you begin deploying your single-node cluster, ensure that the following r
 
 == Replica Count of the Default StorageClass
 
-{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, {longhorn-product-name} is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
@@ -27,14 +27,14 @@ To avoid this issue, you can perform either of the following actions:
 
 == Multiple Replicas on a Node with Multiple Disks
 
-Longhorn creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
+{longhorn-product-name} creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
 
 In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redundancy. However, this same mechanism can cause volumes to become degraded in single-node clusters (since no other nodes are available for scheduling of new replicas).
 
-If you want Longhorn to create multiple replicas on a node with multiple disks, perform the following steps:
+If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://longhorn.io/docs/1.7.0/references/settings/#replica-node-level-soft-anti-affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, Longhorn schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://longhorn.io/docs/1.7.0/references/settings/#replica-disk-level-soft-anti-affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, Longhorn does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.5/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use {harvester-product-name} in an air gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -36,17 +36,17 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 All necessary images to install and run {harvester-product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {harvester-product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest Kubernetes cluster (for example, a {rke2-product-name} cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester Node Driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/global-configuration/global-default-private-registry.html#_configure_a_private_registry_with_credentials_when_creating_a_cluster[private registry].
 
-If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester Cloud Provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 
-As a result, we recommend monitoring each https://github.com/rancher/rke2/releases[RKE2 release] in your air gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-1-2/[Support Matrix page] for the best Harvester cloud provider and CSI driver capability support.
+As a result, we recommend monitoring each RKE2 release in your air-gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Support Matrix] for the best Harvester Cloud Provider and CSI driver capability support.
 
-== Integrate with an External Rancher
+== Integrate with an External {rancher-short-name}
 
-Rancher determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
+{rancher-short-name} determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
 
 [,bash]
 ----
@@ -63,13 +63,13 @@ sudo -i
 docker load -i /tmp/rancher-agent-<version>.tar
 ----
 
-== Harvester UI Extension with Rancher Integration
+== Harvester UI Extension with {rancher-short-name} Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the {harvester-product-name} UI in {rancher-short-name} v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 . Pull the image https://hub.docker.com/r/rancher/ui-plugin-catalog/tags[rancher/ui-plugin-catalog] with the newest tag.
 
-. On the Rancher UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
+. On the {rancher-short-name} UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-01.png[Rancher UI - Manage Extension Catalogs]
 
@@ -102,7 +102,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-03.png[Rancher UI - Extensi
 +
 image::air-gapped/air-gappted-harvester-ui-extension-04.png[Rancher UI - Available Extensions]
 
-. Select the version that matches the Harvester cluster, and then click *Install*.
+. Select the version that matches the {harvester-product-name} cluster, and then click *Install*.
 +
 For more information, see the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension Support Matrix].
 +
@@ -112,7 +112,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-06.png[Rancher UI - Harvest
 
 . Go to *Virtualization Management -> Harvester Clusters*.
 +
-You can now import Harvester clusters and access the Harvester UI.
+You can now import {harvester-product-name} clusters and access the {harvester-product-name} UI.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-07.png[Rancher UI - Harvester Clusters]
 
@@ -163,4 +163,4 @@ spec:
     endpoint: http://ui-plugin-catalog-svc.cattle-ui-plugin-system:8080/plugin/harvester-1.0.3
 ----
 
-Ensure that `svc.namespace` is accessible from Rancher. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.
+Ensure that `svc.namespace` is accessible from {rancher-short-name}. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.

--- a/versions/v1.5/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -135,4 +135,4 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 
 Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.
+You are encouraged to leverage https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.

--- a/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -548,13 +548,11 @@ install:
 
 === `install.harvester.longhorn.default_settings.guaranteedInstanceManagerCPU`
 
-*Versions*: v1.4.0 and later
-
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Instance Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://longhorn.io/docs/1.6.0/references/settings/#guaranteed-instance-manager-cpu[Guaranteed Instance Manager CPU] in the Longhorn documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -575,7 +573,7 @@ For more information about how to set the correct value, see https://longhorn.io
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
@@ -46,13 +46,11 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 === `auto-rotate-rke2-certs`
 
-*Versions*: v1.3.0 and later
-
-*Definition*: Setting that allows you to automatically rotate certificates for RKE2 services. This setting is disabled by default.
+*Definition*: Setting that allows you to automatically rotate certificates for {rke2-product-name} services. This setting is disabled by default.
 
 Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). The certificate is automatically replaced before the specified period ends.
 
-For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[{rancher-product-name}] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
+For more information, see the *Certificate Rotation* section of the https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-admin/manage-clusters/rotate-certificates.html[{rancher-product-name}] and https://documentation.suse.com/cloudnative/rke2/latest/en/advanced.html#_certificate_rotation[{rke2-product-name}] documentation.
 
 *Default value*: `{"enable":false,"expiringInHours":240}`
 
@@ -66,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://ranc
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-aws-s3-backupstore[Longhorn documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.8.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 
@@ -90,7 +88,7 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version].
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
@@ -111,7 +109,7 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 *Definition*: Configuration of a private registry created for the {harvester-product-name} cluster.
 
-The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/private_registry[Containerd Registry Configuration] in the RKE2 documentation.
+The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://documentation.suse.com/cloudnative/rke2/latest/en/install/containerd_registry_configuration.html[Containerd Registry Configuration] in the {rke2-product-name} documentation.
 
 For security purposes, {harvester-product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
@@ -243,7 +241,7 @@ debug
 
 When set to `true`, {harvester-product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
 
-Changing this setting automatically restarts RKE2 on all nodes but does not affect running virtual machine workloads.
+Changing this setting automatically restarts {rke2-product-name} on all nodes but does not affect running virtual machine workloads.
 
 [TIP]
 ====
@@ -299,7 +297,7 @@ With the default values, it would be possible to schedule the following:
 
 * 16x the number of physical CPUs on a host
 * 1.5x the amount of physical RAM on a host
-* 2x the amount of physical storage in Longhorn
+* 2x the amount of physical storage in {longhorn-product-name}
 
 A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {harvester-product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
@@ -399,9 +397,9 @@ If you do not specify any values, {harvester-product-name} uses `TLSv1.2` and `E
 
 === `storage-network`
 
-*Definition*: Segregated storage network for Longhorn traffic.
+*Definition*: Segregated storage network for {longhorn-product-name} traffic.
 
-By default, Longhorn uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate Longhorn in-cluster data traffic.
+By default, {longhorn-product-name} uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate {longhorn-product-name} in-cluster data traffic.
 
 [IMPORTANT]
 .important
@@ -654,7 +652,7 @@ The default value is `0`, which is equivalent to following the cluster's node co
 +
 [NOTE]
 ====
-{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for Longhorn.
+{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for {longhorn-product-name}.
 ====
 +
 * `restoreVM`: Option that enables {harvester-product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {harvester-product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.

--- a/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
@@ -46,7 +46,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 ====
 * Mixed-architecture clusters are not supported. Deploy separate clusters to avoid unexpected system behavior.
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
-* Nested virtualization is not supported on virtual machines running on Harvester.
+* Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
@@ -228,15 +228,15 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 
 If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with {rancher-product-name}], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the {rancher-product-name} load balancer.
 
-When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/about-rancher/architecture/communicating-with-downstream-clusters.html[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
 For the port requirements for guest clusters deployed inside {harvester-product-name} VMs, refer to the following links:
 
-* https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
-* https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]
-* https://docs.rke2.io/install/requirements#networking[RKE2 Networking]
+* https://docs.k3s.io/installation/requirements#networking[K3s Networking]
+* https://rke.docs.rancher.com/os#ports[RKE Ports]
+* https://documentation.suse.com/cloudnative/rke2/latest/en/install/requirements.html#_networking[RKE2 Networking]
 
 == Time Requirements
 

--- a/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -16,9 +16,9 @@ Before you begin deploying your single-node cluster, ensure that the following r
 
 == Replica Count of the Default StorageClass
 
-{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, {longhorn-product-name} is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
@@ -27,14 +27,14 @@ To avoid this issue, you can perform either of the following actions:
 
 == Multiple Replicas on a Node with Multiple Disks
 
-Longhorn creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
+{longhorn-product-name} creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
 
 In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redundancy. However, this same mechanism can cause volumes to become degraded in single-node clusters (since no other nodes are available for scheduling of new replicas).
 
-If you want Longhorn to create multiple replicas on a node with multiple disks, perform the following steps:
+If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://longhorn.io/docs/1.7.0/references/settings/#replica-node-level-soft-anti-affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, Longhorn schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://longhorn.io/docs/1.7.0/references/settings/#replica-disk-level-soft-anti-affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, Longhorn does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.6/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/airgap.adoc
@@ -1,6 +1,6 @@
 = Air-Gapped Environment
 
-This section describes how to use {harvester-product-name} in an air gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
+This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 
 The ISO image contains all the packages to make it work in an air gapped environment.
 
@@ -36,17 +36,17 @@ When the nodes in the cluster do not use a proxy to communicate with each other,
 
 All necessary images to install and run {harvester-product-name} are conveniently packaged into the ISO, eliminating the need to pre-load images on bare-metal nodes. A {harvester-product-name} cluster manages them independently and effectively behind the scenes.
 
-However, it's essential to understand a guest K8s cluster (e.g., RKE2 cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester node driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/authentication-permissions-and-global-configuration/global-default-private-registry#configure-a-private-registry-with-credentials-when-creating-a-cluster[private registry].
+However, it's essential to understand a guest Kubernetes cluster (for example, a {rke2-product-name} cluster) created by the xref:../integrations/rancher/node-driver/node-driver.adoc[Harvester Node Driver] is a distinct entity from a {harvester-product-name} cluster. A guest cluster operates within VMs and requires pulling images either from the internet or a https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/global-configuration/global-default-private-registry.html#_configure_a_private_registry_with_credentials_when_creating_a_cluster[private registry].
 
-If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester cloud provider and Container Storage Interface (CSI) driver.
+If the *Cloud Provider* option is configured to {harvester-product-name} in a guest Kubernetes cluster, it deploys the Harvester Cloud Provider and Container Storage Interface (CSI) driver.
 
 image::cluster-registry.png[cluster-registry]
 
-As a result, we recommend monitoring each https://github.com/rancher/rke2/releases[RKE2 release] in your air gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/harvester-v1-1-2/[Support Matrix page] for the best Harvester cloud provider and CSI driver capability support.
+As a result, we recommend monitoring each RKE2 release in your air-gapped environment and pulling the required images into your private registry. Please refer to the https://www.suse.com/suse-harvester/support-matrix/all-supported-versions/[Support Matrix] for the best Harvester Cloud Provider and CSI driver capability support.
 
-== Integrate with an External Rancher
+== Integrate with an External {rancher-short-name}
 
-Rancher determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
+{rancher-short-name} determines the `rancher-agent` image to be used whenever a {harvester-product-name} cluster is imported. If the image is not included in the {harvester-product-name} ISO, it must be pulled from the internet and loaded on each node, or pushed to the {harvester-product-name} cluster's registry.
 
 [,bash]
 ----
@@ -63,13 +63,13 @@ sudo -i
 docker load -i /tmp/rancher-agent-<version>.tar
 ----
 
-== Harvester UI Extension with Rancher Integration
+== Harvester UI Extension with {rancher-short-name} Integration
 
-The Harvester UI Extension is required to access the Harvester UI in Rancher v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
+The Harvester UI Extension is required to access the {harvester-product-name} UI in {rancher-short-name} v2.10.x and later versions. However, installing the extension over the network is not possible in air-gapped environments, so you must perform the following workaround:
 
 . Pull the image https://hub.docker.com/r/rancher/ui-plugin-catalog/tags[rancher/ui-plugin-catalog] with the newest tag.
 
-. On the Rancher UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
+. On the {rancher-short-name} UI, go to *Extensions*, and then select *⋮ -> Manage Extension Catalogs*.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-01.png[Rancher UI - Manage Extension Catalogs]
 
@@ -102,7 +102,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-03.png[Rancher UI - Extensi
 +
 image::air-gapped/air-gappted-harvester-ui-extension-04.png[Rancher UI - Available Extensions]
 
-. Select the version that matches the Harvester cluster, and then click *Install*.
+. Select the version that matches the {harvester-product-name} cluster, and then click *Install*.
 +
 For more information, see the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension Support Matrix].
 +
@@ -112,7 +112,7 @@ image::air-gapped/air-gappted-harvester-ui-extension-06.png[Rancher UI - Harvest
 
 . Go to *Virtualization Management -> Harvester Clusters*.
 +
-You can now import Harvester clusters and access the Harvester UI.
+You can now import {harvester-product-name} clusters and access the {harvester-product-name} UI.
 +
 image::air-gapped/air-gappted-harvester-ui-extension-07.png[Rancher UI - Harvester Clusters]
 
@@ -163,4 +163,4 @@ spec:
     endpoint: http://ui-plugin-catalog-svc.cattle-ui-plugin-system:8080/plugin/harvester-1.0.3
 ----
 
-Ensure that `svc.namespace` is accessible from Rancher. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.
+Ensure that `svc.namespace` is accessible from {rancher-short-name}. If that endpoint is not accessible, you can directly use a cluster IP such as `10.43.33.58:8080/plugin/harvester-1.0.3`.

--- a/versions/v1.6/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -135,4 +135,4 @@ Once the cloud-init changes are applied, you must reboot the nodes to ensure tha
 
 Deleting the `CloudInit` CRD results in the removal of associated files from the underlying nodes. As with other cloud-init resources, the effects of this change are not exhibited until the impacted nodes are rebooted.
 
-You are encouraged to leverage https://fleet.rancher.io[Fleet] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.
+You are encouraged to leverage https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}] and the `CloudInit` CRD to manage changes to the {harvester-product-name} operating system.

--- a/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -548,13 +548,11 @@ install:
 
 === `install.harvester.longhorn.default_settings.guaranteedInstanceManagerCPU`
 
-*Versions*: v1.4.0 and later
-
 *Definition*: Percentage of the total allocatable CPU on each node to be reserved for each Longhorn Instance Manager pod.
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://longhorn.io/docs/1.6.0/references/settings/#guaranteed-instance-manager-cpu[Guaranteed Instance Manager CPU] in the Longhorn documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -575,7 +573,7 @@ For more information about how to set the correct value, see https://longhorn.io
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://longhorn.io/docs/1.6.0/references/settings/#default-replica-count[Default Replica Count] in the Longhorn documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
@@ -46,13 +46,11 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 === `auto-rotate-rke2-certs`
 
-*Versions*: v1.3.0 and later
-
-*Definition*: Setting that allows you to automatically rotate certificates for RKE2 services. This setting is disabled by default.
+*Definition*: Setting that allows you to automatically rotate certificates for {rke2-product-name} services. This setting is disabled by default.
 
 Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). The certificate is automatically replaced before the specified period ends.
 
-For more information, see the *Certificate Rotation* section of the https://ranchermanager.docs.rancher.com/how-to-guides/new-user-guides/manage-clusters/rotate-certificates[{rancher-product-name}] and https://docs.rke2.io/advanced#certificate-rotation[RKE2] documentation.
+For more information, see the *Certificate Rotation* section of the https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-admin/manage-clusters/rotate-certificates.html[{rancher-product-name}] and https://documentation.suse.com/cloudnative/rke2/latest/en/advanced.html#_certificate_rotation[{rke2-product-name}] documentation.
 
 *Default value*: `{"enable":false,"expiringInHours":240}`
 
@@ -66,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://ranc
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backups/backup-and-restore/set-backup-target/#set-up-aws-s3-backupstore[Longhorn documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.8.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 
@@ -90,7 +88,7 @@ For more information, see the https://longhorn.io/docs/1.6.0/snapshots-and-backu
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://ranchermanager.docs.rancher.com/getting-started/installation-and-upgrade/other-installation-methods/air-gapped-helm-cli-install/publish-images#1-find-the-required-assets-for-your-rancher-version[Find the required assets for your Rancher version].
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
@@ -111,7 +109,7 @@ https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhr
 
 *Definition*: Configuration of a private registry created for the {harvester-product-name} cluster.
 
-The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://docs.rke2.io/install/private_registry[Containerd Registry Configuration] in the RKE2 documentation.
+The value is stored in the `registries.yaml` file of each node (path: `/etc/rancher/rke2/registries.yaml`). For more information, see https://documentation.suse.com/cloudnative/rke2/latest/en/install/containerd_registry_configuration.html[Containerd Registry Configuration] in the {rke2-product-name} documentation.
 
 For security purposes, {harvester-product-name} automatically removes the username and password configured for the private registry after those credentials are stored in the `registries.yaml` file.
 
@@ -243,7 +241,7 @@ debug
 
 When set to `true`, {harvester-product-name} automatically loads the kernel modules required by the Longhorn V2 Data Engine, and attempts to allocate 1024 × 2 MiB-sized huge pages (for example, 2 GiB of RAM) on all nodes. 
 
-Changing this setting automatically restarts RKE2 on all nodes but does not affect running virtual machine workloads.
+Changing this setting automatically restarts {rke2-product-name} on all nodes but does not affect running virtual machine workloads.
 
 [TIP]
 ====
@@ -299,7 +297,7 @@ With the default values, it would be possible to schedule the following:
 
 * 16x the number of physical CPUs on a host
 * 1.5x the amount of physical RAM on a host
-* 2x the amount of physical storage in Longhorn
+* 2x the amount of physical storage in {longhorn-product-name}
 
 A VM that is configured to use 2 CPUs (equivalent to 2,000 milliCPU) can consume the full allocation as long as the resources are available. However, if the host is running heavy workloads and an overcommit value is set (for example, 1600%), {harvester-product-name} only requests 125 milliCPU from the Kubernetes scheduler (2000/16 = 125 milliCPU).
 
@@ -399,9 +397,9 @@ If you do not specify any values, {harvester-product-name} uses `TLSv1.2` and `E
 
 === `storage-network`
 
-*Definition*: Segregated storage network for Longhorn traffic.
+*Definition*: Segregated storage network for {longhorn-product-name} traffic.
 
-By default, Longhorn uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate Longhorn in-cluster data traffic.
+By default, {longhorn-product-name} uses the management network, which is limited to a single interface and shared with cluster-wide workloads. If your implementation requires network segregation, you can use a xref:../../networking/storage-network.adoc[storage network] to isolate {longhorn-product-name} in-cluster data traffic.
 
 [IMPORTANT]
 .important
@@ -654,7 +652,7 @@ The default value is `0`, which is equivalent to following the cluster's node co
 +
 [NOTE]
 ====
-{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for Longhorn.
+{harvester-product-name} deploys an upgrade-repo service on the cluster that serves as an HTTP server for nodes that need to preload the container images. When a `concurrency` value is set, each batch of nodes downloads the container images from this upgrade-repo in parallel. Because of this, you must consider the speed of the {harvester-product-name} management network and the read speed of the default disk for {longhorn-product-name}.
 ====
 +
 * `restoreVM`: Option that enables {harvester-product-name} to automatically restore running virtual machines after a single-node cluster is upgraded. The default value is `false`, which causes all virtual machines to be stopped after the upgrade is completed. When set to `true`, {harvester-product-name} restarts virtual machines that were running before the upgrade was started. Virtual machines that were paused before the upgrade are not restarted.

--- a/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
@@ -46,7 +46,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 ====
 * Mixed-architecture clusters are not supported. Deploy separate clusters to avoid unexpected system behavior.
 * For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
-* Nested virtualization is not supported on virtual machines running on Harvester.
+* Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].
 * During testing, you can use only one NIC for the xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`), and for testing the xref:../networking/vm-network.adoc#_create_a_vm_network[VM network] that is also carried by `mgmt`. High availability and optimal performance are not guaranteed.
@@ -228,15 +228,15 @@ Nodes require the following port connections or inbound rules. Typically, all ou
 
 If you want to xref:../integrations/rancher/rancher-integration.adoc[integrate with {rancher-product-name}], you need to make sure that all {harvester-product-name} nodes can connect to TCP port *443* of the {rancher-product-name} load balancer.
 
-When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://ranchermanager.docs.rancher.com/v2.7/reference-guides/rancher-manager-architecture/communicating-with-downstream-user-clusters[Rancher Architecture].
+When provisioning VMs with Kubernetes clusters from {rancher-product-name} into {harvester-product-name}, you need to be able to connect to TCP port *443* of the {rancher-product-name} load balancer. Otherwise, the cluster won't be manageable by {rancher-product-name}. For more information, refer to https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/about-rancher/architecture/communicating-with-downstream-clusters.html[Rancher Architecture].
 
 === Port Requirements for K3s or RKE/RKE2 Clusters
 
 For the port requirements for guest clusters deployed inside {harvester-product-name} VMs, refer to the following links:
 
-* https://rancher.com/docs/k3s/latest/en/installation/installation-requirements/#networking[K3s Networking]
-* https://rancher.com/docs/rke/latest/en/os/#ports[RKE Ports]
-* https://docs.rke2.io/install/requirements#networking[RKE2 Networking]
+* https://docs.k3s.io/installation/requirements#networking[K3s Networking]
+* https://rke.docs.rancher.com/os#ports[RKE Ports]
+* https://documentation.suse.com/cloudnative/rke2/latest/en/install/requirements.html#_networking[RKE2 Networking]
 
 == Time Requirements
 

--- a/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -16,9 +16,9 @@ Before you begin deploying your single-node cluster, ensure that the following r
 
 == Replica Count of the Default StorageClass
 
-{harvester-product-name} uses StorageClasses to describe how Longhorn must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
+{harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. Each StorageClass has a parameter that defines the number of replicas to be created for each volume.
 
-The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, Longhorn is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
+The default StorageClass `harvester-longhorn` has a replica count value of *3* for high availability. If you use `harvester-longhorn` in your single-node cluster, {longhorn-product-name} is unable to create the default number of replicas, and volumes are marked as _Degraded_ on the *Volumes* screen of the UI.
 
 To avoid this issue, you can perform either of the following actions:
 
@@ -27,14 +27,14 @@ To avoid this issue, you can perform either of the following actions:
 
 == Multiple Replicas on a Node with Multiple Disks
 
-Longhorn creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
+{longhorn-product-name} creates only one replica for each volume even if the node has multiple disks because *Replica Hard Anti-Affinity* is enabled by default. When a healthy replica already exists on a node, the scheduler is prevented from scheduling new replicas of the same volume on the node.
 
 In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redundancy. However, this same mechanism can cause volumes to become degraded in single-node clusters (since no other nodes are available for scheduling of new replicas).
 
-If you want Longhorn to create multiple replicas on a node with multiple disks, perform the following steps:
+If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://longhorn.io/docs/1.7.0/references/settings/#replica-node-level-soft-anti-affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, Longhorn schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://longhorn.io/docs/1.7.0/references/settings/#replica-disk-level-soft-anti-affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, Longhorn does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance


### PR DESCRIPTION
Related issue: [#77](https://github.com/rancher/harvester-product-docs/issues/77)

Scope: v1.3, v1.4, v1.5, v1.6
- `installation-setup/airgap.adoc`
- `installation-setup/requirements.adoc`
- `installation-setup/single-node-clusters.adoc`
- `installation-setup/config/cloudinitcrd.adoc`
- `installation-setup/config/configuration-file.adoc`
- `installation-setup/config/settings.adoc`

Changes:
- Replace community doc URLs with product doc URLs
- Replace community project names with product name variables
- Standardize capitalization of component names (Note: Component names that include "Harvester" will not be rebranded for now. I need more guidance from the PM group.)
