### PR TITLE
Add content from community doc PRs (802, 807)

### DIFF
--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -636,7 +636,7 @@ The Harvester pod logs ('harvester-system/harvester' deployment) indicate that t
 
 === Root cause
 
-When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the {harvester-product-name} controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
 
 This process usually takes a short time to complete, but can be disrupted when the following occur:
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -573,3 +573,87 @@ Also, error indicators are no longer displayed for the downstream objects.
 === Related Issue
 
 https://github.com/harvester/harvester/issues/5505
+
+== Some `rancher-monitoring` add-on pods are abruptly terminated
+
+=== Issue description
+
+When the `rancher-monitoring` add-on is enabled, pods related to Prometheus, Alertmanager, and Grafana are terminated shortly after they are created.
+
+Example:
+
+[,shell]
+----
+$ kubectl -n cattle-monitoring-system get pods,svc,ep,deploy,pvc,sts,prometheus,alertmanager | grep -E 'stateful|deploy'
+
+deployment.apps/rancher-monitoring-grafana              0/0     0            0           7h52m
+deployment.apps/rancher-monitoring-kube-state-metrics   1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-operator             1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-prometheus-adapter   1/1     1            1           7h52m
+statefulset.apps/alertmanager-rancher-monitoring-alertmanager   0/0     7h52m
+statefulset.apps/prometheus-rancher-monitoring-prometheus       0/0     7h52m
+----
+
+The `prometheus` pod logs contain the message `level=warn msg="Received SIGTERM, exiting gracefully..."`.
+
+[,shell]
+----
+...
+ts=2025-05-20T05:41:02.847Z caller=kubernetes.go:327 level=info component="discovery manager notify" discovery=kubernetes config=config-0 msg="Using pod service account via in-cluster config"
+ts=2025-05-20T05:41:02.880Z caller=main.go:1261 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/config_out/prometheus.env.yaml totalDuration=35.457401ms db_storage=998ns remote_storage=1.45Âµs web_handler=392ns query_engine=1.095Âµs scrape=34.384Âµs scrape_sd=515.81Âµs notify=10.226Âµs notify_sd=82.314Âµs rules=32.514863ms tracing=2.344Âµs
+ts=2025-05-20T05:41:50.044Z caller=main.go:854 level=warn msg="Received SIGTERM, exiting gracefully..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:878 level=info msg="Stopping scrape discovery manager..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:892 level=info msg="Stopping notify discovery manager..."
+...
+----
+
+The `prometheus` CRD object includes the `storage-network.settings.harvesterhci.io/replica: "1" ` annotation.
+
+[,yaml]
+----
+- apiVersion: monitoring.coreos.com/v1
+  kind: Prometheus
+  metadata:
+    annotations:
+      meta.helm.sh/release-name: rancher-monitoring
+      meta.helm.sh/release-namespace: cattle-monitoring-system
+      storage-network.settings.harvesterhci.io/replica: "1"
+    creationTimestamp: "2025-05-20T06:40:25Z"
+----
+
+The Harvester pod logs ('harvester-system/harvester' deployment) indicate that the attempt to change the `storage-network` setting was blocked.
+
+[,shell]
+----
+...
+2025-05-20T08:13:49.842448311Z time="2025-05-20T08:13:49Z" level=info msg="storage network change: {\"vlan\":955,\"clusterNetwork\":\"k8s-storage\",\"range\":\"198.18.2.0/24\"}"
+2025-05-20T08:13:49.842476305Z time="2025-05-20T08:13:49Z" level=info msg="rancher monitoring not found. skip"
+2025-05-20T08:13:49.842479072Z time="2025-05-20T08:13:49Z" level=info msg="current Grafana replicas: 0"
+2025-05-20T08:13:49.842480501Z time="2025-05-20T08:13:49Z" level=info msg="VM import controller no found. skip"
+2025-05-20T08:13:49.851381877Z time="2025-05-20T08:13:49Z" level=error msg="error syncing 'storage-network': handler harvester-storage-network-controller: Waiting for all volumes detached: pvc-6f66d234-f9c2-453e-8c17-383d9b489956,pvc-07c626f5-5135-4783-952d-cc20b1607cb5,pvc-1cfd6efe-c928-42e5-a834-8c27ed0e4897,pvc-5ce98d0a-5da1-4f30-af14-a8de29233380,pvc-1c9b7c9a-4943-4462-9082-217f9988cfc5,pvc-e9d92bfd-63c7-4ae3-ba00-1ce209f12caa,pvc-205ba31d-35fb-44f6-a3c4-c53001ec0dd6,pvc-6b5a7d11-7578-4397-9e13-ab475fe91463,pvc-669c69dd-93ad-4304-a340-484f7108362b,pvc-7668c486-b688-4524-b359-0cf9ec21cbc0,pvc-7d294996-821f-4434-ae4f-55a6de67f28c,pvc-216333c6-73f9-4e68-ac8b-53ab95a1f138,pvc-f72ca889-70c9-4dd9-bcec-a17ab65a1df4,pvc-01895fab-12f8-452a-9161-7d3c01e22726,pvc-330caa2d-5fdc-42f2-8c53-c5f80044760f,pvc-9506b7d0-c2d5-41f2-a08b-d7bc22dddb88,pvc-3e2b46d4-c471-44a9-9765-64babdb6ceed,pvc-25fe3372-1802-46d5-abf1-039099c567e2,pvc-b16fb262-cb38-4438-b074-84c7ad080a15,pvc-757c0f22-4ed6-4669-844d-cd7a87ceb26e,pvc-e0d99d8f-581f-4be6-baa3-d345308c9330,pvc-f5e1e19d-3dfb-4be1-9354-c092d7f03009,pvc-383ec26a-51f6-4f9d-8d8a-179651846d92,pvc-0d8f5737-c6e4-4f55-8d19-cf7a785552fc,pvc-5091892e-faf2-47b1-b987-bbde1ab2c13a,pvc-6f0c97ae-dfda-4799-bf26-e85feace5414,pvc-b0f717af-8a79-4c4e-b82e-90dedeae7697,pvc-ffe982d5-5ff1-40aa-a0db-cc10360d2d89,pvc-370757e2-4bce-41e7-b6f7-95aa8a5e8cf1,pvc-5a77d3e3-d555-476c-840f-7b9dadeb7478,pvc-43987c88-99b1-4889-9a47-5261717fe265,pvc-9f675704-9c52-46c2-96bf-2ff83d805383,pvc-d0b4e1d0-9bcd-4a8a-b52c-e1d8062a8099,pvc-a29be31f-531f-409a-bf5a-d267a54e2edb, requeuing"
+...
+----
+
+=== Root cause
+
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+
+This process usually takes a short time to complete, but can be disrupted when the following occur:
+
+* Attached volumes prevent the Harvester controller from applying the changes to the setting.
+* A user or the `monitoring-operator` attempts to enable the `rancher-monitoring` add-on.
+* The Harvester controller terminates the pods.
+
+=== Workaround
+
+. Disable the `rancher-monitoring` add-on.
+
+. Check if the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting is enabled or disabled.
+
+. Check for error indicators in the Harvester pod logs. If volumes are still attached, stop the related virtual machines until no errors appear after the `storage network change` message.
+
+. Enable the `rancher-monitoring` add-on.
+
+=== Related issue
+
+https://github.com/harvester/harvester/issues/8565

