### PR TITLE
Add content from community doc PRs (813, 814)

### DIFF
--- a/versions/v1.4/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -250,7 +250,7 @@ spec:
 
 == Known Issues
 
-=== 1. Upgrade Stuck in "Pre-draining" State
+=== 1. Upgrade stuck in the "Pre-draining" state
 
 A virtual machine with a container disk cannot be migrated because of a limitation of the live migration feature. This causes the upgrade process to become stuck in the "Pre-draining" state.
 
@@ -261,7 +261,7 @@ Manually stop the virtual machines to continue the upgrade process.
 
 Related issue: https://github.com/harvester/harvester/issues/7005[#7005]
 
-=== 2. Upgrade Stuck on Waiting for Bundle to Become Ready
+=== 2. Upgrade stuck on waiting for bundle
 
 This issue is caused by a race condition when the Fleet agent (`fleet-agent`) is redeployed. The following error messages indicate that the issue exists.
 
@@ -309,9 +309,9 @@ kubectl delete svc longhorn-engine-manager -n longhorn-system --ignore-not-found
 kubectl delete svc longhorn-replica-manager -n longhorn-system --ignore-not-found=true
 ----
 
-=== 3. Upgrade Stuck on Waiting for Fleet
+=== 3. Upgrade stuck on waiting for Fleet
 
-When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when Rancher is redeployed.
+When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when {rancher-product-name} is redeployed.
 
 Check the Harvester logs and Fleet history for the following indicators:
 
@@ -341,19 +341,19 @@ You can run the following command to fix the issue.
 helm rollback fleet -n cattle-fleet-system <last-deployed-revision>
 ----
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -361,3 +361,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -31,11 +31,11 @@ If `passive.img` (which represents the previously installed Harvester v1.4.0 ima
 `passive.img` is converted to a sparse file, which should only consume 1.7G of disk space (the same as `active.img`). This ensures that each node has enough free space, preventing the upgrade process from becoming <<3. Upgrade Stuck in "Waiting Reboot" State,stuck in the "Waiting Reboot" state>>.
 ====
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-short-name} v2.10.1
 
-To import Harvester v1.4.1 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for Harvester.
+To import Harvester v1.4.1 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for Harvester.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -58,16 +58,16 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
-Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
+Related issues: https://github.com/harvester/harvester/issues/7234[#7234] and https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
-== Known Issues
+== Known issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -131,9 +131,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[#7366], https://github.com/longhorn/longhorn/issues/6764[#6746]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. Upgrade with Default StorageClass That Is Not harvester-longhorn
+=== 2. Upgrade with default StorageClass that is not `harvester-longhorn`
 
 Harvester adds the annotation `storageclass.kubernetes.io/is-default-class: "true"` to `harvester-longhorn`, which is the original default StorageClass. When you replace `harvester-longhorn` with another StorageClass, the following occur:
 
@@ -165,7 +165,7 @@ image::upgrade/upgrade-with-another-default-storage-class-workaround.png[]
 
 Related issue: https://github.com/harvester/harvester/issues/7375[#7375]
 
-=== 3. Upgrade Stuck in "Waiting Reboot" State
+=== 3. Upgrade stuck in "Waiting Reboot" state
 
 The upgrade process may become stuck in the "Waiting Reboot" state after the Harvester v1.4.1 image is installed on a node and a reboot is initiated. At this point, the upgrade controller observes if the Harvester v1.4.1 operating system is running.
 
@@ -318,19 +318,19 @@ The node should boot successfully into Harvester v1.4.1, and the upgrade should 
 
 Related issues: https://github.com/harvester/harvester/issues/7457[#7457], https://github.com/harvester/harvester/issues/7493[#7493], https://github.com/harvester/harvester/issues/7518[#7518]
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -338,3 +338,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -6,11 +6,11 @@ An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-
 
 For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-short-name} v2.10.1
 
-To import {harvester-product-name} v1.4.2 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for {harvester-product-name}.
+To import {harvester-product-name} v1.4.2 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for {harvester-product-name}.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -33,20 +33,20 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
-=== Virtual Machine Backup Compatibility
+== Virtual machine backup compatibility
 
 You may encounter certain limitations when creating and restoring xref:../storage/csidriver.adoc#_virtual_machine_backup_compatibility[backups that involve external storage].
 
