### PR TITLE
Fix swagger.json filename references to match new names

### DIFF
--- a/versions/v1.5/modules/en/pages/api.adoc
+++ b/versions/v1.5/modules/en/pages/api.adoc
@@ -3,7 +3,7 @@
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>
-        Redoc.init('./_attachments/v1.4-swagger.json',
+        Redoc.init('./_attachments/v1.5-swagger.json',
         {scrollYOffset: '.toolbar'},
         document.getElementById('redoc-container'))
     </script>

--- a/versions/v1.6/modules/en/pages/api.adoc
+++ b/versions/v1.6/modules/en/pages/api.adoc
@@ -3,7 +3,7 @@
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>
-        Redoc.init('./_attachments/v1.4-swagger.json',
+        Redoc.init('./_attachments/v1.6-swagger.json',
         {scrollYOffset: '.toolbar'},
         document.getElementById('redoc-container'))
     </script>


### PR DESCRIPTION
The generated API reference is currently not rendering due to a swagger.json filename mismatch in the references and the actual filename, which changed in https://github.com/rancher/harvester-product-docs/pull/90.