--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -656,4 +656,4 @@ This process usually takes a short time to complete, but can be disrupted when t
 
 === Related issue
 
-https://github.com/harvester/harvester/issues/8565
+https://github.com/harvester/harvester/issues/8565[Issue #8565]

--- a/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
@@ -7,23 +7,25 @@ Here are some tips to troubleshoot a failed upgrade:
 * Check xref:./upgrades.adoc#_upgrade_support_matrix[version-specific upgrade notes]. You can click the version in the support matrix table to see if there are any known issues.
 * Dive into the upgrade https://github.com/harvester/harvester/blob/master/enhancements/20220413-zero-downtime-upgrade.md[design proposal]. The following section briefly describes phases within an upgrade and possible diagnostic methods.
 
-== Investigate the Upgrade Flow
+== Upgrade flow
 
 The upgrade process includes several phases.
 
 image::upgrade/ts_upgrade_phases.png[]
 
-=== Phase 1: Provision upgrade repository VM.
+=== Phase 1: Provision upgrade repository virtual machine
 
-The {harvester-product-name} controller downloads a release ISO file and uses it to provision a VM. During this phase you can see the upgrade status windows show:
+The {harvester-product-name} controller downloads a release ISO file and uses it to provision a repository virtual machine. The virtual machine name uses the format `upgrade-repo-hvst-xxxx`.
 
 image::upgrade/ts_status_phase1.png[]
 
-The time to complete the phase depends on the user's network speed and cluster resource utilization. We see failures in this phase due to network speed. If this happens, the user can <<Start over an upgrade,start over the upgrade>> again.
+Network speed and cluster resource utilization influence the amount of time required to complete this phase. Upgrades typically fail because of network speed issues.
 
-We can also check the repository VM (named with the format `upgrade-repo-hvst-xxxx`) status and its corresponding pod:
+If the upgrade fails at this point, check the status of the repository virtual machine and its corresponding pod before restarting the upgrade. You can check the status using the command `kubectl get vm -n harvester-system`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get vm -n harvester-system
 NAME                              AGE    STATUS     READY
@@ -35,15 +37,17 @@ virt-launcher-upgrade-repo-hvst-upgrade-9gmg2-4mnmq     1/1     Running     0   
 
 === Phase 2: Preload container images
 
-The Harvester controller creates jobs on each Harvester node to download images from the repository VM and preload them. These are the container images required for the next release.
+The {harvester-product-name} controller creates jobs that download and preload container images from the repository virtual machine. These images are required for the next release.
 
-During this stage you can see the upgrade status windows shows:
+Allow some time for the images to be downloaded and preloaded on all nodes.
 
 image::upgrade/ts_status_phase2.png[]
 
-It will take a while for all nodes to preload images. If the upgrade fails at this phase, the user can check job logs in the `cattle-system` namespace:
+If the upgrade fails at this point, check the job logs in the `cattle-system` namespace before restarting the upgrade. You can check the logs using the command `kubectl get jobs -n cattle-system | grep prepare`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n cattle-system | grep prepare
 apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0e86   0/1           47s        47s
@@ -53,15 +57,17 @@ $ kubectl logs jobs/apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0
 ...
 ----
 
-It's also safe to <<Start over an upgrade,start over the upgrade>> if an upgrade fails at this phase.
-
 === Phase 3: Upgrade system services
+
+The {harvester-product-name} controller creates a job that upgrades component Helm charts.
 
 image::upgrade/ts_status_phase3.png[]
 
-The {harvester-product-name} controller upgrades component Helm charts with a job. The user can check the `apply-manifest` job with the following command:
+You can check the `apply-manifest` job using the command `$ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest
 NAME                                 COMPLETIONS   DURATION   AGE
@@ -71,20 +77,31 @@ $ kubectl logs jobs/hvst-upgrade-9gmg2-apply-manifests -n harvester-system
 ...
 ----
 
+[CAUTION]
+====
+If the upgrade fails at this point, you must generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle] before restarting the upgrade. The support bundle contains logs and resource manifests that can help identify the cause of the failure.
+====
+
 === Phase 4: Upgrade nodes
+
+The {harvester-product-name} controller creates the following jobs on each node:
+
+* Multi-node clusters:
++
+** `pre-drain` job: Live-migrates or shuts down virtual machines on the node. Once completed, the embedded {rancher-short-name} service upgrades the {rke2-short-name} runtime on the node.
+** `post-drain` job: Upgrades and reboots the operating system.
+
+* Single-node clusters:
++
+** `single-node-upgrade` job: Upgrades the operating system and {rke2-short-name} runtime. The job name uses the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`.
 
 image::upgrade/ts_status_phase4.png[]
 
-The {harvester-product-name} controller creates jobs on each node (one by one) to upgrade nodes' OSes and RKE2 runtime. For multi-node clusters, there are two kinds of jobs to update a node:
+You can check the jobs running on each node by running the command `kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node`.
 
-* *pre-drain* job: live-migrate or shutdown VMs on a node. When the job completes, the embedded {rancher-short-name} service upgrades RKE2 runtime on a node.
-* *post-drain* job: upgrade OS and reboot.
+Example:
 