-== Known Issues
+== Known issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -110,9 +110,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[#7366], https://github.com/longhorn/longhorn/issues/6764[#6764]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. High CPU Usage
+=== 2. High CPU usage
 
 High CPU usage may occur because of the `backup-target` setting's `refreshIntervalInSeconds` field. If the field is left empty or is set to `0`, {harvester-product-name} constantly refreshes the backup target, resulting in high CPU usage.
 
@@ -127,19 +127,19 @@ value: '{"type":"nfs","endpoint":"nfs://longhorn-test-nfs-svc.default:/opt/backu
 
 Related issue: https://github.com/harvester/harvester/issues/7885[#7885]
 
-=== 3. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 3. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -147,3 +147,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -195,3 +195,13 @@ If you are using the hotfixed image and want to upgrade {harvester-product-name}
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/8354[8354] and https://github.com/longhorn/longhorn/issues/10621[10621]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/nav.adoc
+++ b/versions/v1.5/modules/en/nav.adoc
@@ -44,6 +44,7 @@
 ** xref:upgrades/v1-4-1-to-v1-4-3.adoc[]
 ** xref:upgrades/v1-4-2-to-v1-5-0.adoc[]
 ** xref:upgrades/v1-4-2-to-v1-5-1.adoc[]
+** xref:upgrades/v1-5-0-to-v1-5-1.adoc[]
 ** xref:upgrades/troubleshooting.adoc[]
 
 // Folder: hosts:

--- a/versions/v1.5/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -250,7 +250,7 @@ spec:
 
 == Known Issues
 
-=== 1. The upgrade process becomes stuck in the "Pre-draining" state.
+=== 1. Upgrade stuck in the "Pre-draining" state
 
 A virtual machine with a container disk cannot be migrated because of a limitation of the live migration feature. This causes the upgrade process to become stuck in the "Pre-draining" state.
 
@@ -261,7 +261,7 @@ Manually stop the virtual machines to continue the upgrade process.
 
 Related issue: https://github.com/harvester/harvester/issues/7005[#7005]
 
-=== 2. The upgrade process becomes stuck on waiting for the Harvester bundle to become ready.
+=== 2. Upgrade stuck on waiting for bundle
 
 This issue is caused by a race condition when the Fleet agent (`fleet-agent`) is redeployed. The following error messages indicate that the issue exists.
 
@@ -309,9 +309,9 @@ kubectl delete svc longhorn-engine-manager -n longhorn-system --ignore-not-found
 kubectl delete svc longhorn-replica-manager -n longhorn-system --ignore-not-found=true
 ----
 
-=== 3. Upgrade Stuck on Waiting for Fleet
+=== 3. Upgrade stuck on waiting for Fleet
 
-When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when Rancher is redeployed.
+When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when {rancher-product-name} is redeployed.
 
 Check the Harvester logs and Fleet history for the following indicators:
 
@@ -341,19 +341,19 @@ You can run the following command to fix the issue.
 helm rollback fleet -n cattle-fleet-system <last-deployed-revision>
 ----
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -361,3 +361,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -31,11 +31,11 @@ If `passive.img` (which represents the previously installed Harvester v1.4.0 ima
 `passive.img` is converted to a sparse file, which should only consume 1.7G of disk space (the same as `active.img`). This ensures that each node has enough free space, preventing the upgrade process from becoming <<3. Upgrade Stuck in "Waiting Reboot" State,stuck in the "Waiting Reboot" state>>.
 ====
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-product-name} v2.10.1
 
-To import Harvester v1.4.1 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for Harvester.
+To import Harvester v1.4.1 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for Harvester.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -58,16 +58,16 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
-Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
+Related issues: https://github.com/harvester/harvester/issues/7234[#7234] and https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
 == Known Issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -131,9 +131,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[#7366], https://github.com/longhorn/longhorn/issues/6764[#6764]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. Upgrade with Default StorageClass That Is Not harvester-longhorn
+=== 2. Upgrade with default StorageClass that is not `harvester-longhorn`
 
 Harvester adds the annotation `storageclass.kubernetes.io/is-default-class: "true"` to `harvester-longhorn`, which is the original default StorageClass. When you replace `harvester-longhorn` with another StorageClass, the following occur:
 
@@ -165,7 +165,7 @@ image::upgrade/upgrade-with-another-default-storage-class-workaround.png[]
 
 Related issue: https://github.com/harvester/harvester/issues/7375[#7375]
 
-=== 3. Upgrade Stuck in "Waiting Reboot" State
+=== 3. Upgrade stuck in "Waiting Reboot" state
 
 The upgrade process may become stuck in the "Waiting Reboot" state after the Harvester v1.4.1 image is installed on a node and a reboot is initiated. At this point, the upgrade controller observes if the Harvester v1.4.1 operating system is running.
 
@@ -318,19 +318,19 @@ The node should boot successfully into Harvester v1.4.1, and the upgrade should 
 
 Related issues: https://github.com/harvester/harvester/issues/7457[#7457], https://github.com/harvester/harvester/issues/7493[#7493], https://github.com/harvester/harvester/issues/7518[#7518]
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -338,3 +338,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -6,11 +6,11 @@ An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-
 
 For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-product-name} v2.10.1
 
-To import {harvester-product-name} v1.4.2 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for {harvester-product-name}.
+To import {harvester-product-name} v1.4.2 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for {harvester-product-name}.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -33,20 +33,20 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
-== Virtual Machine Backup Compatibility
+== Virtual machine backup compatibility
 
 You may encounter certain limitations when creating and restoring backups that involve external storage.
 
-== Known Issues
+== Known issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -110,9 +110,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[7366], https://github.com/longhorn/longhorn/issues/6764[6764]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. High CPU Usage
+=== 2. High CPU usage
 
 High CPU usage may occur because of the `backup-target` setting's `refreshIntervalInSeconds` field. If the field is left empty or is set to `0`, {harvester-product-name} constantly refreshes the backup target, resulting in high CPU usage.
 
@@ -127,19 +127,19 @@ value: '{"type":"nfs","endpoint":"nfs://longhorn-test-nfs-svc.default:/opt/backu
 
 Related issue: https://github.com/harvester/harvester/issues/7885[#7885]
 
-=== 3. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 3. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -147,3 +147,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -195,3 +195,13 @@ If you are using the hotfixed image and want to upgrade {harvester-product-name}
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/8354[8354] and https://github.com/longhorn/longhorn/issues/10621[10621]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
@@ -4,13 +4,13 @@
 
 An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-product-name} version that you can upgrade to becomes available. For more information, see xref:./upgrades.adoc#_start_an_upgrade[Start an upgrade].
 
