### PR TITLE
Replace community doc URLs and project names (Hosts, Monitoring, Troubleshooting, Development)

### DIFF
--- a/versions/v1.3/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/hosts.adoc
@@ -85,13 +85,13 @@ Removing a control plane node in this situation is not recommended because etcd 
 
 === 2. Check the status of volumes.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Volume* screen.
 . Verify that the state of all volumes is *Healthy*.
 
 === 3. Evict replicas from the node to be removed.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Node* screen.
 . Select the node that you want to remove, click the icon in the *Operation* column, and then select *Edit node and disks*.
 . Configure the following settings:
@@ -224,7 +224,7 @@ If you are testing {harvester-product-name} in a QEMU environment, you'll need t
 
 === Storage Tags
 
-The storage tag feature enables only certain nodes or disks to be used for storing Longhorn volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
+The storage tag feature enables only certain nodes or disks to be used for storing {longhorn-product-name} volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
 
 This feature supports both disks and nodes.
 
@@ -246,7 +246,7 @@ When multiple tags are specified for a volume, the disk and the nodes (that the 
 
 === Remove disks
 
-Before removing a disk, you must first evict Longhorn replicas on the disk.
+Before removing a disk, you must first evict {longhorn-product-name} replicas on the disk.
 
 [NOTE]
 ====
@@ -261,10 +261,10 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 image::host/remove-disks-harvester-find-disk.png[Find disk to remove]
 
-==== Evict replicas (Longhorn dashboard)
+==== Evict replicas ({longhorn-product-name} dashboard)
 
-. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded Longhorn dashboard.
-. Visit the Longhorn dashboard and go to the *Node* page.
+. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded {longhorn-product-name} dashboard.
+. Visit the {longhorn-product-name} dashboard and go to the *Node* page.
 . Expand the node containing the disk. Confirm the mount point `/var/lib/harvester/extra-disks/1b805b97eb5aa724e6be30cbdb373d04` is in the disks list.
 +
 image::host/remove-disks-longhorn-nodes.png[Check the removing disk]
@@ -306,7 +306,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constrai
 +
 . Click *Save*.
 
-The label is automatically synchronized with the corresponding Longhorn node.
+The label is automatically synchronized with the corresponding {longhorn-product-name} node.
 
 == Ksmtuned Mode
 
@@ -436,7 +436,7 @@ image::host/harvester-ntp-settings-empty.png[]
 
 You may need to customize one or more nodes after installing {harvester-product-name}. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
 
-These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
+These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}].
 
 [WARNING]
 ====

--- a/versions/v1.3/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/observability/monitoring.adoc
@@ -1,16 +1,12 @@
 = Monitoring
 
-The monitoring feature is now implemented with an addon and is disabled by default in new installations.
+The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 
-Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.
-
-Users can also enable/disable the `rancher-monitoring` addon in their Harvester installation by customizing the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
-
-For Harvester clusters upgraded from version v1.1.x, the monitoring feature is converted to an addon automatically and kept enabled as before.
+You can enable and disable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] after installation using the {harvester-product-name} UI or the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
 
 == Dashboard Metrics
 
-Harvester has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during the Harvester installations.
+{harvester-product-name} has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during installation.
 
 From the `Dashboard` page, users can view the cluster metrics and top 10 most used VM metrics respectively.
 Also, users can click the http://grafana.com/[Grafana] dashboard link to view more dashboards on the Grafana UI.
@@ -48,9 +44,7 @@ The corresponding `Memory Usage` is `(1 - 4.6/7.7) * 100%`, roughly `40%`.
 
 == How to Configure Monitoring Settings
 
-_Available as of v1.0.2_
-
-Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. Harvester sets defaults based on general use cases, and you can change them accordingly.
+Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. {harvester-product-name} sets defaults based on general use cases, and you can change them accordingly.
 
 Currently, `Resources Settings` can be configured for the following components:
 
@@ -121,7 +115,7 @@ You can still make configuration adjustments when the addon is disabled. However
 
 == Alertmanager
 
-`Harvester` uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
+{harvester-product-name} uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
 
 === Alertmanager Config
 
@@ -174,9 +168,9 @@ helm install rancher-charts/rancher-alerting-drivers \
   --generate-name
 ----
 
-For detailed configuration instructions, see https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration/receivers[Rancher Monitoring Receiver Configuration] in the Rancher documentation.
+For detailed configuration instructions, see https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/observability/monitoring-and-dashboards/configuration/receivers.html[Receiver Configuration] in the {rancher-short-name} documentation.
 
-If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the Harvester cluster.
+If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the {harvester-product-name} cluster.
 
 . Download the rancher-alerting-drivers Helm chart and package it.
 +
@@ -191,20 +185,20 @@ docker save -o sachet.tar rancher/mirrored-messagebird-sachet:<VERSION>
 docker save -o prom2teams.tar rancher/mirrored-idealista-prom2teams:<VERSION>
 ----
 
-. Upload the chart and images to the Harvester cluster.
+. Upload the chart and images to the {harvester-product-name} cluster.
 
-. Load the images on all Harvester nodes.
+. Load the images on all {harvester-product-name} nodes.
 +
 ----
 docker load -i sachet.tar
 docker load -i prom2teams.tar
 ----
 
-. Install rancher-alerting-drivers on the Harvester cluster.
+. Install rancher-alerting-drivers on the {harvester-product-name} cluster.
 
 [IMPORTANT]
 ====
-Harvester does not manage upgrades of the rancher-alerting-drivers app, which is not part of the Harvester project. You must upgrade the app manually.
+{harvester-product-name} does not manage upgrades of the `rancher-alerting-drivers` app, which is not part of {harvester-product-name}. You must upgrade the app manually.
 ====
 
 ==== Configure AlertmanagerConfig from CLI