-For single-node clusters, there is only one `single-node-upgrade` type job for each node (named with the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`).
-
-The user can check node jobs by:
-
-[,console]
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node
 NAME                                  COMPLETIONS   DURATION   AGE
@@ -97,22 +114,31 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 ...
 ----
 
-[CAUTION]
+[WARNING]
 ====
-Please do not start over an upgrade if the upgrade fails at this phase.
+If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
-=== Phase 5: Clean-up
+=== Phase 5: Cleanup
 
-The {harvester-product-name} controller deletes the upgrade repository VM and all files that are no longer needed.
+The {harvester-product-name} controller deletes the repository virtual machine and all files that are no longer necessary.
 
 == Common operations
 
-=== Start over an upgrade
+=== Stop the ongoing upgrade
+
+[CAUTION]
+====
+If an ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, identify the cause first.
+====
+
+You can stop the upgrade by performing the following steps:
 
 . Log in to a control plane node.
-. List `Upgrade` CRs in the cluster:
+
+. Retrieve a list of `Upgrade` CRs in the cluster.
 +
+[,shell]
 ----
  # become root
  $ sudo -i
@@ -123,17 +149,16 @@ The {harvester-product-name} controller deletes the upgrade repository VM and al
  hvst-upgrade-9gmg2   10m
 ----
 
-. Delete the Upgrade CR
+. Delete the `Upgrade` CR.
 +
+[,shell]
 ----
  $ kubectl delete upgrade.harvesterhci.io/hvst-upgrade-9gmg2 -n harvester-system
 ----
 
-. Click the upgrade button in the {harvester-product-name} UI to start an upgrade again.
-
 === Download upgrade logs
 
-We have designed and implemented a mechanism to automatically collect all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
+{harvester-product-name} automatically collects all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
 
 image::upgrade/enable_logging.png[The "Enable Logging" checkbox on the upgrade confirmation dialog]
 
@@ -145,7 +170,7 @@ Log entries will be collected as files for each upgrade-related Pod, even for in
 
 image::upgrade/upgradelog_archive.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
-After the upgrade ended, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
+After the upgrade ends, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
 
 image::upgrade/dismiss_upgrade_to_remove_upgradelog.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
@@ -153,9 +178,9 @@ For more details, please refer to the https://github.com/harvester/harvester/blo
 
 [CAUTION]
 ====
-The storage volume for storing upgrade-related logs is 1GB by default. If an upgrade went into issues, the logs may consume all the available space of the volume. To work around such kind of incidents, try the following steps:
+The default size of the volume that stores upgrade-related logs is 1 GB. When errors occur, these logs may completely consume the volume's available space. To work around this issue, you can perform the following steps:
 
-. Detach the `log-archive` Volume by scaling down the `fluentd` StatefulSet and `downloader` Deployment.
+. Detach the `log-archive` volume by scaling down the `fluentd` StatefulSet and `downloader` deployment.
 +
 ----
 # Locate the StatefulSet and Deployment
@@ -166,7 +191,6 @@ hvst-upgrade-xxxxx-upgradelog-infra-fluentd   1/1     43s
 $ kubectl -n harvester-system get deployments -l harvesterhci.io/upgradeLogComponent=downloader
 NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
 hvst-upgrade-xxxxx-upgradelog-downloader   1/1     1            1           38s
-
 
 # Scale down the resources to terminate any Pods using the volume
 $ kubectl -n harvester-system scale statefulset hvst-upgrade-xxxxx-upgradelog-infra-fluentd --replicas=0
@@ -184,7 +208,7 @@ $ kubectl -n harvester-system get pvc -l harvesterhci.io/upgradeLogComponent=log
 pvc-63355afb-ce61-46c4-8781-377cf962278a
 ----
 
-. Recover the `fluentd` StatefulSet and `downloader` Deployment.
+. Recover the `fluentd` StatefulSet and `downloader` deployment.
 +
 [,console]
 ----
@@ -196,7 +220,7 @@ deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 ====
 
-=== Clean Up Unused Images
+=== Clean up unused images
 
 The default value of `imageGCHighThresholdPercent` in https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration[KubeletConfiguration] is `85`. When disk usage exceeds 85%, the kubelet attempts to remove unused images.
 

--- a/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
@@ -116,7 +116,7 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 
 [WARNING]
 ====
-If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+If the upgrade fails at this point, *do not restart* the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
 === Phase 5: Cleanup

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -636,7 +636,7 @@ The Harvester pod logs ('harvester-system/harvester' deployment) indicate that t
 
 === Root cause
 
-When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the {harvester-product-name} controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
 
 This process usually takes a short time to complete, but can be disrupted when the following occur:
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -573,3 +573,87 @@ Also, error indicators are no longer displayed for the downstream objects.
 === Related Issue
 
 https://github.com/harvester/harvester/issues/5505
+
+== Some `rancher-monitoring` add-on pods are abruptly terminated
+
+=== Issue description
+
+When the `rancher-monitoring` add-on is enabled, pods related to Prometheus, Alertmanager, and Grafana are terminated shortly after they are created.
+
+Example:
+
+[,shell]
+----
+$ kubectl -n cattle-monitoring-system get pods,svc,ep,deploy,pvc,sts,prometheus,alertmanager | grep -E 'stateful|deploy'
+
+deployment.apps/rancher-monitoring-grafana              0/0     0            0           7h52m
+deployment.apps/rancher-monitoring-kube-state-metrics   1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-operator             1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-prometheus-adapter   1/1     1            1           7h52m
+statefulset.apps/alertmanager-rancher-monitoring-alertmanager   0/0     7h52m
+statefulset.apps/prometheus-rancher-monitoring-prometheus       0/0     7h52m
+----
+
+The `prometheus` pod logs contain the message `level=warn msg="Received SIGTERM, exiting gracefully..."`.
+
+[,shell]
+----
+...
+ts=2025-05-20T05:41:02.847Z caller=kubernetes.go:327 level=info component="discovery manager notify" discovery=kubernetes config=config-0 msg="Using pod service account via in-cluster config"
+ts=2025-05-20T05:41:02.880Z caller=main.go:1261 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/config_out/prometheus.env.yaml totalDuration=35.457401ms db_storage=998ns remote_storage=1.45Âµs web_handler=392ns query_engine=1.095Âµs scrape=34.384Âµs scrape_sd=515.81Âµs notify=10.226Âµs notify_sd=82.314Âµs rules=32.514863ms tracing=2.344Âµs
+ts=2025-05-20T05:41:50.044Z caller=main.go:854 level=warn msg="Received SIGTERM, exiting gracefully..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:878 level=info msg="Stopping scrape discovery manager..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:892 level=info msg="Stopping notify discovery manager..."
+...
+----
+
+The `prometheus` CRD object includes the `storage-network.settings.harvesterhci.io/replica: "1" ` annotation.
+
+[,yaml]
+----
+- apiVersion: monitoring.coreos.com/v1
+  kind: Prometheus
+  metadata:
+    annotations:
+      meta.helm.sh/release-name: rancher-monitoring
+      meta.helm.sh/release-namespace: cattle-monitoring-system
+      storage-network.settings.harvesterhci.io/replica: "1"
+    creationTimestamp: "2025-05-20T06:40:25Z"
+----
+
+The Harvester pod logs ('harvester-system/harvester' deployment) indicate that the attempt to change the `storage-network` setting was blocked.
+
+[,shell]
+----
+...
+2025-05-20T08:13:49.842448311Z time="2025-05-20T08:13:49Z" level=info msg="storage network change: {\"vlan\":955,\"clusterNetwork\":\"k8s-storage\",\"range\":\"198.18.2.0/24\"}"
+2025-05-20T08:13:49.842476305Z time="2025-05-20T08:13:49Z" level=info msg="rancher monitoring not found. skip"
+2025-05-20T08:13:49.842479072Z time="2025-05-20T08:13:49Z" level=info msg="current Grafana replicas: 0"
+2025-05-20T08:13:49.842480501Z time="2025-05-20T08:13:49Z" level=info msg="VM import controller no found. skip"
+2025-05-20T08:13:49.851381877Z time="2025-05-20T08:13:49Z" level=error msg="error syncing 'storage-network': handler harvester-storage-network-controller: Waiting for all volumes detached: pvc-6f66d234-f9c2-453e-8c17-383d9b489956,pvc-07c626f5-5135-4783-952d-cc20b1607cb5,pvc-1cfd6efe-c928-42e5-a834-8c27ed0e4897,pvc-5ce98d0a-5da1-4f30-af14-a8de29233380,pvc-1c9b7c9a-4943-4462-9082-217f9988cfc5,pvc-e9d92bfd-63c7-4ae3-ba00-1ce209f12caa,pvc-205ba31d-35fb-44f6-a3c4-c53001ec0dd6,pvc-6b5a7d11-7578-4397-9e13-ab475fe91463,pvc-669c69dd-93ad-4304-a340-484f7108362b,pvc-7668c486-b688-4524-b359-0cf9ec21cbc0,pvc-7d294996-821f-4434-ae4f-55a6de67f28c,pvc-216333c6-73f9-4e68-ac8b-53ab95a1f138,pvc-f72ca889-70c9-4dd9-bcec-a17ab65a1df4,pvc-01895fab-12f8-452a-9161-7d3c01e22726,pvc-330caa2d-5fdc-42f2-8c53-c5f80044760f,pvc-9506b7d0-c2d5-41f2-a08b-d7bc22dddb88,pvc-3e2b46d4-c471-44a9-9765-64babdb6ceed,pvc-25fe3372-1802-46d5-abf1-039099c567e2,pvc-b16fb262-cb38-4438-b074-84c7ad080a15,pvc-757c0f22-4ed6-4669-844d-cd7a87ceb26e,pvc-e0d99d8f-581f-4be6-baa3-d345308c9330,pvc-f5e1e19d-3dfb-4be1-9354-c092d7f03009,pvc-383ec26a-51f6-4f9d-8d8a-179651846d92,pvc-0d8f5737-c6e4-4f55-8d19-cf7a785552fc,pvc-5091892e-faf2-47b1-b987-bbde1ab2c13a,pvc-6f0c97ae-dfda-4799-bf26-e85feace5414,pvc-b0f717af-8a79-4c4e-b82e-90dedeae7697,pvc-ffe982d5-5ff1-40aa-a0db-cc10360d2d89,pvc-370757e2-4bce-41e7-b6f7-95aa8a5e8cf1,pvc-5a77d3e3-d555-476c-840f-7b9dadeb7478,pvc-43987c88-99b1-4889-9a47-5261717fe265,pvc-9f675704-9c52-46c2-96bf-2ff83d805383,pvc-d0b4e1d0-9bcd-4a8a-b52c-e1d8062a8099,pvc-a29be31f-531f-409a-bf5a-d267a54e2edb, requeuing"
+...
+----
+
+=== Root cause
+
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+
+This process usually takes a short time to complete, but can be disrupted when the following occur:
+
+* Attached volumes prevent the Harvester controller from applying the changes to the setting.
+* A user or the `monitoring-operator` attempts to enable the `rancher-monitoring` add-on.
+* The Harvester controller terminates the pods.
+
+=== Workaround
+
+. Disable the `rancher-monitoring` add-on.
+
+. Check if the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting is enabled or disabled.
+
+. Check for error indicators in the Harvester pod logs. If volumes are still attached, stop the related virtual machines until no errors appear after the `storage network change` message.
+
+. Enable the `rancher-monitoring` add-on.
+
+=== Related issue
+
+https://github.com/harvester/harvester/issues/8565

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -656,4 +656,4 @@ This process usually takes a short time to complete, but can be disrupted when t
 
 === Related issue
 
-https://github.com/harvester/harvester/issues/8565
+https://github.com/harvester/harvester/issues/8565[Issue #8565]

--- a/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
@@ -7,23 +7,25 @@ Here are some tips to troubleshoot a failed upgrade:
 * Check xref:./upgrades.adoc#_upgrade_support_matrix[version-specific upgrade notes]. You can click the version in the support matrix table to see if there are any known issues.
 * Dive into the upgrade https://github.com/harvester/harvester/blob/master/enhancements/20220413-zero-downtime-upgrade.md[design proposal]. The following section briefly describes phases within an upgrade and possible diagnostic methods.
 
-== Investigate the Upgrade Flow
+== Upgrade flow
 
 The upgrade process includes several phases.
 
 image::upgrade/ts_upgrade_phases.png[]
 
-=== Phase 1: Provision upgrade repository VM.
+=== Phase 1: Provision upgrade repository virtual machine
 
-The {harvester-product-name} controller downloads a release ISO file and uses it to provision a VM. During this phase you can see the upgrade status windows show:
+The {harvester-product-name} controller downloads a release ISO file and uses it to provision a repository virtual machine. The virtual machine name uses the format `upgrade-repo-hvst-xxxx`.
 
 image::upgrade/ts_status_phase1.png[]
 
-The time to complete the phase depends on the user's network speed and cluster resource utilization. We see failures in this phase due to network speed. If this happens, the user can <<Restart the upgrade,restart the upgrade>> again.
+Network speed and cluster resource utilization influence the amount of time required to complete this phase. Upgrades typically fail because of network speed issues.
 
-We can also check the repository VM (named with the format `upgrade-repo-hvst-xxxx`) status and its corresponding pod:
+If the upgrade fails at this point, check the status of the repository virtual machine and its corresponding pod before <<Restart the upgrade,restarting the upgrade>>. You can check the status using the command `kubectl get vm -n harvester-system`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get vm -n harvester-system
 NAME                              AGE    STATUS     READY
@@ -35,15 +37,17 @@ virt-launcher-upgrade-repo-hvst-upgrade-9gmg2-4mnmq     1/1     Running     0   
 
 === Phase 2: Preload container images
 
-The {harvester-product-name} controller creates jobs on each node to download images from the repository VM and preload them. These are the container images required for the next release.
+The {harvester-product-name} controller creates jobs that download and preload container images from the repository virtual machine. These images are required for the next release.
 
-During this stage you can see the upgrade status windows shows:
+Allow some time for the images to be downloaded and preloaded on all nodes.
 
 image::upgrade/ts_status_phase2.png[]
 
-It will take a while for all nodes to preload images. If the upgrade fails at this phase, the user can check job logs in the `cattle-system` namespace:
+If the upgrade fails at this point, check the job logs in the `cattle-system` namespace before <<Restart the upgrade,restarting the upgrade>>. You can check the logs using the command `kubectl get jobs -n cattle-system | grep prepare`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n cattle-system | grep prepare
 apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0e86   0/1           47s        47s
@@ -53,15 +57,17 @@ $ kubectl logs jobs/apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0
 ...
 ----
 
-It's also safe to <<Restart the upgrade,restart the upgrade>> if an upgrade fails at this phase.
-
 === Phase 3: Upgrade system services
+
+The {harvester-product-name} controller creates a job that upgrades component Helm charts.
 
 image::upgrade/ts_status_phase3.png[]
 
-The {harvester-product-name} controller upgrades component Helm charts with a job. The user can check the `apply-manifest` job with the following command:
+You can check the `apply-manifest` job using the command `$ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest
 NAME                                 COMPLETIONS   DURATION   AGE
@@ -71,20 +77,31 @@ $ kubectl logs jobs/hvst-upgrade-9gmg2-apply-manifests -n harvester-system
 ...
 ----
 
+[CAUTION]
+====
+If the upgrade fails at this point, you must generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle] before <<Restart the upgrade,restarting the upgrade>>. The support bundle contains logs and resource manifests that can help identify the cause of the failure.
+====
+
 === Phase 4: Upgrade nodes