-{harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31). This allows you to directly upgrade from v1.4.2 to v1.5.0.
+You can directly upgrade from v1.4.2 to v1.5.0 because {harvester-product-name} allows a maximum of one minor version upgrade for underlying components. {harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31), while {harvester-product-name} v1.5.0 uses the next minor version (v1.32).
 
-For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
 === Update the Harvester UI Extension on {rancher-product-name} v2.11.0
 
-To import {harvester-product-name} v1.5.0 clusters, you must use **v1.5.0** of the Harvester UI Extension.
+You must use **v1.5.0** of the Harvester UI Extension to import {harvester-product-name} v1.5.0 clusters on {rancher-short-name} v2.11.0.
 
 . On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
@@ -208,3 +208,13 @@ kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/8163[#8163]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
@@ -6,11 +6,11 @@ An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-
 
 You can directly upgrade from v1.4.2 to v1.5.1 because {harvester-product-name} allows a maximum of one minor version upgrade for underlying components. {harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31), while {harvester-product-name} v1.5.0 and v1.5.1 use the next minor version (v1.32).
 
-For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
 === Update the Harvester UI Extension on {rancher-product-name} v2.11.0
 
-To import {harvester-product-name} v1.5.1 clusters, you must use **v1.5.1** of the Harvester UI extension.
+You must use **v1.5.1** of the Harvester UI Extension to import {harvester-product-name} v1.5.1 clusters on {rancher-short-name} v2.11.0.
 
 . On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
@@ -119,3 +119,13 @@ The upgrade process should continue after the images are preloaded.
 - (Not recommended) Restart the upgrade process with logging disabled. Ensure that the *Enable Logging* checkbox in the *Upgrade* dialog is not selected.
 
 Related issue: https://github.com/harvester/harvester/issues/7955[#7955]
+
+=== 2. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -1,0 +1,35 @@
+= Upgrade from v1.5.0 to v1.5.1
+
+== General information
+
+An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-product-name} version that you can upgrade to becomes available. For more information, see xref:./upgrades.adoc#_start_an_upgrade[Start an upgrade].
+
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+
+=== Update the Harvester UI Extension on {rancher-product-name} v2.11.0
+
+You must use **v1.5.1** of the Harvester UI Extension to import {harvester-product-name} v1.5.1 clusters on {rancher-short-name} v2.11.0.
+
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
+
+. Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
+
+. Go to the *Extensions* screen.
+
+. Locate the extension named *Harvester*, and then click *Update*.
+
+. Select version *1.5.1*, and then click *Update*.
+
+. Allow some time for the extension to be updated, and then refresh the screen.
+
+== Known issues
+
+=== 1. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/nav.adoc
+++ b/versions/v1.6/modules/en/nav.adoc
@@ -45,6 +45,7 @@
 ** xref:upgrades/v1-4-1-to-v1-4-3.adoc[]
 ** xref:upgrades/v1-4-2-to-v1-5-0.adoc[]
 ** xref:upgrades/v1-4-2-to-v1-5-1.adoc[]
