### PR TITLE
Updated version format in SUSE Storage URLs

### DIFF
--- a/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -591,7 +591,7 @@ install:
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
@@ -64,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://docu
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.7.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.7/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -33,8 +33,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.3/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/overview.adoc
@@ -9,7 +9,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]

--- a/versions/v1.3/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.3/modules/en/pages/networking/best-practices.adoc
@@ -247,14 +247,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.7.0/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.7/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.3/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/storage-network.adoc
@@ -2,7 +2,7 @@
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-documentation.html[Longhorn Storage Network].
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-documentation.html[Longhorn Storage Network].
 
 [NOTE]
 ====

--- a/versions/v1.3/modules/en/pages/observability/calculation-resource-metrics.adoc
+++ b/versions/v1.3/modules/en/pages/observability/calculation-resource-metrics.adoc
@@ -117,7 +117,7 @@ For more information, see https://kubernetes.io/docs/concepts/configuration/mana
 
 === Reserved Storage in {longhorn-product-name}
 
-{longhorn-product-name} allows you to specify the percentage of disk space that is not allocated to the default disk on each new {longhorn-product-name} node. The default value is `30`. For more information, see https://documentation.suse.com/cloudnative/storage/1.9.0/en/longhorn-system/settings.html#_storage_reserved_percentage_for_default_disk[Storage Reserved Percentage For Default Disk] in the {longhorn-product-name} documentation.
+{longhorn-product-name} allows you to specify the percentage of disk space that is not allocated to the default disk on each new {longhorn-product-name} node. The default value is `30`. For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_storage_reserved_percentage_for_default_disk[Storage Reserved Percentage For Default Disk] in the {longhorn-product-name} documentation.
 
 Depending on the disk size, you can modify the default value using the xref:../troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI].
 

--- a/versions/v1.3/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.3/modules/en/pages/storage/storageclass.adoc
@@ -74,7 +74,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:../virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Appendix - Use Case
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -4,7 +4,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.7.0/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.7/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
@@ -68,7 +68,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.3/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/troubleshooting.adoc
@@ -176,7 +176,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -549,7 +549,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -570,7 +570,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -64,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://docu
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.7.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.7/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -33,8 +33,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -9,7 +9,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]

--- a/versions/v1.4/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.4/modules/en/pages/networking/best-practices.adoc
@@ -247,14 +247,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.7.0/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.7/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.4/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/storage-network.adoc
@@ -2,7 +2,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.4/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.4/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -63,7 +63,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.4/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.4/modules/en/pages/storage/storageclass.adoc
@@ -129,7 +129,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.7/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Appendix - Use Case
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -4,7 +4,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.7.0/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.7/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -68,7 +68,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.7/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
@@ -200,7 +200,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -552,7 +552,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -573,7 +573,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
@@ -64,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://docu
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -33,8 +33,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.5/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/overview.adoc
@@ -9,7 +9,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]

--- a/versions/v1.5/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.5/modules/en/pages/networking/best-practices.adoc
@@ -247,14 +247,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8.0/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.5/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.5/modules/en/pages/networking/storage-network.adoc
@@ -2,7 +2,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -59,7 +59,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.5/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.5/modules/en/pages/storage/storageclass.adoc
@@ -129,7 +129,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Appendix - Use Case
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -4,7 +4,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8.0/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -68,7 +68,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
@@ -252,7 +252,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -552,7 +552,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -573,7 +573,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
@@ -64,7 +64,7 @@ For more information, see the *Certificate Rotation* section of the https://docu
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8.0/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -33,8 +33,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.6/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/overview.adoc
@@ -9,7 +9,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]

--- a/versions/v1.6/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.6/modules/en/pages/networking/best-practices.adoc
@@ -247,14 +247,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8.0/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.6/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/storage-network.adoc
@@ -2,7 +2,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -59,7 +59,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8.0/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.6/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.6/modules/en/pages/storage/storageclass.adoc
@@ -129,7 +129,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Appendix - Use Case
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -4,7 +4,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8.0/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -68,7 +68,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
@@ -252,7 +252,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8.0/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume


### PR DESCRIPTION
Scope: v1.3, v1.4, v1.5, v1.6

Changes:
- v1.7.0 -> v1.7
- v1.8.0 -> v1.8

Affected files:
- `installation-setup/config/configuration-file.adoc`
- `installation-setup/config/settings.adoc`
- `installation-setup/single-node-clusters.adoc`
- `introduction/overview.adoc`
- `networking/best-practices.adoc`
- `networking/storage-network.adoc`
- `observability/calculation-resource-metrics.adoc`
- `storage/longhorn-v2-data-engine.adoc`
- `storage/storageclass.adoc`
- `storage/volumes/edit-volume.adoc`
- `troubleshooting/monitoring.adoc`
- `upgrades/troubleshooting.adoc`