@@ -275,7 +269,7 @@ Different receivers may present the alerts in different formats. For details, pl
 
 The `AlertmanagerConfig` is enforced by the `namespace`. Gloabl-level `AlertmanagerConfig` without a namespace is not supported.
 
-We have already created a https://github.com/harvester/harvester/issues/2760[GithHb issue] to track upstream changes. Once the feature is available, `Harvester` will adopt it.
+We have already created a https://github.com/harvester/harvester/issues/2760[GitHub issue] to track upstream changes. Once the feature is available, {harvester-product-name} will adopt it.
 
 === View and Manage Alerts
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
@@ -2,11 +2,11 @@
 
 == Monitoring is unusable
 
-When the Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
+When the {harvester-product-name} Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
 
 === Monitoring is unusable due to Pod being stuck in `Terminating` status
 
-Harvester Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
+{harvester-product-name} Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
 
 [,shell]
 ----
@@ -64,19 +64,19 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 == Expand PV/Volume Size
 
-`Harvester` integrates `Longhorn` as the default storage provider.
+{harvester-product-name} integrates {longhorn-product-name} as the default storage provider.
 
-Harvester `Monitoring` uses `Persistent Volume (PV)` to store running data. When a cluster has been running for a certain time, the `Persistent Volume` may need to expand its size.
+{harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-Based on the `Longhorn` `Volume` expansion guide, `Harvester` illustrates how to https://longhorn.io/docs/1.3.2/volumes-and-nodes/expansion/[expand the volume size].
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 
-==== From Embedded Longhorn WebUI
+==== From Embedded {longhorn-product-name} UI
 
-Access the embedded Longhorn WebUI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
+Access the embedded {longhorn-product-name} UI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
 
-The Longhorn dashboard default view.
+The {longhorn-product-name} dashboard default view.
 
 image::troubleshooting/2-longhorn-dashboard.png[]
 
@@ -144,11 +144,11 @@ longhorn-system   pvc-b2b2c07c-f7cd-4965-90e6-ac3319597bf7   detached   unknown 
 
 === Expand Volume
 
-In the Longhorn WebUI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
+In the {longhorn-product-name} UI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
 
 image::troubleshooting/4-select-volume-to-expand.png[]
 
-Input a new size, and `Longhorn` will expand the volume to this size.
+Input a new size, and {longhorn-product-name} will expand the volume to this size.
 
 image::troubleshooting/5-expand-volue-to-new-size.png[]
 
@@ -179,12 +179,12 @@ To now, the `Volume` is expanded to the new size and the POD is using it smoothl
 
 == Fail to Enable `rancher-monitoring` Addon
 
-You may encounter this when you install the Harvester v1.3.0 or higher version cluster with the minimal 250 GB disk per xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements].
+You may encounter this when you install {harvester-product-name} v1.3.0 or later on a cluster with the xref:../installation-setup/requirements.adoc#_hardware_requirements[minimum required disk size].
 
 === Reproduce Steps
 
-. Install the Harvester v1.3.0 cluster.
-. Enable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[addon], you will observe:
+. Install the {harvester-product-name} cluster.
+. Enable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on], you will observe:
 
 * The POD `prometheus-rancher-monitoring-prometheus-0` in `cattle-monitoring-system` namespace fails to start due to PVC attached failed.
 +
@@ -223,7 +223,7 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
   longhorn-system   pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0   v1            detached   unknown                  53687091200            6m55s
 ----
 
-* The Longhorn manager is unable to schedule the replica.
+* The Longhorn Manager is unable to schedule the replica.
 +
 ----
   $ kubectl logs -n longhorn-system longhorn-manager-bf65b | grep "pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0"
@@ -263,7 +263,7 @@ All pods in `cattle-monitoring-system` are deleted but the PVCs are retained. Fo
  alertmanager-rancher-monitoring-alertmanager-db-alertmanager-rancher-monitoring-alertmanager-0   Bound    pvc-cea6316e-f74f-4771-870b-49edb5442819   5Gi        RWO            harvester-longhorn   16m
 ----
 
-. On the *Addons* screen of the Harvester UI, select *⋮* (menu icon) and then select *Edit YAML*.
+. On the *Addons* screen of the {harvester-product-name} UI, select *⋮* (menu icon) and then select *Edit YAML*.
 +
 image::troubleshooting/edit-rancher-monitoring.png[]
 
@@ -365,7 +365,7 @@ Example:
  fleet-local   mcc-rancher-logging-crd                       1/1
  fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
 
-When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], {harvester-product-name} may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
 
 Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
 

--- a/versions/v1.4/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/hosts.adoc
@@ -96,13 +96,13 @@ Removing a control plane node in this situation is not recommended because etcd 
 
 === 2. Check the status of volumes.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Volume* screen.
 . Verify that the state of all volumes is *Healthy*.
 
 === 3. Evict replicas from the node to be removed.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Node* screen.
 . Select the node that you want to remove, click the icon in the *Operation* column, and then select *Edit node and disks*.
 . Configure the following settings:
@@ -231,7 +231,7 @@ image::host/multidisk-mgmt-05.png[Provisioner LVM]
 
 . On the host details screen, verify that the disks were added and the correct provisioner was set.
 +
-You can also add <<Storage Tags,storage tags>> if you want Longhorn volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
+You can also add <<Storage Tags,storage tags>> if you want {longhorn-product-name} volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
 +
 image::host/multidisk-mgmt-06.png[Disk tag 01]
 +
@@ -250,7 +250,7 @@ If you are testing {harvester-product-name} in a QEMU environment, you'll need t
 
 === Storage Tags
 
-The storage tag feature enables only certain nodes or disks to be used for storing Longhorn volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
+The storage tag feature enables only certain nodes or disks to be used for storing {longhorn-product-name} volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
 
 This feature supports both disks and nodes.
 