+
+The {harvester-product-name} controller creates the following jobs on each node:
+
+* Multi-node clusters:
++
+** `pre-drain` job: Live-migrates or shuts down virtual machines on the node. Once completed, the embedded {rancher-short-name} service upgrades the {rke2-short-name} runtime on the node.
+** `post-drain` job: Upgrades and reboots the operating system.
+
+* Single-node clusters:
++
+** `single-node-upgrade` job: Upgrades the operating system and {rke2-short-name} runtime. The job name uses the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`.
 
 image::upgrade/ts_status_phase4.png[]
 
-The {harvester-product-name} controller creates jobs on each node (one by one) to upgrade nodes' OSes and RKE2 runtime. For multi-node clusters, there are two kinds of jobs to update a node:
+You can check the jobs running on each node by running the command `kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node`.
 
-* *pre-drain* job: live-migrate or shutdown VMs on a node. When the job completes, the embedded {rancher-short-name} service upgrades RKE2 runtime on a node.
-* *post-drain* job: upgrade OS and reboot.
+Example:
 
-For single-node clusters, there is only one `single-node-upgrade` type job for each node (named with the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`).
-
-The user can check node jobs by:
-
-[,console]
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node
 NAME                                  COMPLETIONS   DURATION   AGE
@@ -97,16 +114,31 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 ...
 ----
 
