### PR TITLE
Add content from community doc PRs (812. 819, 823)

### DIFF
--- a/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -35,6 +35,20 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
  cat /etc/resolv.conf
 ----
 
+. Restart `rke2-coredns`.
++
+[,shell]
+----
+kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
+. Verify that `rke2-coredns` was rolled out successfully.
++
+[,shell]
+----
+kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
 === Configuration persistence
 
 The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {harvester-product-name} now uses a newer version of Elemental, which creates the file during installation.

--- a/versions/v1.4/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.4/modules/en/pages/storage/csidriver.adoc
@@ -68,3 +68,55 @@ image::advanced/rook-ceph-vm-external.png[rook-ceph-vm-external]
 
 * https://harvesterhci.io/kb/use_rook_ceph_external_storage[Use Rook Ceph External Storage with Harvester]
 * https://harvesterhci.io/kb/install_netapp_trident_csi[Using NetApp Storage on Harvester]
+
+== Known issues
+
+=== 1. Multipath support
+
+The `multipathd` service is disabled in {harvester-product-name} by default. However, certain third-party CSIs may require you to enable the service.
+
+After installing {harvester-product-name}, you can enable and start `multipathd` by logging into each cluster node and running the following commands:
+
+[,shell]
+----
+systemctl enable multipathd
+systemctl start multipathd
+----
+
+Alternatively, you can create a {elemental-product-name} CloudInit file in the `/oem` directory on each host (for example, `/oem/99-start-multipathd.yaml`) with the following contents:
+
+[,yaml]
+----
+stages:
+   default:
+   - name: "start multipathd"
+     systemctl:
+       enable:
+         - multipathd
+       start:
+         - multipathd
+----
+
+This process can be automated across the Harvester cluster using a `CloudInit` CRD.
+
+[,yaml]
+----
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: start-mutlitpathd
+spec:
+  matchSelector:
+    harvesterhci.io/managed: "true"
+  filename: 99-start-mutlitpathd
+  contents: |
+    stages:
+      default:
+        - name: "start multipathd"
+          systemctl:
+            enable:
+              - multipathd
+            start:
+              - multipathd
+  paused: false
+----

--- a/versions/v1.5/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -35,6 +35,20 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
  cat /etc/resolv.conf
 ----
 
+. Restart `rke2-coredns`.
++
+[,shell]
+----
+kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
+. Verify that `rke2-coredns` was rolled out successfully.
++
+[,shell]
+----
+kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
 === Configuration persistence
 
 The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {harvester-product-name} now uses a newer version of Elemental, which creates the file during installation.

--- a/versions/v1.5/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.5/modules/en/pages/storage/csidriver.adoc
@@ -240,7 +240,7 @@ Once created, you can use the StorageClass to create virtual machine images, roo
 
 == Known issues
 
-=== Infinite image download loop
+=== 1. Infinite image download loop
 
 The image download process loops endlessly when the StorageClass for the image uses the LVM CSI driver. This issue is related to the scratch volume, which is created by CDI and is used to temporarily store the image data. When the issue exists in your environment, you might find the following error messages in `importer-prime-xxx` pod logs:
 
@@ -283,3 +283,53 @@ Increasing the overhead value does not affect the image PVC size. The scratch vo
 ====
 
 Related issue: https://github.com/harvester/harvester/issues/7993[#7993] (See https://github.com/harvester/harvester/issues/7993#issuecomment-2790260841[this comment].)
+
+=== 2. Multipath support
+
+The `multipathd` service is disabled in {harvester-product-name} by default. However, certain third-party CSIs may require you to enable the service.
+
+After installing {harvester-product-name}, you can enable and start `multipathd` by logging into each cluster node and running the following commands:
+
+[,shell]
+----
+systemctl enable multipathd
+systemctl start multipathd
+----
+
+Alternatively, you can create a {elemental-product-name} CloudInit file in the `/oem` directory on each host (for example, `/oem/99-start-multipathd.yaml`) with the following contents:
+
+[,yaml]
+----
+stages:
+   default:
+   - name: "start multipathd"
+     systemctl:
+       enable:
+         - multipathd
+       start:
+         - multipathd
+----
+
+This process can be automated across the Harvester cluster using a `CloudInit` CRD.
+
+[,yaml]
+----
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: start-mutlitpathd
+spec:
+  matchSelector:
+    harvesterhci.io/managed: "true"
+  filename: 99-start-mutlitpathd
+  contents: |
+    stages:
+      default:
+        - name: "start multipathd"
+          systemctl:
+            enable:
+              - multipathd
+            start:
+              - multipathd
+  paused: false
+----