@@ -272,7 +272,7 @@ When multiple tags are specified for a volume, the disk and the nodes (that the 
 
 === Remove disks
 
-Before removing a disk, you must first evict Longhorn replicas on the disk.
+Before removing a disk, you must first evict {longhorn-product-name} replicas on the disk.
 
 [NOTE]
 ====
@@ -287,10 +287,10 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 image::host/remove-disks-harvester-find-disk.png[Find disk to remove]
 
-==== Evict replicas (Longhorn dashboard)
+==== Evict replicas ({longhorn-product-name} dashboard)
 
-. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded Longhorn dashboard.
-. Visit the Longhorn dashboard and go to the *Node* page.
+. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded {longhorn-product-name} dashboard.
+. Visit the {longhorn-product-name} dashboard and go to the *Node* page.
 . Expand the node containing the disk. Confirm the mount point `/var/lib/harvester/extra-disks/1b805b97eb5aa724e6be30cbdb373d04` is in the disks list.
 +
 image::host/remove-disks-longhorn-nodes.png[Check the removing disk]
@@ -332,7 +332,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constrai
 +
 . Click *Save*.
 
-The label is automatically synchronized with the corresponding Longhorn node.
+The label is automatically synchronized with the corresponding {longhorn-product-name} node.
 
 == Ksmtuned Mode
 
@@ -462,7 +462,7 @@ image::host/harvester-ntp-settings-empty.png[]
 
 You may need to customize one or more nodes after installing {harvester-product-name}. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
 
-These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
+These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}].
 
 [WARNING]
 ====

--- a/versions/v1.4/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/observability/monitoring.adoc
@@ -1,16 +1,12 @@
 = Monitoring
 
-The monitoring feature is now implemented with an addon and is disabled by default in new installations.
+The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 
-Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.
-
-Users can also enable/disable the `rancher-monitoring` addon in their Harvester installation by customizing the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
-
-For Harvester clusters upgraded from version v1.1.x, the monitoring feature is converted to an addon automatically and kept enabled as before.
+You can enable and disable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] after installation using the {harvester-product-name} UI or the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
 
 == Dashboard Metrics
 
-Harvester has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during the Harvester installations.
+{harvester-product-name} has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during installation.
 
 From the `Dashboard` page, users can view the cluster metrics and top 10 most used VM metrics respectively.
 Also, users can click the http://grafana.com/[Grafana] dashboard link to view more dashboards on the Grafana UI.
@@ -34,7 +30,6 @@ image::monitoring/vm-metrics.png[]
 
 [NOTE]
 ====
-
 The current `Memory Usage` is calculated based on `(1 - free/total) * 100%`, not `(used/total) * 100%`.
 ====
 
@@ -49,9 +44,7 @@ The corresponding `Memory Usage` is `(1 - 4.6/7.7) * 100%`, roughly `40%`.
 
 == How to Configure Monitoring Settings
 
-_Available as of v1.0.2_
-
-Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. Harvester sets defaults based on general use cases, and you can change them accordingly.
+Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. {harvester-product-name} sets defaults based on general use cases, and you can change them accordingly.
 
 Currently, `Resources Settings` can be configured for the following components:
 
@@ -122,7 +115,7 @@ You can still make configuration adjustments when the addon is disabled. However
 
 == Alertmanager
 
-`Harvester` uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
+{harvester-product-name} uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
 
 === Alertmanager Config
 
@@ -175,9 +168,9 @@ helm install rancher-charts/rancher-alerting-drivers \
   --generate-name
 ----
 
-For detailed configuration instructions, see https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration/receivers[Rancher Monitoring Receiver Configuration] in the Rancher documentation.
+For detailed configuration instructions, see https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/observability/monitoring-and-dashboards/configuration/receivers.html[Receiver Configuration] in the {rancher-short-name} documentation.
 
-If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the Harvester cluster.
+If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the {harvester-product-name} cluster.
 
 . Download the rancher-alerting-drivers Helm chart and package it.
 +
@@ -192,20 +185,20 @@ docker save -o sachet.tar rancher/mirrored-messagebird-sachet:<VERSION>
 docker save -o prom2teams.tar rancher/mirrored-idealista-prom2teams:<VERSION>
 ----
 
-. Upload the chart and images to the Harvester cluster.
+. Upload the chart and images to the {harvester-product-name} cluster.
 
-. Load the images on all Harvester nodes.
+. Load the images on all {harvester-product-name} nodes.
 +
 ----
 docker load -i sachet.tar
 docker load -i prom2teams.tar
 ----
 
-. Install rancher-alerting-drivers on the Harvester cluster.
+. Install rancher-alerting-drivers on the {harvester-product-name} cluster.
 
 [IMPORTANT]
 ====
-Harvester does not manage upgrades of the rancher-alerting-drivers app, which is not part of the Harvester project. You must upgrade the app manually.
+{harvester-product-name} does not manage upgrades of the `rancher-alerting-drivers` app, which is not part of {harvester-product-name}. You must upgrade the app manually.
 ====
 
 ==== Configure AlertmanagerConfig from CLI
@@ -276,7 +269,7 @@ Different receivers may present the alerts in different formats. For details, pl
 
 The `AlertmanagerConfig` is enforced by the `namespace`. Gloabl-level `AlertmanagerConfig` without a namespace is not supported.
 
-We have already created a https://github.com/harvester/harvester/issues/2760[GithHb issue] to track upstream changes. Once the feature is available, `Harvester` will adopt it.
+We have already created a https://github.com/harvester/harvester/issues/2760[GitHub issue] to track upstream changes. Once the feature is available, {harvester-product-name} will adopt it.
 
 === View and Manage Alerts
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -2,11 +2,11 @@
 
 == Monitoring is unusable
 