-[CAUTION]
+[WARNING]
 ====
-Do not <<Restart the upgrade,restart the upgrade>> if the process fails at this point. Identify the cause and then contact https://www.suse.com/support[SUSE Support], if necessary.
+If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
-=== Phase 5: Clean-up
+=== Phase 5: Cleanup
 
-The {harvester-product-name} controller deletes the upgrade repository VM and all files that are no longer needed.
+The {harvester-product-name} controller deletes the repository virtual machine and all files that are no longer necessary.
 
 == Common operations
+
+=== Restart the upgrade
+
+[WARNING]
+====
+If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+====
+
+. Generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle].
+
+. <<Stop the ongoing upgrade>>.
+
+. Click the *Upgrade* button on the *Dashboard* screen.
++
+If you xref:./upgrades.adoc#_customize_the_version[customized the version], you might need to xref:./upgrades.adoc#_prepare_the_version[create the version object] again.
 
 === Stop the ongoing upgrade
 
@@ -121,7 +153,7 @@ You can stop the upgrade by performing the following steps:
 
 . Retrieve a list of `Upgrade` CRs in the cluster.
 +
-[,console]
+[,shell]
 ----
 # become root
 $ sudo -i
@@ -134,7 +166,7 @@ hvst-upgrade-9gmg2   10m
 
 . Delete the `Upgrade` CR.
 +
-[,console]
+[,shell]
 ----
 $ kubectl delete upgrade.harvesterhci.io/hvst-upgrade-9gmg2 -n harvester-system
 ----
@@ -176,17 +208,9 @@ chmod +x ./resumeallcharts.sh
 ./resumeallcharts.sh
 ----
 
-=== Restart the upgrade
-
-. <<Stop the ongoing upgrade>>.
-
-. Click the *Upgrade* button on the UI *Dashboard* screen.
-+
-If you xref:./upgrades.adoc#_customize_the_version[customized the version], you might need to xref:./upgrades.adoc#_prepare_the_version[create the version object] again.
-
 === Download upgrade logs
 
-We have designed and implemented a mechanism to automatically collect all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
+{harvester-product-name} automatically collects all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
 
 image::upgrade/enable_logging.png[The "Enable Logging" checkbox on the upgrade confirmation dialog]
 
@@ -198,7 +222,7 @@ Log entries will be collected as files for each upgrade-related Pod, even for in
 
 image::upgrade/upgradelog_archive.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
-After the upgrade ended, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
+After the upgrade ends, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
 
 image::upgrade/dismiss_upgrade_to_remove_upgradelog.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
@@ -206,9 +230,9 @@ For more details, please refer to the https://github.com/harvester/harvester/blo
 
 [CAUTION]
 ====
-The storage volume for storing upgrade-related logs is 1GB by default. If an upgrade went into issues, the logs may consume all the available space of the volume. To work around such kind of incidents, try the following steps:
+The default size of the volume that stores upgrade-related logs is 1 GB. When errors occur, these logs may completely consume the volume's available space. To work around this issue, you can perform the following steps:
 
-. Detach the `log-archive` Volume by scaling down the `fluentd` StatefulSet and `downloader` Deployment.
+. Detach the `log-archive` volume by scaling down the `fluentd` StatefulSet and `downloader` deployment.
 +
 ----
 # Locate the StatefulSet and Deployment
@@ -219,7 +243,6 @@ hvst-upgrade-xxxxx-upgradelog-infra-fluentd   1/1     43s
 $ kubectl -n harvester-system get deployments -l harvesterhci.io/upgradeLogComponent=downloader
 NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
 hvst-upgrade-xxxxx-upgradelog-downloader   1/1     1            1           38s
-
 
 # Scale down the resources to terminate any Pods using the volume
 $ kubectl -n harvester-system scale statefulset hvst-upgrade-xxxxx-upgradelog-infra-fluentd --replicas=0
@@ -237,7 +260,7 @@ $ kubectl -n harvester-system get pvc -l harvesterhci.io/upgradeLogComponent=log
 pvc-63355afb-ce61-46c4-8781-377cf962278a
 ----
 
-. Recover the `fluentd` StatefulSet and `downloader` Deployment.
+. Recover the `fluentd` StatefulSet and `downloader` deployment.
 +
 [,console]
 ----
@@ -249,7 +272,7 @@ deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 ====
 
-=== Clean Up Unused Images
+=== Clean up unused images
 
 The default value of `imageGCHighThresholdPercent` in https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration[KubeletConfiguration] is `85`. When disk usage exceeds 85%, the kubelet attempts to remove unused images.
 