+** xref:upgrades/v1-5-0-to-v1-5-1.adoc[]
 ** xref:upgrades/troubleshooting.adoc[]
 
 // Folder: hosts:

--- a/versions/v1.6/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -250,7 +250,7 @@ spec:
 
 == Known Issues
 
-=== 1. The upgrade process becomes stuck in the "Pre-draining" state.
+=== 1. Upgrade stuck in the "Pre-draining" state
 
 A virtual machine with a container disk cannot be migrated because of a limitation of the live migration feature. This causes the upgrade process to become stuck in the "Pre-draining" state.
 
@@ -261,7 +261,7 @@ Manually stop the virtual machines to continue the upgrade process.
 
 Related issue: https://github.com/harvester/harvester/issues/7005[#7005]
 
-=== 2. The upgrade process becomes stuck on waiting for the Harvester bundle to become ready.
+=== 2. Upgrade stuck on waiting for bundle
 
 This issue is caused by a race condition when the Fleet agent (`fleet-agent`) is redeployed. The following error messages indicate that the issue exists.
 
@@ -309,9 +309,9 @@ kubectl delete svc longhorn-engine-manager -n longhorn-system --ignore-not-found
 kubectl delete svc longhorn-replica-manager -n longhorn-system --ignore-not-found=true
 ----
 
-=== 3. Upgrade Stuck on Waiting for Fleet
+=== 3. Upgrade stuck on waiting for Fleet
 
-When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when Rancher is redeployed.
+When upgrading from v1.3.2 to v1.4.0, the upgrade process may become stuck on waiting for Fleet to become ready. This issue is caused by a race condition when {rancher-product-name} is redeployed.
 
 Check the Harvester logs and Fleet history for the following indicators:
 
@@ -341,19 +341,19 @@ You can run the following command to fix the issue.
 helm rollback fleet -n cattle-fleet-system <last-deployed-revision>
 ----
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -361,3 +361,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -31,11 +31,11 @@ If `passive.img` (which represents the previously installed Harvester v1.4.0 ima
 `passive.img` is converted to a sparse file, which should only consume 1.7G of disk space (the same as `active.img`). This ensures that each node has enough free space, preventing the upgrade process from becoming <<3. Upgrade Stuck in "Waiting Reboot" State,stuck in the "Waiting Reboot" state>>.
 ====
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-short-name} v2.10.1
 