-When the Harvester Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
+When the {harvester-product-name} Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
 
 === Monitoring is unusable due to Pod being stuck in `Terminating` status
 
-Harvester Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
+{harvester-product-name} Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
 
 [,shell]
 ----
@@ -64,19 +64,19 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 == Expand PV/Volume Size
 
-`Harvester` integrates `Longhorn` as the default storage provider.
+{harvester-product-name} integrates {longhorn-product-name} as the default storage provider.
 
-Harvester `Monitoring` uses `Persistent Volume (PV)` to store running data. When a cluster has been running for a certain time, the `Persistent Volume` may need to expand its size.
+{harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-Based on the `Longhorn` `Volume` expansion guide, `Harvester` illustrates how to https://longhorn.io/docs/1.3.2/volumes-and-nodes/expansion/[expand the volume size].
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 
-==== From Embedded Longhorn WebUI
+==== From Embedded {longhorn-product-name} UI
 
-Access the embedded Longhorn WebUI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
+Access the embedded {longhorn-product-name} UI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
 
-The Longhorn dashboard default view.
+The {longhorn-product-name} dashboard default view.
 
 image::troubleshooting/2-longhorn-dashboard.png[]
 
@@ -144,11 +144,11 @@ longhorn-system   pvc-b2b2c07c-f7cd-4965-90e6-ac3319597bf7   detached   unknown 
 
 === Expand Volume
 
-In the Longhorn WebUI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
+In the {longhorn-product-name} UI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
 
 image::troubleshooting/4-select-volume-to-expand.png[]
 
-Input a new size, and `Longhorn` will expand the volume to this size.
+Input a new size, and {longhorn-product-name} will expand the volume to this size.
 
 image::troubleshooting/5-expand-volue-to-new-size.png[]
 
@@ -179,11 +179,11 @@ To now, the `Volume` is expanded to the new size and the POD is using it smoothl
 
 == Fail to Enable `rancher-monitoring` Addon
 
-You may encounter this when you install the Harvester v1.3.0 or higher version cluster with the minimal 250 GB disk per xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements].
+You may encounter this when you install {harvester-product-name} v1.3.0 or later on a cluster with the xref:../installation-setup/requirements.adoc#_hardware_requirements[minimum required disk size].
 
 === Reproduce Steps
 
-. Install the Harvester v1.3.0 cluster.
+. Install the {harvester-product-name} cluster.
 . Enable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on], you will observe:
 
 * The POD `prometheus-rancher-monitoring-prometheus-0` in `cattle-monitoring-system` namespace fails to start due to PVC attached failed.
@@ -223,7 +223,7 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
   longhorn-system   pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0   v1            detached   unknown                  53687091200            6m55s
 ----
 
-* The Longhorn manager is unable to schedule the replica.
+* The Longhorn Manager is unable to schedule the replica.
 +
 ----
   $ kubectl logs -n longhorn-system longhorn-manager-bf65b | grep "pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0"
@@ -263,7 +263,7 @@ All pods in `cattle-monitoring-system` are deleted but the PVCs are retained. Fo
  alertmanager-rancher-monitoring-alertmanager-db-alertmanager-rancher-monitoring-alertmanager-0   Bound    pvc-cea6316e-f74f-4771-870b-49edb5442819   5Gi        RWO            harvester-longhorn   16m
 ----
 
-. On the *Addons* screen of the Harvester UI, select *⋮* (menu icon) and then select *Edit YAML*.
+. On the *Addons* screen of the {harvester-product-name} UI, select *⋮* (menu icon) and then select *Edit YAML*.
 +
 image::troubleshooting/edit-rancher-monitoring.png[]
 
@@ -365,7 +365,7 @@ Example:
  fleet-local   mcc-rancher-logging-crd                       1/1
  fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
 
-When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], {harvester-product-name} may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
 
 Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
 

--- a/versions/v1.5/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.5/modules/en/pages/hosts/hosts.adoc
@@ -96,13 +96,13 @@ Removing a control plane node in this situation is not recommended because etcd 
 
 === 2. Check the status of volumes.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Volume* screen.
 . Verify that the state of all volumes is *Healthy*.
 
 === 3. Evict replicas from the node to be removed.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Node* screen.
 . Select the node that you want to remove, click the icon in the *Operation* column, and then select *Edit node and disks*.
 . Configure the following settings:
@@ -231,7 +231,7 @@ image::host/multidisk-mgmt-05.png[Provisioner LVM]
 
 . On the host details screen, verify that the disks were added and the correct provisioner was set.
 +
-You can also add <<Storage Tags,storage tags>> if you want Longhorn volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
+You can also add <<Storage Tags,storage tags>> if you want {longhorn-product-name} volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
 +
 image::host/multidisk-mgmt-06.png[Disk tag 01]
 +
@@ -250,7 +250,7 @@ If you are testing {harvester-product-name} in a QEMU environment, you'll need t
 
 === Storage Tags
 
-The storage tag feature enables only certain nodes or disks to be used for storing Longhorn volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
+The storage tag feature enables only certain nodes or disks to be used for storing {longhorn-product-name} volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
 
 This feature supports both disks and nodes.
 