--- a/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
@@ -116,7 +116,7 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 
 [WARNING]
 ====
-If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+If the upgrade fails at this point, *do not restart* the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
 === Phase 5: Cleanup
@@ -129,7 +129,7 @@ The {harvester-product-name} controller deletes the repository virtual machine a
 
 [WARNING]
 ====
-If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, *do not restart* the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
 . Generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle].

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -636,7 +636,7 @@ The Harvester pod logs ('harvester-system/harvester' deployment) indicate that t
 
 === Root cause
 
-When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the {harvester-product-name} controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
 
 This process usually takes a short time to complete, but can be disrupted when the following occur:
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -573,3 +573,87 @@ Also, error indicators are no longer displayed for the downstream objects.
 === Related Issue
 
 https://github.com/harvester/harvester/issues/5505
+
+== Some `rancher-monitoring` add-on pods are abruptly terminated
+
+=== Issue description
+
+When the `rancher-monitoring` add-on is enabled, pods related to Prometheus, Alertmanager, and Grafana are terminated shortly after they are created.
+
+Example:
+
+[,shell]
+----
+$ kubectl -n cattle-monitoring-system get pods,svc,ep,deploy,pvc,sts,prometheus,alertmanager | grep -E 'stateful|deploy'
+
+deployment.apps/rancher-monitoring-grafana              0/0     0            0           7h52m
+deployment.apps/rancher-monitoring-kube-state-metrics   1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-operator             1/1     1            1           7h52m
+deployment.apps/rancher-monitoring-prometheus-adapter   1/1     1            1           7h52m
+statefulset.apps/alertmanager-rancher-monitoring-alertmanager   0/0     7h52m
+statefulset.apps/prometheus-rancher-monitoring-prometheus       0/0     7h52m
+----
+
+The `prometheus` pod logs contain the message `level=warn msg="Received SIGTERM, exiting gracefully..."`.
+
+[,shell]
+----
+...
+ts=2025-05-20T05:41:02.847Z caller=kubernetes.go:327 level=info component="discovery manager notify" discovery=kubernetes config=config-0 msg="Using pod service account via in-cluster config"
+ts=2025-05-20T05:41:02.880Z caller=main.go:1261 level=info msg="Completed loading of configuration file" filename=/etc/prometheus/config_out/prometheus.env.yaml totalDuration=35.457401ms db_storage=998ns remote_storage=1.45Âµs web_handler=392ns query_engine=1.095Âµs scrape=34.384Âµs scrape_sd=515.81Âµs notify=10.226Âµs notify_sd=82.314Âµs rules=32.514863ms tracing=2.344Âµs
+ts=2025-05-20T05:41:50.044Z caller=main.go:854 level=warn msg="Received SIGTERM, exiting gracefully..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:878 level=info msg="Stopping scrape discovery manager..."
+ts=2025-05-20T05:41:50.044Z caller=main.go:892 level=info msg="Stopping notify discovery manager..."
+...
+----
+
+The `prometheus` CRD object includes the `storage-network.settings.harvesterhci.io/replica: "1" ` annotation.
+
+[,yaml]
+----
+- apiVersion: monitoring.coreos.com/v1
+  kind: Prometheus
+  metadata:
+    annotations:
+      meta.helm.sh/release-name: rancher-monitoring
+      meta.helm.sh/release-namespace: cattle-monitoring-system
+      storage-network.settings.harvesterhci.io/replica: "1"
+    creationTimestamp: "2025-05-20T06:40:25Z"
+----
+
+The Harvester pod logs ('harvester-system/harvester' deployment) indicate that the attempt to change the `storage-network` setting was blocked.
+
+[,shell]
+----
+...
+2025-05-20T08:13:49.842448311Z time="2025-05-20T08:13:49Z" level=info msg="storage network change: {\"vlan\":955,\"clusterNetwork\":\"k8s-storage\",\"range\":\"198.18.2.0/24\"}"
+2025-05-20T08:13:49.842476305Z time="2025-05-20T08:13:49Z" level=info msg="rancher monitoring not found. skip"
+2025-05-20T08:13:49.842479072Z time="2025-05-20T08:13:49Z" level=info msg="current Grafana replicas: 0"
+2025-05-20T08:13:49.842480501Z time="2025-05-20T08:13:49Z" level=info msg="VM import controller no found. skip"
+2025-05-20T08:13:49.851381877Z time="2025-05-20T08:13:49Z" level=error msg="error syncing 'storage-network': handler harvester-storage-network-controller: Waiting for all volumes detached: pvc-6f66d234-f9c2-453e-8c17-383d9b489956,pvc-07c626f5-5135-4783-952d-cc20b1607cb5,pvc-1cfd6efe-c928-42e5-a834-8c27ed0e4897,pvc-5ce98d0a-5da1-4f30-af14-a8de29233380,pvc-1c9b7c9a-4943-4462-9082-217f9988cfc5,pvc-e9d92bfd-63c7-4ae3-ba00-1ce209f12caa,pvc-205ba31d-35fb-44f6-a3c4-c53001ec0dd6,pvc-6b5a7d11-7578-4397-9e13-ab475fe91463,pvc-669c69dd-93ad-4304-a340-484f7108362b,pvc-7668c486-b688-4524-b359-0cf9ec21cbc0,pvc-7d294996-821f-4434-ae4f-55a6de67f28c,pvc-216333c6-73f9-4e68-ac8b-53ab95a1f138,pvc-f72ca889-70c9-4dd9-bcec-a17ab65a1df4,pvc-01895fab-12f8-452a-9161-7d3c01e22726,pvc-330caa2d-5fdc-42f2-8c53-c5f80044760f,pvc-9506b7d0-c2d5-41f2-a08b-d7bc22dddb88,pvc-3e2b46d4-c471-44a9-9765-64babdb6ceed,pvc-25fe3372-1802-46d5-abf1-039099c567e2,pvc-b16fb262-cb38-4438-b074-84c7ad080a15,pvc-757c0f22-4ed6-4669-844d-cd7a87ceb26e,pvc-e0d99d8f-581f-4be6-baa3-d345308c9330,pvc-f5e1e19d-3dfb-4be1-9354-c092d7f03009,pvc-383ec26a-51f6-4f9d-8d8a-179651846d92,pvc-0d8f5737-c6e4-4f55-8d19-cf7a785552fc,pvc-5091892e-faf2-47b1-b987-bbde1ab2c13a,pvc-6f0c97ae-dfda-4799-bf26-e85feace5414,pvc-b0f717af-8a79-4c4e-b82e-90dedeae7697,pvc-ffe982d5-5ff1-40aa-a0db-cc10360d2d89,pvc-370757e2-4bce-41e7-b6f7-95aa8a5e8cf1,pvc-5a77d3e3-d555-476c-840f-7b9dadeb7478,pvc-43987c88-99b1-4889-9a47-5261717fe265,pvc-9f675704-9c52-46c2-96bf-2ff83d805383,pvc-d0b4e1d0-9bcd-4a8a-b52c-e1d8062a8099,pvc-a29be31f-531f-409a-bf5a-d267a54e2edb, requeuing"
+...
+----
+
+=== Root cause
+
+When you make changes to the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting, the Harvester controller waits for the attached volumes to be detached before applying the changes. In addition, the controller automatically terminates the pods related to Prometheus, Alertmanager, and Grafana because those pods use volumes to store data.
+
+This process usually takes a short time to complete, but can be disrupted when the following occur:
+
+* Attached volumes prevent the Harvester controller from applying the changes to the setting.
+* A user or the `monitoring-operator` attempts to enable the `rancher-monitoring` add-on.
+* The Harvester controller terminates the pods.
+
+=== Workaround
+
+. Disable the `rancher-monitoring` add-on.
+
+. Check if the xref:networking/storage-network.adoc#_storage_network_setting[storage-network] setting is enabled or disabled.
+
+. Check for error indicators in the Harvester pod logs. If volumes are still attached, stop the related virtual machines until no errors appear after the `storage network change` message.
+
+. Enable the `rancher-monitoring` add-on.
+
+=== Related issue
+
+https://github.com/harvester/harvester/issues/8565

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -656,4 +656,4 @@ This process usually takes a short time to complete, but can be disrupted when t
 
 === Related issue
 