--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -133,6 +133,7 @@ spec:
     destinationNetwork: "default/vlan1"
   - sourceNetwork: "dvSwitch 2"
     destinationNetwork: "default/vlan2"
+  skipPreflightChecks: false
   storageClass: "my-storage-class"
   sourceCluster:
     name: vcsim
@@ -141,13 +142,15 @@ spec:
     apiVersion: migration.harvesterhci.io/v1beta1
 ----
 
-The controller exports the virtual machine named `alpine-export-test` on the source VMware cluster to be exported, processed, and recreated in the {harvester-product-name} cluster.
+This prompts the controller to export the virtual machine named `alpine-export-test` on the source VMware cluster to be exported, processed, and recreated in the {harvester-product-name} cluster.
 
-This can take a while based on the size of the virtual machine, but users should see `VirtualMachineImages` created for each disk in the defined virtual machine.
+The controller checks the configuration before starting the import process, and cancels the import when it detects errors such as unknown xref:storage/storageclass.adoc[StorageClasses] or networks. These checks are enabled by default, but can be disabled by setting `skipPreflightChecks` to `true`.
+
+The duration of the import process depends on the size of the virtual machine. While the import process may take some time, you should see `VirtualMachineImages` created for each disk in the defined virtual machine.
 
 If the source virtual machine is placed in a folder, you can specify the folder name in the optional `folder` field.
 
-The list of items in `networkMapping` will define how the source network interfaces are mapped to the SUSE® Virtualization Networks.
+The list of items in `networkMapping` will define how the source network interfaces are mapped to the {harvester-product-name} Networks.
 
 If a match is not found, each unmatched network interface is attached to the default `managementNetwork`.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -35,6 +35,20 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
  cat /etc/resolv.conf
 ----
 
+. Restart `rke2-coredns`.
++
+[,shell]
+----
+kubectl rollout restart deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
+. Verify that `rke2-coredns` was rolled out successfully.
++
+[,shell]
+----
+kubectl rollout status deployment/rke2-coredns-rke2-coredns -n kube-system
+----
+
 === Configuration persistence
 
 The persistent name of the cloud-init file is `/oem/90_custom.yaml`. {harvester-product-name} now uses a newer version of Elemental, which creates the file during installation.

--- a/versions/v1.6/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.6/modules/en/pages/storage/csidriver.adoc
@@ -240,7 +240,7 @@ Once created, you can use the StorageClass to create virtual machine images, roo
 
 == Known issues
 
-=== Infinite image download loop
+=== 1. Infinite image download loop
 
 The image download process loops endlessly when the StorageClass for the image uses the LVM CSI driver. This issue is related to the scratch volume, which is created by CDI and is used to temporarily store the image data. When the issue exists in your environment, you might find the following error messages in `importer-prime-xxx` pod logs:
 
@@ -283,3 +283,53 @@ Increasing the overhead value does not affect the image PVC size. The scratch vo
 ====
 
 Related issue: https://github.com/harvester/harvester/issues/7993[#7993] (See https://github.com/harvester/harvester/issues/7993#issuecomment-2790260841[this comment].)
+
+=== 2. Multipath support
+
+The `multipathd` service is disabled in {harvester-product-name} by default. However, certain third-party CSIs may require you to enable the service.
+
+After installing {harvester-product-name}, you can enable and start `multipathd` by logging into each cluster node and running the following commands:
+
+[,shell]
+----
+systemctl enable multipathd
+systemctl start multipathd
+----
+
+Alternatively, you can create a {elemental-product-name} CloudInit file in the `/oem` directory on each host (for example, `/oem/99-start-multipathd.yaml`) with the following contents:
+
+[,yaml]
+----
+stages:
+   default:
+   - name: "start multipathd"
+     systemctl:
+       enable:
+         - multipathd
+       start:
+         - multipathd
+----
+
+This process can be automated across the Harvester cluster using a `CloudInit` CRD.
+
+[,yaml]
+----
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: start-mutlitpathd
+spec:
+  matchSelector:
+    harvesterhci.io/managed: "true"
+  filename: 99-start-mutlitpathd
+  contents: |
+    stages:
+      default:
+        - name: "start multipathd"
+          systemctl:
+            enable:
+              - multipathd
+            start:
+              - multipathd
+  paused: false
+----


### PR DESCRIPTION
Scope: v1.4, v1.5, v1.6

PRs:
- [812](https://github.com/harvester/docs/pull/812): RKE2 CoreDNS restart
- [819](https://github.com/harvester/docs/pull/819): Enabling multipathd after installation
- [823](https://github.com/harvester/docs/pull/823): `skipPreflightChecks` field in `VirtualMachineImport` CRD