@@ -272,7 +272,7 @@ When multiple tags are specified for a volume, the disk and the nodes (that the 
 
 === Remove disks
 
-Before removing a disk, you must first evict Longhorn replicas on the disk.
+Before removing a disk, you must first evict {longhorn-product-name} replicas on the disk.
 
 [NOTE]
 ====
@@ -287,10 +287,10 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 image::host/remove-disks-harvester-find-disk.png[Find disk to remove]
 
-==== Evict replicas (Longhorn dashboard)
+==== Evict replicas ({longhorn-product-name} dashboard)
 
-. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded Longhorn dashboard.
-. Visit the Longhorn dashboard and go to the *Node* page.
+. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded {longhorn-product-name} dashboard.
+. Visit the {longhorn-product-name} dashboard and go to the *Node* page.
 . Expand the node containing the disk. Confirm the mount point `/var/lib/harvester/extra-disks/1b805b97eb5aa724e6be30cbdb373d04` is in the disks list.
 +
 image::host/remove-disks-longhorn-nodes.png[Check the removing disk]
@@ -332,7 +332,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constrai
 +
 . Click *Save*.
 
-The label is automatically synchronized with the corresponding Longhorn node.
+The label is automatically synchronized with the corresponding {longhorn-product-name} node.
 
 == Ksmtuned Mode
 
@@ -462,7 +462,7 @@ image::host/harvester-ntp-settings-empty.png[]
 
 You may need to customize one or more nodes after installing {harvester-product-name}. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
 
-These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
+These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}].
 
 [WARNING]
 ====

--- a/versions/v1.5/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/observability/monitoring.adoc
@@ -1,16 +1,12 @@
 = Monitoring
 
-The monitoring feature is now implemented with an addon and is disabled by default in new installations.
+The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 
-Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.
-
-Users can also enable/disable the `rancher-monitoring` addon in their Harvester installation by customizing the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
-
-For Harvester clusters upgraded from version v1.1.x, the monitoring feature is converted to an addon automatically and kept enabled as before.
+You can enable and disable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] after installation using the {harvester-product-name} UI or the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
 
 == Dashboard Metrics
 
-Harvester has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during the Harvester installations.
+{harvester-product-name} has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during installation.
 
 From the `Dashboard` page, users can view the cluster metrics and top 10 most used VM metrics respectively.
 Also, users can click the http://grafana.com/[Grafana] dashboard link to view more dashboards on the Grafana UI.
@@ -34,7 +30,6 @@ image::monitoring/vm-metrics.png[]
 
 [NOTE]
 ====
-
 The current `Memory Usage` is calculated based on `(1 - free/total) * 100%`, not `(used/total) * 100%`.
 ====
 
@@ -49,9 +44,7 @@ The corresponding `Memory Usage` is `(1 - 4.6/7.7) * 100%`, roughly `40%`.
 
 == How to Configure Monitoring Settings
 
-_Available as of v1.0.2_
-
-Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. Harvester sets defaults based on general use cases, and you can change them accordingly.
+Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. {harvester-product-name} sets defaults based on general use cases, and you can change them accordingly.
 
 Currently, `Resources Settings` can be configured for the following components:
 
@@ -122,7 +115,7 @@ You can still make configuration adjustments when the addon is disabled. However
 
 == Alertmanager
 
-`Harvester` uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
+{harvester-product-name} uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
 
 === Alertmanager Config
 
@@ -175,9 +168,9 @@ helm install rancher-charts/rancher-alerting-drivers \
   --generate-name
 ----
 
-For detailed configuration instructions, see https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration/receivers[Rancher Monitoring Receiver Configuration] in the Rancher documentation.
+For detailed configuration instructions, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/observability/monitoring-and-dashboards/configuration/receivers.html[Receiver Configuration] in the {rancher-short-name} documentation.
 
-If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the Harvester cluster.
+If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the {harvester-product-name} cluster.
 
 . Download the rancher-alerting-drivers Helm chart and package it.
 +
@@ -192,20 +185,20 @@ docker save -o sachet.tar rancher/mirrored-messagebird-sachet:<VERSION>
 docker save -o prom2teams.tar rancher/mirrored-idealista-prom2teams:<VERSION>
 ----
 
-. Upload the chart and images to the Harvester cluster.
+. Upload the chart and images to the {harvester-product-name} cluster.
 
-. Load the images on all Harvester nodes.
+. Load the images on all {harvester-product-name} nodes.
 +
 ----
 docker load -i sachet.tar
 docker load -i prom2teams.tar
 ----
 
-. Install rancher-alerting-drivers on the Harvester cluster.
+. Install rancher-alerting-drivers on the {harvester-product-name} cluster.
 
 [IMPORTANT]
 ====
-Harvester does not manage upgrades of the rancher-alerting-drivers app, which is not part of the Harvester project. You must upgrade the app manually.
+{harvester-product-name} does not manage upgrades of the `rancher-alerting-drivers` app, which is not part of {harvester-product-name}. You must upgrade the app manually.
 ====
 
 ==== Configure AlertmanagerConfig from CLI
@@ -276,7 +269,7 @@ Different receivers may present the alerts in different formats. For details, pl
 
 The `AlertmanagerConfig` is enforced by the `namespace`. Gloabl-level `AlertmanagerConfig` without a namespace is not supported.
 
-We have already created a https://github.com/harvester/harvester/issues/2760[GithHb issue] to track upstream changes. Once the feature is available, `Harvester` will adopt it.
+We have already created a https://github.com/harvester/harvester/issues/2760[GitHub issue] to track upstream changes. Once the feature is available, {harvester-product-name} will adopt it.
 
 === View and Manage Alerts
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -2,11 +2,11 @@
 
 == Monitoring is unusable
 
-When the Harvester Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
+When the {harvester-product-name} Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
 
 === Monitoring is unusable due to Pod being stuck in `Terminating` status
 
-Harvester Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
+{harvester-product-name} Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
 
 [,shell]
 ----
@@ -64,19 +64,19 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 == Expand PV/Volume Size
 
-`Harvester` integrates `Longhorn` as the default storage provider.
+{harvester-product-name} integrates {longhorn-product-name} as the default storage provider.
 