-https://github.com/harvester/harvester/issues/8565
+https://github.com/harvester/harvester/issues/8565[Issue #8565]

--- a/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
@@ -7,23 +7,25 @@ Here are some tips to troubleshoot a failed upgrade:
 * Check xref:./upgrades.adoc#_upgrade_support_matrix[version-specific upgrade notes]. You can click the version in the support matrix table to see if there are any known issues.
 * Dive into the upgrade https://github.com/harvester/harvester/blob/master/enhancements/20220413-zero-downtime-upgrade.md[design proposal]. The following section briefly describes phases within an upgrade and possible diagnostic methods.
 
-== Investigate the Upgrade Flow
+== Upgrade flow
 
 The upgrade process includes several phases.
 
 image::upgrade/ts_upgrade_phases.png[]
 
-=== Phase 1: Provision upgrade repository VM.
+=== Phase 1: Provision upgrade repository virtual machine
 
-The {harvester-product-name} controller downloads a release ISO file and uses it to provision a VM. During this phase you can see the upgrade status windows show:
+The {harvester-product-name} controller downloads a release ISO file and uses it to provision a repository virtual machine. The virtual machine name uses the format `upgrade-repo-hvst-xxxx`.
 
 image::upgrade/ts_status_phase1.png[]
 
-The time to complete the phase depends on the user's network speed and cluster resource utilization. We see failures in this phase due to network speed. If this happens, the user can <<Restart the upgrade,restart the upgrade>> again.
+Network speed and cluster resource utilization influence the amount of time required to complete this phase. Upgrades typically fail because of network speed issues.
 
-We can also check the repository VM (named with the format `upgrade-repo-hvst-xxxx`) status and its corresponding pod:
+If the upgrade fails at this point, check the status of the repository virtual machine and its corresponding pod before <<Restart the upgrade,restarting the upgrade>>. You can check the status using the command `kubectl get vm -n harvester-system`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get vm -n harvester-system
 NAME                              AGE    STATUS     READY
@@ -35,15 +37,17 @@ virt-launcher-upgrade-repo-hvst-upgrade-9gmg2-4mnmq     1/1     Running     0   
 
 === Phase 2: Preload container images
 
-The {harvester-product-name} controller creates jobs on each node to download images from the repository VM and preload them. These are the container images required for the next release.
+The {harvester-product-name} controller creates jobs that download and preload container images from the repository virtual machine. These images are required for the next release.
 
-During this stage you can see the upgrade status windows shows:
+Allow some time for the images to be downloaded and preloaded on all nodes.
 
 image::upgrade/ts_status_phase2.png[]
 
-It will take a while for all nodes to preload images. If the upgrade fails at this phase, the user can check job logs in the `cattle-system` namespace:
+If the upgrade fails at this point, check the job logs in the `cattle-system` namespace before <<Restart the upgrade,restarting the upgrade>>. You can check the logs using the command `kubectl get jobs -n cattle-system | grep prepare`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n cattle-system | grep prepare
 apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0e86   0/1           47s        47s
@@ -53,15 +57,17 @@ $ kubectl logs jobs/apply-hvst-upgrade-9gmg2-prepare-on-node1-with-2bbea1599a-f0
 ...
 ----
 
-It's also safe to <<Restart the upgrade,restart the upgrade>> if an upgrade fails at this phase.
-
 === Phase 3: Upgrade system services
+
+The {harvester-product-name} controller creates a job that upgrades component Helm charts.
 
 image::upgrade/ts_status_phase3.png[]
 
-The {harvester-product-name} controller upgrades component Helm charts with a job. The user can check the `apply-manifest` job with the following command:
+You can check the `apply-manifest` job using the command `$ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest`.
 
-[,console]
+Example:
+
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=manifest
 NAME                                 COMPLETIONS   DURATION   AGE
@@ -71,20 +77,31 @@ $ kubectl logs jobs/hvst-upgrade-9gmg2-apply-manifests -n harvester-system
 ...
 ----
 
+[CAUTION]
+====
+If the upgrade fails at this point, you must generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle] before <<Restart the upgrade,restarting the upgrade>>. The support bundle contains logs and resource manifests that can help identify the cause of the failure.
+====
+
 === Phase 4: Upgrade nodes