-To import Harvester v1.4.1 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for Harvester.
+To import Harvester v1.4.1 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for Harvester.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -58,16 +58,16 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
-Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
+Related issues: https://github.com/harvester/harvester/issues/7234[#7234] and https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
-== Known Issues
+== Known issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -131,9 +131,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[#7366], https://github.com/longhorn/longhorn/issues/6764[#6764]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. Upgrade with Default StorageClass That Is Not harvester-longhorn
+=== 2. Upgrade with default StorageClass that is not `harvester-longhorn`
 
 Harvester adds the annotation `storageclass.kubernetes.io/is-default-class: "true"` to `harvester-longhorn`, which is the original default StorageClass. When you replace `harvester-longhorn` with another StorageClass, the following occur:
 
@@ -165,7 +165,7 @@ image::upgrade/upgrade-with-another-default-storage-class-workaround.png[]
 
 Related issue: https://github.com/harvester/harvester/issues/7375[#7375]
 
-=== 3. Upgrade Stuck in "Waiting Reboot" State
+=== 3. Upgrade stuck in "Waiting Reboot" state
 
 The upgrade process may become stuck in the "Waiting Reboot" state after the Harvester v1.4.1 image is installed on a node and a reboot is initiated. At this point, the upgrade controller observes if the Harvester v1.4.1 operating system is running.
 
@@ -318,19 +318,19 @@ The node should boot successfully into Harvester v1.4.1, and the upgrade should 
 
 Related issues: https://github.com/harvester/harvester/issues/7457[#7457], https://github.com/harvester/harvester/issues/7493[#7493], https://github.com/harvester/harvester/issues/7518[#7518]
 
-=== 4. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 4. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -338,3 +338,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 5. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -6,11 +6,11 @@ An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-
 
 For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
-=== Update Harvester UI Extension on Rancher v2.10.1
+=== Update Harvester UI Extension on {rancher-product-name} v2.10.1
 
-To import {harvester-product-name} v1.4.2 clusters on Rancher v2.10.1, you must use **v1.0.3** of the Rancher UI extension for {harvester-product-name}.
+To import {harvester-product-name} v1.4.2 clusters on {rancher-short-name} v2.10.1, you must use **v1.0.3** of the {rancher-short-name} UI extension for {harvester-product-name}.
 
-. On the Rancher UI, go to *local -> Apps -> Repositories*.
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
 . Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
 +
@@ -33,20 +33,20 @@ image::upgrade/update-harvester-ui-extension-modal.png[]
 
 [IMPORTANT]
 ====
-The Rancher UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
+The {rancher-short-name} UI displays an error message after the extension is updated. The error message disappears when you refresh the screen.
 
-This issue, which exists in Rancher v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
+This issue, which exists in {rancher-short-name} v2.10.0 and v2.10.1, will be fixed in v2.10.2. 
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/7234[#7234], https://github.com/rancher/capi-ui-extension/issues/107[#107]
 
-== Virtual Machine Backup Compatibility
+== Virtual machine backup compatibility
 
 You may encounter certain limitations when creating and restoring backups that involve external storage.
 
-== Known Issues
+== Known issues
 
-=== 1. Upgrade Stuck in "Pre-drained" State
+=== 1. Upgrade stuck in "Pre-drained" state
 
 The upgrade process may become stuck in the "Pre-drained" state. Kubernetes is supposed to drain the workload on the node, but some factors may cause the process to stall.
 
@@ -110,9 +110,9 @@ Example:
 kubectl delete pdb instance-manager-d80e13f520e7b952f4b7593fc1883e2a -n longhorn-system
 ----
 
-Related issues: https://github.com/harvester/harvester/issues/7366[7366], https://github.com/longhorn/longhorn/issues/6764[6764]
+Related issues: https://github.com/harvester/harvester/issues/7366[#7366] and https://github.com/longhorn/longhorn/issues/6764[#6764]
 
-=== 2. High CPU Usage
+=== 2. High CPU usage
 
 High CPU usage may occur because of the `backup-target` setting's `refreshIntervalInSeconds` field. If the field is left empty or is set to `0`, {harvester-product-name} constantly refreshes the backup target, resulting in high CPU usage.
 
@@ -127,19 +127,19 @@ value: '{"type":"nfs","endpoint":"nfs://longhorn-test-nfs-svc.default:/opt/backu
 
 Related issue: https://github.com/harvester/harvester/issues/7885[#7885]
 
-=== 3. Upgrade Restarts Unexpectedly After Clicking "Dismiss it" Button
+=== 3. Upgrade restarts unexpectedly after the "Dismiss it" button is clicked
 
-When you use Rancher to upgrade {harvester-product-name}, the Rancher UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
+When you use {rancher-short-name} to upgrade {harvester-product-name}, the {rancher-short-name} UI displays a dialog with a button labeled "Dismiss it". Clicking this button may result in the following issues:
 
 * The `status` section of the `harvesterhci.io/v1beta1/upgrade` CR is cleared, causing the loss of all important information about the upgrade.
 * The upgrade process restarts unexpectedly.
 
-This issue affects Rancher v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
+This issue affects {rancher-short-name} v2.10.x, which uses v1.0.2, v1.0.3, and v1.0.4 of the xref:../integrations/rancher/harvester-ui-extension.adoc#_support_matrix[Harvester UI Extension]. All {harvester-product-name} UI versions are not affected. The issue is fixed in Harvester UI Extension v1.0.5 and v1.5.0.
 
 To avoid this issue, perform either of the following actions:
 
 * Use the {harvester-product-name} UI for upgrades. Clicking the "Dismiss it" button on the {harvester-product-name} UI does not result in unexpected behavior.
-* Instead of clicking the button on the Rancher UI, run the following command against the cluster:
+* Instead of clicking the button on the {rancher-short-name} UI, run the following command against the cluster:
 +
 [,shell]
 ----
@@ -147,3 +147,13 @@ kubectl -n harvester-system label upgrades -l harvesterhci.io/latestUpgrade=true
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/7791[#7791]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -195,3 +195,13 @@ If you are using the hotfixed image and want to upgrade {harvester-product-name}
 ====
 
 Related issues: https://github.com/harvester/harvester/issues/8354[8354] and https://github.com/longhorn/longhorn/issues/10621[10621]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
@@ -4,13 +4,13 @@
 
 An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-product-name} version that you can upgrade to becomes available. For more information, see xref:./upgrades.adoc#_start_an_upgrade[Start an upgrade].
 
-{harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31). This allows you to directly upgrade from v1.4.2 to v1.5.0.
+You can directly upgrade from v1.4.2 to v1.5.0 because {harvester-product-name} allows a maximum of one minor version upgrade for underlying components. {harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31), while {harvester-product-name} v1.5.0 uses the next minor version (v1.32).
 
-For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
 === Update the Harvester UI Extension on {rancher-product-name} v2.11.0
 
-To import {harvester-product-name} v1.5.0 clusters, you must use **v1.5.0** of the Harvester UI extension.
+You must use **v1.5.0** of the Harvester UI Extension to import {harvester-product-name} v1.5.0 clusters on {rancher-short-name} v2.11.0.
 
 . On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
@@ -208,3 +208,13 @@ kubectl apply -f https://raw.githubusercontent.com/harvester/harvester/refs/tags
 ----
 
 Related issue: https://github.com/harvester/harvester/issues/8163[#8163]
+
+=== 4. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
@@ -6,11 +6,11 @@ An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-
 
 You can directly upgrade from v1.4.2 to v1.5.1 because {harvester-product-name} allows a maximum of one minor version upgrade for underlying components. {harvester-product-name} v1.4.2 and v1.4.3 use the same minor version of {rke2-product-name} (v1.31), while {harvester-product-name} v1.5.0 and v1.5.1 use the next minor version (v1.32).
 
-For air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
 
 === Update the Harvester UI Extension on {rancher-product-name} v2.11.0
 
-To import {harvester-product-name} v1.5.1 clusters, you must use **v1.5.1** of the Harvester UI extension.
+You must use **v1.5.1** of the Harvester UI Extension to import {harvester-product-name} v1.5.1 clusters on {rancher-short-name} v2.11.0.
 
 . On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
 
@@ -119,3 +119,13 @@ The upgrade process should continue after the images are preloaded.
 - (Not recommended) Restart the upgrade process with logging disabled. Ensure that the *Enable Logging* checkbox in the *Upgrade* dialog is not selected.
 
 Related issue: https://github.com/harvester/harvester/issues/7955[#7955]
+
+=== 2. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]

--- a/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -1,0 +1,35 @@
+= Upgrade from v1.5.0 to v1.5.1
+
+== General information
+
+An *Upgrade* button appears on the *Dashboard* screen whenever a new {harvester-product-name} version that you can upgrade to becomes available. For more information, see xref:./upgrades.adoc#_start_an_upgrade[Start an upgrade].
+
+For information about upgrading {harvester-product-name} in air-gapped environments, see xref:./upgrades.adoc#_prepare_an_air_gapped_upgrade[Prepare an air-gapped upgrade].
+
+=== Update the Harvester UI Extension on {rancher-product-name} v2.11.0
+
+You must use **v1.5.1** of the Harvester UI Extension to import {harvester-product-name} v1.5.1 clusters on {rancher-short-name} v2.11.0.
+
+. On the {rancher-short-name} UI, go to *local -> Apps -> Repositories*.
+
+. Locate the repository named *harvester*, and then select *⋮ -> Refresh*.
+
+. Go to the *Extensions* screen.
+
+. Locate the extension named *Harvester*, and then click *Update*.
+
+. Select version *1.5.1*, and then click *Update*.
+
+. Allow some time for the extension to be updated, and then refresh the screen.
+
+== Known issues
+
+=== 1. Virtual machines that use migratable RWX volumes restart unexpectedly
+
+Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
+
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+
+The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
+
+Related issues: https://github.com/harvester/harvester/issues/8534[#8534] and https://github.com/longhorn/longhorn/issues/11158[#11158]


### PR DESCRIPTION
Scope: v1.4, v1.5, v1.6

PRs:
- [813](https://github.com/harvester/docs/pull/813): Longhorn issue #11158
- [814](https://github.com/harvester/docs/pull/814): v1.5.0 to v1.5.1 upgrade path

Other changes:
- Replaced community project names with product name variables (Note: Component names that include "Harvester" and "Longhorn" will not be rebranded for now.)
- Used sentence case in headings per SUSE style guide