-Harvester `Monitoring` uses `Persistent Volume (PV)` to store running data. When a cluster has been running for a certain time, the `Persistent Volume` may need to expand its size.
+{harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-Based on the `Longhorn` `Volume` expansion guide, `Harvester` illustrates how to https://longhorn.io/docs/1.3.2/volumes-and-nodes/expansion/[expand the volume size].
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 
-==== From Embedded Longhorn WebUI
+==== From Embedded {longhorn-product-name} UI
 
-Access the embedded Longhorn WebUI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
+Access the embedded {longhorn-product-name} UI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
 
-The Longhorn dashboard default view.
+The {longhorn-product-name} dashboard default view.
 
 image::troubleshooting/2-longhorn-dashboard.png[]
 
@@ -144,11 +144,11 @@ longhorn-system   pvc-b2b2c07c-f7cd-4965-90e6-ac3319597bf7   detached   unknown 
 
 === Expand Volume
 
-In the Longhorn WebUI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
+In the {longhorn-product-name} UI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
 
 image::troubleshooting/4-select-volume-to-expand.png[]
 
-Input a new size, and `Longhorn` will expand the volume to this size.
+Input a new size, and {longhorn-product-name} will expand the volume to this size.
 
 image::troubleshooting/5-expand-volue-to-new-size.png[]
 
@@ -179,11 +179,11 @@ To now, the `Volume` is expanded to the new size and the POD is using it smoothl
 
 == Fail to Enable `rancher-monitoring` Addon
 
-You may encounter this when you install the Harvester v1.3.0 or higher version cluster with the minimal 250 GB disk per xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements].
+You may encounter this when you install {harvester-product-name} v1.3.0 or later on a cluster with the xref:../installation-setup/requirements.adoc#_hardware_requirements[minimum required disk size].
 
 === Reproduce Steps
 
-. Install the Harvester v1.3.0 cluster.
+. Install the {harvester-product-name} cluster.
 . Enable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on], you will observe:
 
 * The POD `prometheus-rancher-monitoring-prometheus-0` in `cattle-monitoring-system` namespace fails to start due to PVC attached failed.
@@ -223,7 +223,7 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
   longhorn-system   pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0   v1            detached   unknown                  53687091200            6m55s
 ----
 
-* The Longhorn manager is unable to schedule the replica.
+* The Longhorn Manager is unable to schedule the replica.
 +
 ----
   $ kubectl logs -n longhorn-system longhorn-manager-bf65b | grep "pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0"
@@ -263,7 +263,7 @@ All pods in `cattle-monitoring-system` are deleted but the PVCs are retained. Fo
  alertmanager-rancher-monitoring-alertmanager-db-alertmanager-rancher-monitoring-alertmanager-0   Bound    pvc-cea6316e-f74f-4771-870b-49edb5442819   5Gi        RWO            harvester-longhorn   16m
 ----
 
-. On the *Addons* screen of the Harvester UI, select *⋮* (menu icon) and then select *Edit YAML*.
+. On the *Addons* screen of the {harvester-product-name} UI, select *⋮* (menu icon) and then select *Edit YAML*.
 +
 image::troubleshooting/edit-rancher-monitoring.png[]
 
@@ -365,7 +365,7 @@ Example:
  fleet-local   mcc-rancher-logging-crd                       1/1
  fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
 
-When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], {harvester-product-name} may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
 
 Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
 

--- a/versions/v1.6/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.6/modules/en/pages/hosts/hosts.adoc
@@ -96,13 +96,13 @@ Removing a control plane node in this situation is not recommended because etcd 
 
 === 2. Check the status of volumes.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Volume* screen.
 . Verify that the state of all volumes is *Healthy*.
 
 === 3. Evict replicas from the node to be removed.
 
-. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded Longhorn UI].
+. Access the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 . Go to the *Node* screen.
 . Select the node that you want to remove, click the icon in the *Operation* column, and then select *Edit node and disks*.
 . Configure the following settings:
@@ -231,7 +231,7 @@ image::host/multidisk-mgmt-05.png[Provisioner LVM]
 
 . On the host details screen, verify that the disks were added and the correct provisioner was set.
 +
-You can also add <<Storage Tags,storage tags>> if you want Longhorn volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
+You can also add <<Storage Tags,storage tags>> if you want {longhorn-product-name} volume data to be stored on specific nodes or disks. Storage tags can only be used with the *LonghornV1 (CSI)* and *LonghornV2 (CSI)* provisioners.
 +
 image::host/multidisk-mgmt-06.png[Disk tag 01]
 +
@@ -250,7 +250,7 @@ If you are testing {harvester-product-name} in a QEMU environment, you'll need t
 
 === Storage Tags
 
-The storage tag feature enables only certain nodes or disks to be used for storing Longhorn volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
+The storage tag feature enables only certain nodes or disks to be used for storing {longhorn-product-name} volume data. For example, performance-sensitive data can use only the high-performance disks which can be tagged as `fast`, `ssd` or `nvme`, or only the high-performance nodes tagged as `baremetal`.
 
 This feature supports both disks and nodes.
 
@@ -272,7 +272,7 @@ When multiple tags are specified for a volume, the disk and the nodes (that the 
 
 === Remove disks
 
-Before removing a disk, you must first evict Longhorn replicas on the disk.
+Before removing a disk, you must first evict {longhorn-product-name} replicas on the disk.
 
 [NOTE]
 ====
@@ -287,10 +287,10 @@ The replica data would be rebuilt to another disk automatically to keep the high
 
 image::host/remove-disks-harvester-find-disk.png[Find disk to remove]
 
-==== Evict replicas (Longhorn dashboard)
+==== Evict replicas ({longhorn-product-name} dashboard)
 
-. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded Longhorn dashboard.
-. Visit the Longhorn dashboard and go to the *Node* page.
+. Please follow xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this session] to enable the embedded {longhorn-product-name} dashboard.
+. Visit the {longhorn-product-name} dashboard and go to the *Node* page.
 . Expand the node containing the disk. Confirm the mount point `/var/lib/harvester/extra-disks/1b805b97eb5aa724e6be30cbdb373d04` is in the disks list.
 +
 image::host/remove-disks-longhorn-nodes.png[Check the removing disk]