+
+The {harvester-product-name} controller creates the following jobs on each node:
+
+* Multi-node clusters:
++
+** `pre-drain` job: Live-migrates or shuts down virtual machines on the node. Once completed, the embedded {rancher-short-name} service upgrades the {rke2-short-name} runtime on the node.
+** `post-drain` job: Upgrades and reboots the operating system.
+
+* Single-node clusters:
++
+** `single-node-upgrade` job: Upgrades the operating system and {rke2-short-name} runtime. The job name uses the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`.
 
 image::upgrade/ts_status_phase4.png[]
 
-The {harvester-product-name} controller creates jobs on each node (one by one) to upgrade nodes' OSes and RKE2 runtime. For multi-node clusters, there are two kinds of jobs to update a node:
+You can check the jobs running on each node by running the command `kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node`.
 
-* *pre-drain* job: live-migrate or shutdown VMs on a node. When the job completes, the embedded {rancher-short-name} service upgrades RKE2 runtime on a node.
-* *post-drain* job: upgrade OS and reboot.
+Example:
 
-For single-node clusters, there is only one `single-node-upgrade` type job for each node (named with the format `hvst-upgrade-xxx-single-node-upgrade-<hostname>`).
-
-The user can check node jobs by:
-
-[,console]
+[,shell]
 ----
 $ kubectl get jobs -n harvester-system -l harvesterhci.io/upgradeComponent=node
 NAME                                  COMPLETIONS   DURATION   AGE
@@ -97,16 +114,31 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 ...
 ----
 
-[CAUTION]
+[WARNING]
 ====
-Do not <<Restart the upgrade,restart the upgrade>> if the process fails at this point. Identify the cause and then contact https://www.suse.com/support[SUSE Support], if necessary.
+If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
-=== Phase 5: Clean-up
+=== Phase 5: Cleanup
 
-The {harvester-product-name} controller deletes the upgrade repository VM and all files that are no longer needed.
+The {harvester-product-name} controller deletes the repository virtual machine and all files that are no longer necessary.
 
 == Common operations
+
+=== Restart the upgrade
+
+[WARNING]
+====
+If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+====
+
+. Generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle].
+
+. <<Stop the ongoing upgrade>>.
+
+. Click the *Upgrade* button on the *Dashboard* screen.
++
+If you xref:./upgrades.adoc#_customize_the_version[customized the version], you might need to xref:./upgrades.adoc#_prepare_the_version[create the version object] again.
 
 === Stop the ongoing upgrade
 
@@ -121,7 +153,7 @@ You can stop the upgrade by performing the following steps:
 
 . Retrieve a list of `Upgrade` CRs in the cluster.
 +
-[,console]
+[,shell]
 ----
 # become root
 $ sudo -i
@@ -134,7 +166,7 @@ hvst-upgrade-9gmg2   10m
 
 . Delete the `Upgrade` CR.
 +
-[,console]
+[,shell]
 ----
 $ kubectl delete upgrade.harvesterhci.io/hvst-upgrade-9gmg2 -n harvester-system
 ----
@@ -176,17 +208,9 @@ chmod +x ./resumeallcharts.sh
 ./resumeallcharts.sh
 ----
 
-=== Restart the upgrade
-
-. <<Stop the ongoing upgrade>>.
-
-. Click the *Upgrade* button on the UI *Dashboard* screen.
-+
-If you xref:./upgrades.adoc#_customize_the_version[customized the version], you might need to xref:./upgrades.adoc#_prepare_the_version[create the version object] again.
-
 === Download upgrade logs
 
-We have designed and implemented a mechanism to automatically collect all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
+{harvester-product-name} automatically collects all the upgrade-related logs and display the upgrade procedure. By default, this is enabled. You can also choose to opt out of such behavior.
 
 image::upgrade/enable_logging.png[The "Enable Logging" checkbox on the upgrade confirmation dialog]
 
@@ -198,7 +222,7 @@ Log entries will be collected as files for each upgrade-related Pod, even for in
 
 image::upgrade/upgradelog_archive.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
-After the upgrade ended, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
+After the upgrade ends, {harvester-product-name} stops collecting the upgrade logs to avoid occupying the disk space. In addition, you can click the *Dismiss it* button to purge the upgrade logs.
 
 image::upgrade/dismiss_upgrade_to_remove_upgradelog.png[The upgrade log archive contains all the logs generated by the upgrade-related Pods]
 
@@ -206,9 +230,9 @@ For more details, please refer to the https://github.com/harvester/harvester/blo
 
 [CAUTION]
 ====
-The storage volume for storing upgrade-related logs is 1GB by default. If an upgrade went into issues, the logs may consume all the available space of the volume. To work around such kind of incidents, try the following steps:
+The default size of the volume that stores upgrade-related logs is 1 GB. When errors occur, these logs may completely consume the volume's available space. To work around this issue, you can perform the following steps:
 
-. Detach the `log-archive` Volume by scaling down the `fluentd` StatefulSet and `downloader` Deployment.
+. Detach the `log-archive` volume by scaling down the `fluentd` StatefulSet and `downloader` deployment.
 +
 ----
 # Locate the StatefulSet and Deployment
@@ -219,7 +243,6 @@ hvst-upgrade-xxxxx-upgradelog-infra-fluentd   1/1     43s
 $ kubectl -n harvester-system get deployments -l harvesterhci.io/upgradeLogComponent=downloader
 NAME                                            READY   UP-TO-DATE   AVAILABLE   AGE
 hvst-upgrade-xxxxx-upgradelog-downloader   1/1     1            1           38s
-
 
 # Scale down the resources to terminate any Pods using the volume
 $ kubectl -n harvester-system scale statefulset hvst-upgrade-xxxxx-upgradelog-infra-fluentd --replicas=0
@@ -237,7 +260,7 @@ $ kubectl -n harvester-system get pvc -l harvesterhci.io/upgradeLogComponent=log
 pvc-63355afb-ce61-46c4-8781-377cf962278a
 ----
 
-. Recover the `fluentd` StatefulSet and `downloader` Deployment.
+. Recover the `fluentd` StatefulSet and `downloader` deployment.
 +
 [,console]
 ----
@@ -249,7 +272,7 @@ deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 ====
 
-=== Clean Up Unused Images
+=== Clean up unused images
 
 The default value of `imageGCHighThresholdPercent` in https://kubernetes.io/docs/reference/config-api/kubelet-config.v1beta1/#kubelet-config-k8s-io-v1beta1-KubeletConfiguration[KubeletConfiguration] is `85`. When disk usage exceeds 85%, the kubelet attempts to remove unused images.
 

--- a/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
@@ -116,7 +116,7 @@ $ kubectl logs -n harvester-system jobs/hvst-upgrade-9gmg2-post-drain-node2
 
 [WARNING]
 ====
-If the upgrade fails at this point, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+If the upgrade fails at this point, *do not restart* the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
 === Phase 5: Cleanup
@@ -129,7 +129,7 @@ The {harvester-product-name} controller deletes the repository virtual machine a
 
 [WARNING]
 ====
-If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, **do not restart** the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
+If the ongoing upgrade fails or becomes stuck at <<Phase 4: Upgrade nodes>>, *do not restart* the upgrade unless instructed by https://www.suse.com/support[SUSE Support].
 ====
 
 . Generate a xref:troubleshooting/operating-system.adoc#_generate_a_support_bundle[support bundle].


### PR DESCRIPTION
Scope: v1.4, v1.5, v1.6

PRs:
- [802](https://github.com/harvester/docs/pull/802): Upgrade troubleshooting warnings and instructions
- [807](https://github.com/harvester/docs/pull/807): `rancher-monitoring`add-on issue and workaround

Other changes:
- Replaced community project names with product name variables (Note: Component names that include "Harvester" and "Longhorn" will not be rebranded for now.)
- Used sentence case in headings per SUSE style guide