@@ -332,7 +332,7 @@ https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constrai
 +
 . Click *Save*.
 
-The label is automatically synchronized with the corresponding Longhorn node.
+The label is automatically synchronized with the corresponding {longhorn-product-name} node.
 
 == Ksmtuned Mode
 
@@ -462,7 +462,7 @@ image::host/harvester-ntp-settings-empty.png[]
 
 You may need to customize one or more nodes after installing {harvester-product-name}. This process usually entails updating the xref:../installation-setup/config/update-configuration.adoc[runtime configuration] and modifying files in the `/oem` directory of each node to make changes persist after rebooting.
 
-These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://fleet.rancher.io/[Fleet].
+These customizations can be described in a Kubernetes manifest and then applied to the underlying cluster using kubectl or other GitOps-centric tools such as https://documentation.suse.com/cloudnative/continuous-delivery/[{fleet-product-name}].
 
 [WARNING]
 ====

--- a/versions/v1.6/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/observability/monitoring.adoc
@@ -1,16 +1,12 @@
 = Monitoring
 
-The monitoring feature is now implemented with an addon and is disabled by default in new installations.
+The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 
-Users can enable/disable `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] from the Harvester UI after installation.
-
-Users can also enable/disable the `rancher-monitoring` addon in their Harvester installation by customizing the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
-
-For Harvester clusters upgraded from version v1.1.x, the monitoring feature is converted to an addon automatically and kept enabled as before.
+You can enable and disable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on] after installation using the {harvester-product-name} UI or the xref:../installation-setup/config/configuration-file.adoc#_install_addons[configuration file].
 
 == Dashboard Metrics
 
-Harvester has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during the Harvester installations.
+{harvester-product-name} has provided a built-in monitoring integration using https://prometheus.io/[Prometheus]. Monitoring is automatically enabled during installation.
 
 From the `Dashboard` page, users can view the cluster metrics and top 10 most used VM metrics respectively.
 Also, users can click the http://grafana.com/[Grafana] dashboard link to view more dashboards on the Grafana UI.
@@ -34,7 +30,6 @@ image::monitoring/vm-metrics.png[]
 
 [NOTE]
 ====
-
 The current `Memory Usage` is calculated based on `(1 - free/total) * 100%`, not `(used/total) * 100%`.
 ====
 
@@ -49,9 +44,7 @@ The corresponding `Memory Usage` is `(1 - 4.6/7.7) * 100%`, roughly `40%`.
 
 == How to Configure Monitoring Settings
 
-_Available as of v1.0.2_
-
-Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. Harvester sets defaults based on general use cases, and you can change them accordingly.
+Monitoring has several components that help to collect and aggregate metric data from all Nodes/Pods/VMs. The resources required for monitoring depend on your workloads and hardware resources. {harvester-product-name} sets defaults based on general use cases, and you can change them accordingly.
 
 Currently, `Resources Settings` can be configured for the following components:
 
@@ -122,7 +115,7 @@ You can still make configuration adjustments when the addon is disabled. However
 
 == Alertmanager
 
-`Harvester` uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
+{harvester-product-name} uses `Alertmanager` to collect and manage all the alerts that happened/happening in the cluster.
 
 === Alertmanager Config
 
@@ -175,9 +168,9 @@ helm install rancher-charts/rancher-alerting-drivers \
   --generate-name
 ----
 
-For detailed configuration instructions, see https://ranchermanager.docs.rancher.com/reference-guides/monitoring-v2-configuration/receivers[Rancher Monitoring Receiver Configuration] in the Rancher documentation.
+For detailed configuration instructions, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/observability/monitoring-and-dashboards/configuration/receivers.html[Receiver Configuration] in the {rancher-short-name} documentation.
 
-If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the Harvester cluster.
+If your environment does not have direct internet access (air-gapped), you must manually download the Helm chart and related container images, and then upload them to the {harvester-product-name} cluster.
 
 . Download the rancher-alerting-drivers Helm chart and package it.
 +
@@ -192,20 +185,20 @@ docker save -o sachet.tar rancher/mirrored-messagebird-sachet:<VERSION>
 docker save -o prom2teams.tar rancher/mirrored-idealista-prom2teams:<VERSION>
 ----
 
-. Upload the chart and images to the Harvester cluster.
+. Upload the chart and images to the {harvester-product-name} cluster.
 
-. Load the images on all Harvester nodes.
+. Load the images on all {harvester-product-name} nodes.
 +
 ----
 docker load -i sachet.tar
 docker load -i prom2teams.tar
 ----
 
-. Install rancher-alerting-drivers on the Harvester cluster.
+. Install rancher-alerting-drivers on the {harvester-product-name} cluster.
 
 [IMPORTANT]
 ====
-Harvester does not manage upgrades of the rancher-alerting-drivers app, which is not part of the Harvester project. You must upgrade the app manually.
+{harvester-product-name} does not manage upgrades of the `rancher-alerting-drivers` app, which is not part of {harvester-product-name}. You must upgrade the app manually.
 ====
 
 ==== Configure AlertmanagerConfig from CLI
@@ -276,7 +269,7 @@ Different receivers may present the alerts in different formats. For details, pl
 
 The `AlertmanagerConfig` is enforced by the `namespace`. Gloabl-level `AlertmanagerConfig` without a namespace is not supported.
 
-We have already created a https://github.com/harvester/harvester/issues/2760[GithHb issue] to track upstream changes. Once the feature is available, `Harvester` will adopt it.
+We have already created a https://github.com/harvester/harvester/issues/2760[GitHub issue] to track upstream changes. Once the feature is available, {harvester-product-name} will adopt it.
 
 === View and Manage Alerts
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -2,11 +2,11 @@
 
 == Monitoring is unusable
 
-When the Harvester Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
+When the {harvester-product-name} Dashboard is not showing any monitoring metrics, it can be caused by the following reasons.
 
 === Monitoring is unusable due to Pod being stuck in `Terminating` status
 
-Harvester Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
+{harvester-product-name} Monitoring pods are deployed randomly on the cluster Nodes. When the Node hosting the pods accidentally goes down, the related pods may become stuck in the `Terminating` status rendering the Monitoring unusable from the WebUI.
 
 [,shell]
 ----
@@ -64,19 +64,19 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 == Expand PV/Volume Size
 
-`Harvester` integrates `Longhorn` as the default storage provider.
+{harvester-product-name} integrates {longhorn-product-name} as the default storage provider.
 
-Harvester `Monitoring` uses `Persistent Volume (PV)` to store running data. When a cluster has been running for a certain time, the `Persistent Volume` may need to expand its size.
+{harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-Based on the `Longhorn` `Volume` expansion guide, `Harvester` illustrates how to https://longhorn.io/docs/1.3.2/volumes-and-nodes/expansion/[expand the volume size].
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 
-==== From Embedded Longhorn WebUI
+==== From Embedded {longhorn-product-name} UI
 
-Access the embedded Longhorn WebUI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
+Access the embedded {longhorn-product-name} UI according to xref:./cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[this document].
 
-The Longhorn dashboard default view.
+The {longhorn-product-name} dashboard default view.
 
 image::troubleshooting/2-longhorn-dashboard.png[]
 
@@ -144,11 +144,11 @@ longhorn-system   pvc-b2b2c07c-f7cd-4965-90e6-ac3319597bf7   detached   unknown 
 
 === Expand Volume
 
-In the Longhorn WebUI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
+In the {longhorn-product-name} UI, the related volume becomes `Detached`. Click the icon in the `Operation` column, and select `Expand Volume`.
 
 image::troubleshooting/4-select-volume-to-expand.png[]
 
-Input a new size, and `Longhorn` will expand the volume to this size.
+Input a new size, and {longhorn-product-name} will expand the volume to this size.
 
 image::troubleshooting/5-expand-volue-to-new-size.png[]
 
@@ -179,11 +179,11 @@ To now, the `Volume` is expanded to the new size and the POD is using it smoothl
 
 == Fail to Enable `rancher-monitoring` Addon
 
-You may encounter this when you install the Harvester v1.3.0 or higher version cluster with the minimal 250 GB disk per xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements].
+You may encounter this when you install {harvester-product-name} v1.3.0 or later on a cluster with the xref:../installation-setup/requirements.adoc#_hardware_requirements[minimum required disk size].
 
 === Reproduce Steps
 
-. Install the Harvester v1.3.0 cluster.
+. Install the {harvester-product-name} cluster.
 . Enable the `rancher-monitoring` xref:../add-ons/add-ons.adoc[add-on], you will observe:
 
 * The POD `prometheus-rancher-monitoring-prometheus-0` in `cattle-monitoring-system` namespace fails to start due to PVC attached failed.
@@ -223,7 +223,7 @@ You may encounter this when you install the Harvester v1.3.0 or higher version c
   longhorn-system   pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0   v1            detached   unknown                  53687091200            6m55s
 ----
 
-* The Longhorn manager is unable to schedule the replica.
+* The Longhorn Manager is unable to schedule the replica.
 +
 ----
   $ kubectl logs -n longhorn-system longhorn-manager-bf65b | grep "pvc-bbe8760d-926c-484a-851c-b8ec29ae05c0"
@@ -263,7 +263,7 @@ All pods in `cattle-monitoring-system` are deleted but the PVCs are retained. Fo
  alertmanager-rancher-monitoring-alertmanager-db-alertmanager-rancher-monitoring-alertmanager-0   Bound    pvc-cea6316e-f74f-4771-870b-49edb5442819   5Gi        RWO            harvester-longhorn   16m
 ----
 
-. On the *Addons* screen of the Harvester UI, select *⋮* (menu icon) and then select *Edit YAML*.
+. On the *Addons* screen of the {harvester-product-name} UI, select *⋮* (menu icon) and then select *Edit YAML*.
 +
 image::troubleshooting/edit-rancher-monitoring.png[]
 
@@ -365,7 +365,7 @@ Example:
  fleet-local   mcc-rancher-logging-crd                       1/1
  fleet-local   mcc-rancher-monitoring-crd                    0/1                       Modified(1) [Cluster fleet-local/local]; clusterrole.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; clusterrolebinding.rbac.authorization.k8s.io rancher-monitoring-crd-manager missing; configmap.v1 cattle-monitoring-system/rancher-monitoring-crd-manifest missing; serviceaccount.v1 cattle-monitoring-system/rancher-monitoring-crd-manager missing
 
-When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], Harvester may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
+When the issue exists and you xref:../upgrades/upgrades.adoc#_start_an_upgrade[start an upgrade], {harvester-product-name} may return the following error message: `admission webhook "validator.harvesterhci.io" denied the request: managed chart rancher-monitoring-crd is not ready, please wait for it to be ready`.
 
 Also, when you search for the objects marked as `missing`, you will find that they exist in the cluster.
 


### PR DESCRIPTION
Related issue: [#77](https://github.com/rancher/harvester-product-docs/issues/77)

Scope: v1.3, v1.4, v1.5, v1.6
- `hosts/hosts.adoc`
- `observability/monitoring.adoc`
- `troubleshooting/monitoring.adoc`

Changes:
- Replace community doc URLs with product doc URLs
- Replace community project names with product name variables
- Standardize capitalization of component names (Note: Component names that include "Harvester" and "Longhorn" will not be rebranded for now. I need more guidance from the PM group.)