### PR TITLE
Add revdate and page-revdate attributes to content files

### DIFF
--- a/versions/v1.3/modules/en/pages/add-ons/add-ons.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/add-ons.adoc
@@ -1,4 +1,6 @@
 = Add-ons
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 SUSE® Virtualization makes optional functionality available as add-ons.
 

--- a/versions/v1.3/modules/en/pages/add-ons/harvester-seeder.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/harvester-seeder.adoc
@@ -1,4 +1,6 @@
 = Harvester Seeder
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 The *harvester-seeder* add-on allows you to perform out-of-band operations on Harvester hosts using the Intelligent Platform Management Interface (IPMI).
 

--- a/versions/v1.3/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,4 +1,6 @@
 = NVIDIA Driver Toolkit
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing SUSE® Virtualization clusters.
 

--- a/versions/v1.3/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,4 +1,6 @@
 = PCI Devices Controller
+:revdate: 2025-05-23
+:page-revdate: {revdate}
 
 A `PCIDevice` in SUSE® Virtualization represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource,

--- a/versions/v1.3/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,4 +1,6 @@
 = Rancher Manager (Experimental)
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 The `rancher-vcluster` add-on allows you to run Rancher Manager as a workload on the underlying SUSE® Virtualization cluster and is implemented using https://www.vcluster.com/[vcluster].
 

--- a/versions/v1.3/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,4 +1,6 @@
 = VM DHCP Controller (Managed DHCP)
+:revdate: 2025-01-09
+:page-revdate: {revdate}
 
 You can configure IP pool information and serve IP addresses to VMs running on SUSE® Virtualization clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.3/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.3/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,4 +1,6 @@
 = VM Import Controller
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 You can import virtual machines from VMware and OpenStack into {harvester-product-name} using the `vm-import-controller` add-on. The add-on must be enabled before you start importing virtual machines.
 

--- a/versions/v1.3/modules/en/pages/api.adoc
+++ b/versions/v1.3/modules/en/pages/api.adoc
@@ -1,5 +1,7 @@
 ++++
 <div class="api-doc">
+:revdate: 2024-09-25
+:page-revdate: {revdate}
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>

--- a/versions/v1.3/modules/en/pages/developer/developer-mode-installation.adoc
+++ b/versions/v1.3/modules/en/pages/developer/developer-mode-installation.adoc
@@ -1,4 +1,6 @@
 = Developer Mode
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 [CAUTION]
 ====

--- a/versions/v1.3/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/hosts.adoc
@@ -1,4 +1,6 @@
 = Host Management
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 Users can view and manage {harvester-product-name} nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 

--- a/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,4 +1,6 @@
 = vGPU Support
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 {harvester-product-name} is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
 

--- a/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.3/modules/en/pages/hosts/witness-node.adoc
@@ -1,4 +1,6 @@
 = Witness Node
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 {harvester-product-name} clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in {harvester-product-name}) to ensure that a quorum is maintained.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/airgap.adoc
@@ -1,4 +1,6 @@
 = Air-Gapped Environment
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/authentication.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/authentication.adoc
@@ -1,4 +1,6 @@
 = Authentication
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,4 +1,6 @@
 = CloudInit CRD
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 You can use the `CloudInit` CRD to configure {harvester-product-name} operating system settings either manually or using GitOps solutions.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,4 +1,6 @@
 = Configuration File
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Configuration Example
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,4 +1,6 @@
 = Settings
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,4 +1,6 @@
 = Update the Configuration After Installation
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/management-address.adoc
@@ -1,4 +1,6 @@
 = Management Address
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 {harvester-product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,4 +1,6 @@
 = Install Binaries Only
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 You can install and configure binaries only, which is ideal for cloud and edge use cases.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/media/net-install.adoc
@@ -1,4 +1,6 @@
 = Net Install ISO
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 The net install ISO is a minimal installation image that contains only the core operating system components, allowing the installer to boot and then install the operating system on a disk. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 

--- a/versions/v1.3/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,4 +1,6 @@
 = ISO Installation
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,4 +1,6 @@
 = PXE Boot Installation
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 {harvester-product-name} can be installed automatically with PXE boot.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/methods/usb-install.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/methods/usb-install.adoc
@@ -1,4 +1,6 @@
 = USB Installation
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 == Create a bootable USB flash drive
 

--- a/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/requirements.adoc
@@ -1,4 +1,6 @@
 = Hardware and Network Requirements
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
 

--- a/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.3/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,4 +1,6 @@
 = Single-Node Clusters
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:/installation-setup/methods/iso-install.adoc[ISO], xref:/installation-setup/methods/usb-install.adoc[USB], and xref:/installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -1,4 +1,6 @@
 = Harvester Cloud Provider
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 xref:../../integrations/rancher/node-driver/rke1-cluster.adoc[RKE1] and xref:../../integrations/rancher/node-driver/rke2-cluster.adoc[RKE2] clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides <<Load Balancer Support,load balancer>> and Harvester cluster xref:./csi-driver.adoc[storage passthrough] support to the guest Kubernetes cluster.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester CSI Driver
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters in Harvester. It connects to the host cluster and hot-plugs host volumes to the virtual machines (VMs) to provide native storage performance.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
@@ -1,4 +1,6 @@
 = Harvester UI Extension
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 Rancher 2.10.0 and later versions integrate with {harvester-product-name} using the https://github.com/harvester/harvester-ui-extension[Harvester UI Extension], which is built on the https://www.npmjs.com/package/@rancher/shell[@rancher/shell] library.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/import-vm.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/import-vm.adoc
@@ -1,4 +1,6 @@
 = Import a Cluster Built on a SUSE® Virtualization VM
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 Rancher allows you to import SUSE® Virtualization virtual machines in which you installed Kubernetes.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an K3s Kubernetes Cluster
+:revdate: 2025-02-13
+:page-revdate: {revdate}
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester Node Driver
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 The https://github.com/harvester/docker-machine-driver-harvester[Harvester Node Driver], similar to the Docker Machine driver, is used to provision VMs in the {harvester-product-name} cluster, and {rancher-short-name} uses it to launch and manage Kubernetes clusters.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE1 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 [WARNING]
 ====

--- a/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE2 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 You can now provision {rke2-product-name} Kubernetes clusters on top of the {harvester-product-name} cluster in {rancher-product-name} using the built-in Harvester Node Driver.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,4 +1,6 @@
 = {rancher-product-name} Integration
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Rancher Terraform
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 https://registry.terraform.io/providers/rancher/rancher2/[Rancher Terraform] is a terraform provider that allows administrators to create and manage RKE2 guest clusters using Terraform.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -1,4 +1,6 @@
 = Resource Quotas
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota] is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 

--- a/versions/v1.3/modules/en/pages/integrations/rancher/virtualization-management.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/rancher/virtualization-management.adoc
@@ -1,4 +1,6 @@
 = Virtualization Management
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 With {rancher-short-name}'s virtualization management capabilities, you can import and manage multiple {harvester-product-name} clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.
 

--- a/versions/v1.3/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.3/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Terraform Provider
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 == Support Matrix
 

--- a/versions/v1.3/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a High-Availability Cluster
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:/hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:/installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.3/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a Single-Node Cluster
+:revdate: 2024-11-22
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.3/modules/en/pages/introduction/document-conventions.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/document-conventions.adoc
@@ -1,4 +1,6 @@
 = Document Conventions
+:revdate: 2025-02-20
+:page-revdate: {revdate}
 
 == Release Labels
 

--- a/versions/v1.3/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/glossary.adoc
@@ -1,4 +1,6 @@
 = Glossary
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 == *guest cluster* / *guest Kubernetes cluster*
 

--- a/versions/v1.3/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.3/modules/en/pages/introduction/overview.adoc
@@ -1,4 +1,6 @@
 = Overview
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.9/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versions/v1.3/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.3/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,6 @@
 = Networking Best Practices
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Replace Ethernet NICs
 

--- a/versions/v1.3/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/cluster-network.adoc
@@ -1,4 +1,6 @@
 = Cluster Network
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 == Concepts
 

--- a/versions/v1.3/modules/en/pages/networking/deep-dive.adoc
+++ b/versions/v1.3/modules/en/pages/networking/deep-dive.adoc
@@ -1,4 +1,6 @@
 = Networking Deep Dive
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 The network topology below reveals how we implement the Harvester network.
 

--- a/versions/v1.3/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.3/modules/en/pages/networking/ip-pool.adoc
@@ -1,4 +1,6 @@
 = IP Pool
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 

--- a/versions/v1.3/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.3/modules/en/pages/networking/load-balancer.adoc
@@ -1,4 +1,6 @@
 = Load Balancer
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 

--- a/versions/v1.3/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/storage-network.adoc
@@ -1,4 +1,6 @@
 = Storage Network
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 Harvester uses Longhorn as its built-in storage system to provide block device volumes for VMs and Pods. If the user wishes to isolate Longhorn replication traffic from the Kubernetes cluster network (i.e. the management network) or other cluster-wide workloads. Users can allocate a dedicated storage network for Longhorn replication traffic to get better network bandwidth and performance.
 

--- a/versions/v1.3/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.3/modules/en/pages/networking/vm-network.adoc
@@ -1,4 +1,6 @@
 = VM Network
+:revdate: 2025-06-03
+:page-revdate: {revdate}
 
 Harvester provides three types of networks for virtual machines (VMs), including:
 

--- a/versions/v1.3/modules/en/pages/observability/calculation-resource-metrics.adoc
+++ b/versions/v1.3/modules/en/pages/observability/calculation-resource-metrics.adoc
@@ -1,4 +1,6 @@
 = Calculation of Resource Metrics
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 {harvester-product-name} calculates resource metrics using data that is dynamically collected from the system. Host-level resource metrics are calculated and then aggregated to obtain the cluster-level metrics.
 

--- a/versions/v1.3/modules/en/pages/observability/logging.adoc
+++ b/versions/v1.3/modules/en/pages/observability/logging.adoc
@@ -1,4 +1,6 @@
 = Logging
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 

--- a/versions/v1.3/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/observability/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring
+:revdate: 2025-06-16
+:page-revdate: {revdate}
 
 The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 

--- a/versions/v1.3/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.3/modules/en/pages/storage/csidriver.adoc
@@ -1,4 +1,6 @@
 = Third-Party Storage Support
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 Harvester now offers the capability to install a https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] in your Harvester cluster. This allows you to leverage external storage for the Virtual Machine's non-system data disk, allowing you to use different drivers tailored for specific needs, whether for performance optimization or seamless integration with your existing in-house storage solutions.
 

--- a/versions/v1.3/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.3/modules/en/pages/storage/storageclass.adoc
@@ -1,4 +1,6 @@
 = StorageClass
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 A StorageClass allows administrators to describe the *classes* of storage they offer. Different {longhorn-product-name} StorageClasses might map to replica policies, or to node schedule policies, or disk schedule policies determined by the cluster administrators. This concept is sometimes called *profiles* in other storage systems.
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/clone-volume.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/clone-volume.adoc
@@ -1,4 +1,6 @@
 = Clone a Volume
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 == How to Clone a Volume
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/create-volume.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/create-volume.adoc
@@ -1,4 +1,6 @@
 = Create a Volume
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 == Create an Empty Volume
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -1,4 +1,6 @@
 = Edit a Volume
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/export-volume.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/export-volume.adoc
@@ -1,4 +1,6 @@
 = Export a Volume to Image
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 You can select and export an existing volume to an image by following the steps below:
 

--- a/versions/v1.3/modules/en/pages/storage/volumes/volume-snapshots.adoc
+++ b/versions/v1.3/modules/en/pages/storage/volumes/volume-snapshots.adoc
@@ -1,4 +1,6 @@
 = Volume Snapshots
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/cluster.adoc
@@ -1,4 +1,6 @@
 = Cluster Issues
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 == Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/faq.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/faq.adoc
@@ -1,4 +1,6 @@
 = FAQ
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/installation.adoc
@@ -1,4 +1,6 @@
 = Installation Issues
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring Issues
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Monitoring is unusable
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/operating-system.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/operating-system.adoc
@@ -1,4 +1,6 @@
 = Operating System Issues
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the https://github.com/rancher/elemental-toolkit[elemental-toolkit]. The following sections contain information and tips to help users troubleshoot OS-related issues.
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/rancher.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/rancher.adoc
@@ -1,4 +1,6 @@
 = Rancher Issues
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 == Guest Cluster Log Collection
 

--- a/versions/v1.3/modules/en/pages/troubleshooting/virtual-machines.adoc
+++ b/versions/v1.3/modules/en/pages/troubleshooting/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Issues
+:revdate: 2025-02-18
+:page-revdate: {revdate}
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.
 

--- a/versions/v1.3/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,4 +1,6 @@
 = Troubleshooting
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.3/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/upgrades.adoc
@@ -1,4 +1,6 @@
 = Upgrades
+:revdate: 2025-06-12
+:page-revdate: {revdate}
 
 == Upgrade support matrix
 

--- a/versions/v1.3/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2 to v1.2.0 (not recommended)
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 [CAUTION]
 ====

--- a/versions/v1.3/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 == Important changes to this version
 

--- a/versions/v1.3/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.1 to v1.2.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.3/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.2/v1.3.0 to v1.3.1
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.3/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.1 to v1.3.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.3/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.3/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.2 to v1.4.0
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/access-vm.adoc
@@ -1,4 +1,6 @@
 = Access to the Virtual Machine
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 Once the VM is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the Harvester UI.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -1,4 +1,6 @@
 = VM Backup, Snapshot & Restore
+:revdate: 2025-03-11
+:page-revdate: {revdate}
 
 == VM Backup & Restore
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,4 +1,6 @@
 = Clone VM
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 VM can be cloned with/without data. This function doesn't need to take a VM snapshot or set up a backup target first.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/create-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Virtual Machine
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 == How to Create a VM
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/create-windows-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/create-windows-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Windows Virtual Machine
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 Create one or more virtual machines from the *Virtual Machines* page.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/edit-vm.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/edit-vm.adoc
@@ -1,4 +1,6 @@
 = Edit a Virtual Machine
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 == How to Edit a VM
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/hotplug-volume.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/hotplug-volume.adoc
@@ -1,4 +1,6 @@
 = Hot-Plug Volumes
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 Harvester supports adding hot-plug volumes to a running VM.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/live-migration.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/live-migration.adoc
@@ -1,4 +1,6 @@
 = Live Migration
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 Live migration means moving a virtual machine to a different host without downtime.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/resource-overcommit.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/resource-overcommit.adoc
@@ -1,4 +1,6 @@
 = Resource Overcommit
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 Harvester supports global configuration of resource overload percentages on CPU, memory, and storage. By setting xref:../installation-setup/config/settings.adoc#_overcommit_config[`overcommit-config`], this will allow scheduling of additional virtual machines even when physical resources are fully utilized.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machines
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux virtual machines] using one of the following methods: 
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
@@ -1,4 +1,6 @@
 = Custom SUSE VM Images
+:revdate: 2025-02-20
+:page-revdate: {revdate}
 
 SUSE provides https://www.suse.com/download/sles/[SUSE Linux Enterprise (SLE)] and https://get.opensuse.org/leap/[openSUSE Leap] virtual machine (VM) images suitable for use in {harvester-product-name}. These images are built on the https://build.opensuse.org/[openSUSE Build Service] (OBS) using the https://osinside.github.io/kiwi/[Kiwi] image building tool, and can be used immediately after downloading.
 

--- a/versions/v1.3/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.3/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,4 +1,6 @@
 = Upload Images
+:revdate: 2025-04-07
+:page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 

--- a/versions/v1.4/modules/en/pages/add-ons/add-ons.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/add-ons.adoc
@@ -1,4 +1,6 @@
 = Add-ons
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 SUSE® Virtualization makes optional functionality available as add-ons.
 

--- a/versions/v1.4/modules/en/pages/add-ons/harvester-seeder.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/harvester-seeder.adoc
@@ -1,4 +1,6 @@
 = Harvester Seeder
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 The *harvester-seeder* add-on allows you to perform out-of-band operations on Harvester hosts using the Intelligent Platform Management Interface (IPMI).
 

--- a/versions/v1.4/modules/en/pages/add-ons/lvm-local-storage.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/lvm-local-storage.adoc
@@ -1,4 +1,6 @@
 = Local Storage Support
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester v1.4.0 allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
 

--- a/versions/v1.4/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,4 +1,6 @@
 = NVIDIA Driver Toolkit
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing SUSE® Virtualization clusters.
 

--- a/versions/v1.4/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,4 +1,6 @@
 = PCI Devices Controller
+:revdate: 2025-05-23
+:page-revdate: {revdate}
 
 A `PCIDevice` in SUSE® Virtualization represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, or by using the UI to enable passthrough. Passing a device through the hypervisor means that the VM can directly access the device, and effectively owns the device. A VM can even install its own drivers for that device.

--- a/versions/v1.4/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,4 +1,6 @@
 = Rancher Manager (Experimental)
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 The `rancher-vcluster` add-on allows you to run Rancher Manager as a workload on the underlying SUSE® Virtualization cluster and is implemented using https://www.vcluster.com/[vcluster].
 

--- a/versions/v1.4/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,4 +1,6 @@
 = VM DHCP Controller (Managed DHCP)
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 You can configure IP pool information and serve IP addresses to VMs running on {harvester-product-name} clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.4/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.4/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,4 +1,6 @@
 = VM Import Controller
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 You can import virtual machines from VMware and OpenStack into {harvester-product-name} using the `vm-import-controller` add-on. The add-on must be enabled before you start importing virtual machines.
 

--- a/versions/v1.4/modules/en/pages/api.adoc
+++ b/versions/v1.4/modules/en/pages/api.adoc
@@ -1,5 +1,7 @@
 ++++
 <div class="api-doc">
+:revdate: 2024-09-25
+:page-revdate: {revdate}
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>

--- a/versions/v1.4/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.4/modules/en/pages/developer/addon-development.adoc
@@ -1,4 +1,6 @@
 = Add-on Development Guide
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 {harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
 

--- a/versions/v1.4/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/hosts.adoc
@@ -1,4 +1,6 @@
 = Host Management
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 Users can view and manage {harvester-product-name} nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 

--- a/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,4 +1,6 @@
 = vGPU Support
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 {harvester-product-name} is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
 

--- a/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.4/modules/en/pages/hosts/witness-node.adoc
@@ -1,4 +1,6 @@
 = Witness Node
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 {harvester-product-name} clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in {harvester-product-name}) to ensure that a quorum is maintained.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/airgap.adoc
@@ -1,4 +1,6 @@
 = Air-Gapped Environment
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/authentication.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/authentication.adoc
@@ -1,4 +1,6 @@
 = Authentication
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,4 +1,6 @@
 = CloudInit CRD
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 You can use the `CloudInit` CRD to configure {harvester-product-name} operating system settings either manually or using GitOps solutions.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,4 +1,6 @@
 = Configuration File
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Configuration Example
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,4 +1,6 @@
 = Settings
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,4 +1,6 @@
 = Update the Configuration After Installation
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/external-disk.adoc
@@ -1,4 +1,6 @@
 = External Disk Support
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/management-address.adoc
@@ -1,4 +1,6 @@
 = Management Address
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 {harvester-product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,4 +1,6 @@
 = Install Binaries Only
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 You can install and configure binaries only, which is ideal for cloud and edge use cases.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/media/net-install.adoc
@@ -1,4 +1,6 @@
 = Net Install ISO
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 The net install ISO is a minimal installation image that contains only the core operating system components, allowing the installer to boot and then install the operating system on a disk. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,4 +1,6 @@
 = ISO Installation
+:revdate: 2025-04-16
+:page-revdate: {revdate}
 
 {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,4 +1,6 @@
 = PXE Boot Installation
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 {harvester-product-name} can be installed automatically with PXE boot.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/methods/usb-install.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/methods/usb-install.adoc
@@ -1,4 +1,6 @@
 = USB Installation
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 == Create a bootable USB flash drive
 

--- a/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/requirements.adoc
@@ -1,4 +1,6 @@
 = Hardware and Network Requirements
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
 

--- a/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.4/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,4 +1,6 @@
 = Single-Node Clusters
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:/installation-setup/methods/iso-install.adoc[ISO], xref:/installation-setup/methods/usb-install.adoc[USB], and xref:/installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -1,4 +1,6 @@
 = Harvester Cloud Provider
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 xref:../../integrations/rancher/node-driver/rke1-cluster.adoc[RKE1] and xref:../../integrations/rancher/node-driver/rke2-cluster.adoc[RKE2] clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides <<Load Balancer Support,load balancer>> and Harvester cluster xref:./csi-driver.adoc[storage passthrough] support to the guest Kubernetes cluster.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester CSI Driver
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the host cluster and hot-plugs host volumes to the virtual machines to provide native storage performance.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
@@ -1,4 +1,6 @@
 = Harvester UI Extension
+:revdate: 2025-07-02
+:page-revdate: {revdate}
 
 {rancher-short-name} 2.10.0 and later versions integrate with {harvester-product-name} using the https://github.com/harvester/harvester-ui-extension[Harvester UI Extension], which is built on the https://www.npmjs.com/package/@rancher/shell[@rancher/shell] library.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/import-vm.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/import-vm.adoc
@@ -1,4 +1,6 @@
 = Import a Cluster Built on a SUSE® Virtualization VM
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 Rancher allows you to import SUSE® Virtualization virtual machines in which you installed Kubernetes.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an K3s Kubernetes Cluster
+:revdate: 2025-02-13
+:page-revdate: {revdate}
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester Node Driver
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 The https://github.com/harvester/docker-machine-driver-harvester[Harvester Node Driver], similar to the Docker Machine driver, is used to provision VMs in the {harvester-product-name} cluster, and {rancher-short-name} uses it to launch and manage Kubernetes clusters.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE1 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 [WARNING]
 ====

--- a/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE2 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 You can now provision {rke2-product-name} Kubernetes clusters on top of the {harvester-product-name} cluster in {rancher-product-name} using the built-in Harvester Node Driver.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,4 +1,6 @@
 = {rancher-product-name} Integration
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Rancher Terraform
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 The https://registry.terraform.io/providers/rancher/rancher2/[Rancher Terraform Provider] allows administrators to create and manage RKE2 guest clusters using Terraform.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -1,4 +1,6 @@
 = Resource Quotas
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota] is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 

--- a/versions/v1.4/modules/en/pages/integrations/rancher/virtualization-management.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/rancher/virtualization-management.adoc
@@ -1,4 +1,6 @@
 = Virtualization Management
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 With {rancher-short-name}'s virtualization management capabilities, you can import and manage multiple {harvester-product-name} clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.
 

--- a/versions/v1.4/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.4/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Terraform Provider
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 == Support Matrix
 

--- a/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a High-Availability Cluster
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:/hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:/installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a Single-Node Cluster
+:revdate: 2024-11-21
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.4/modules/en/pages/introduction/document-conventions.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/document-conventions.adoc
@@ -1,4 +1,6 @@
 = Document Conventions
+:revdate: 2025-02-20
+:page-revdate: {revdate}
 
 == Release Labels
 

--- a/versions/v1.4/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/glossary.adoc
@@ -1,4 +1,6 @@
 = Glossary
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 == *guest cluster* / *guest Kubernetes cluster*
 

--- a/versions/v1.4/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.4/modules/en/pages/introduction/overview.adoc
@@ -1,4 +1,6 @@
 = Overview
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.10/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versions/v1.4/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.4/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,6 @@
 = Networking Best Practices
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Replace Ethernet NICs
 

--- a/versions/v1.4/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/cluster-network.adoc
@@ -1,4 +1,6 @@
 = Cluster Network
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 == Concepts
 

--- a/versions/v1.4/modules/en/pages/networking/deep-dive.adoc
+++ b/versions/v1.4/modules/en/pages/networking/deep-dive.adoc
@@ -1,4 +1,6 @@
 = Networking Deep Dive
+:revdate: 2025-05-20
+:page-revdate: {revdate}
 
 == Network topology
 

--- a/versions/v1.4/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.4/modules/en/pages/networking/ip-pool.adoc
@@ -1,4 +1,6 @@
 = IP Pool
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 

--- a/versions/v1.4/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.4/modules/en/pages/networking/load-balancer.adoc
@@ -1,4 +1,6 @@
 = Load Balancer
+:revdate: 2024-09-25
+:page-revdate: {revdate}
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 

--- a/versions/v1.4/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/storage-network.adoc
@@ -1,4 +1,6 @@
 = Storage Network
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 

--- a/versions/v1.4/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.4/modules/en/pages/networking/vm-network.adoc
@@ -1,4 +1,6 @@
 = VM Network
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester provides three types of networks for virtual machines (VMs), including:
 

--- a/versions/v1.4/modules/en/pages/observability/logging.adoc
+++ b/versions/v1.4/modules/en/pages/observability/logging.adoc
@@ -1,4 +1,6 @@
 = Logging
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 

--- a/versions/v1.4/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/observability/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring
+:revdate: 2025-06-16
+:page-revdate: {revdate}
 
 The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 

--- a/versions/v1.4/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.4/modules/en/pages/storage/csidriver.adoc
@@ -1,4 +1,6 @@
 = Third-Party Storage Support
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 {harvester-product-name} now offers the capability to install a https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] in your {harvester-product-name} cluster. This allows you to leverage external storage for the Virtual Machine's non-system data disk, allowing you to use different drivers tailored for specific needs, whether for performance optimization or seamless integration with your existing in-house storage solutions.
 

--- a/versions/v1.4/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.4/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -1,4 +1,6 @@
 = Longhorn V2 Data Engine
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.
 

--- a/versions/v1.4/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.4/modules/en/pages/storage/storageclass.adoc
@@ -1,4 +1,6 @@
 = StorageClass
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. {longhorn-product-name} StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as _profiles_ in other storage systems.
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/clone-volume.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/clone-volume.adoc
@@ -1,4 +1,6 @@
 = Clone a Volume
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 == How to Clone a Volume
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/create-volume.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/create-volume.adoc
@@ -1,4 +1,6 @@
 = Create a Volume
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 == Create an Empty Volume
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -1,4 +1,6 @@
 = Edit a Volume
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/export-volume.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/export-volume.adoc
@@ -1,4 +1,6 @@
 = Export a Volume to Image
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 You can select and export an existing volume to an image by following the steps below:
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/volume-security.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/volume-security.adoc
@@ -1,4 +1,6 @@
 = Volume Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.4/modules/en/pages/storage/volumes/volume-snapshots.adoc
+++ b/versions/v1.4/modules/en/pages/storage/volumes/volume-snapshots.adoc
@@ -1,4 +1,6 @@
 = Volume Snapshots
+:revdate: 2024-09-23
+:page-revdate: {revdate}
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/cluster.adoc
@@ -1,4 +1,6 @@
 = Cluster Issues
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 == Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/faq.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/faq.adoc
@@ -1,4 +1,6 @@
 = FAQ
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/installation.adoc
@@ -1,4 +1,6 @@
 = Installation Issues
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring Issues
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Monitoring is unusable
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/operating-system.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/operating-system.adoc
@@ -1,4 +1,6 @@
 = Operating System Issues
+:revdate: 2024-09-27
+:page-revdate: {revdate}
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the https://github.com/rancher/elemental-toolkit[elemental-toolkit]. The following sections contain information and tips to help users troubleshoot OS-related issues.
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/rancher.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/rancher.adoc
@@ -1,4 +1,6 @@
 = Rancher Issues
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 == Guest Cluster Log Collection
 

--- a/versions/v1.4/modules/en/pages/troubleshooting/virtual-machines.adoc
+++ b/versions/v1.4/modules/en/pages/troubleshooting/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Issues
+:revdate: 2025-02-18
+:page-revdate: {revdate}
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.
 

--- a/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,4 +1,6 @@
 = Troubleshooting
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.4/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/upgrades.adoc
@@ -1,4 +1,6 @@
 = Upgrades
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 == Upgrade support matrix
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2 to v1.2.0 (not recommended)
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 [CAUTION]
 ====

--- a/versions/v1.4/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
+:revdate: 2024-09-24
+:page-revdate: {revdate}
 
 == Important changes to this version
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.1 to v1.2.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.2/v1.3.0 to v1.3.1
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.1 to v1.3.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.2 to v1.4.0
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.0 to v1.4.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 to v1.4.2
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.4/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 or v1.4.2 to v1.4.3
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/access-vm.adoc
@@ -1,4 +1,6 @@
 = Access to the Virtual Machine
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 Once the virtual machine is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the {harvester-product-name} UI.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Backup, Snapshot & Restore
+:revdate: 2025-04-02
+:page-revdate: {revdate}
 
 == Virtual Machine Backup & Restore
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,4 +1,6 @@
 = Clone a Virtual Machine
+:revdate: 2024-11-29
+:page-revdate: {revdate}
 
 Virtual machines can be cloned with or without data. This function doesn't need to take a virtual machine snapshot or set up a backup target first.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/cpu-pinning.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/cpu-pinning.adoc
@@ -1,4 +1,6 @@
 = CPU Pinning
+:revdate: 2024-11-29
+:page-revdate: {revdate}
 
 {harvester-product-name} supports virtual machine CPU pinning. To use this feature, you must first enable the CPU Manager on the nodes, and then enable CPU pinning when you create the virtual machine.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/create-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Virtual Machine
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 == How to Create a Virtual Machine
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/create-windows-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/create-windows-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Windows Virtual Machine
+:revdate: 2024-12-02
+:page-revdate: {revdate}
 
 Create one or more virtual machines from the *Virtual Machines* page.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/edit-vm.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/edit-vm.adoc
@@ -1,4 +1,6 @@
 = Edit a Virtual Machine
+:revdate: 2024-12-02
+:page-revdate: {revdate}
 
 == How to Edit a Virtual Machine
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/hotplug-volume.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/hotplug-volume.adoc
@@ -1,4 +1,6 @@
 = Hot-Plug Volumes
+:revdate: 2024-12-02
+:page-revdate: {revdate}
 
 {harvester-product-name} supports adding hot-plug volumes to a running virtual machine.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/live-migration.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/live-migration.adoc
@@ -1,4 +1,6 @@
 = Live Migration
+:revdate: 2024-12-02
+:page-revdate: {revdate}
 
 Live migration means moving a virtual machine to a different host without downtime.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/resource-overcommit.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/resource-overcommit.adoc
@@ -1,4 +1,6 @@
 = Resource Overcommit
+:revdate: 2024-12-02
+:page-revdate: {revdate}
 
 {harvester-product-name} supports global configuration of resource overload percentages on CPU, memory, and storage. By setting xref:../installation-setup/config/settings.adoc#_overcommit_config[`overcommit-config`], this will allow scheduling of additional virtual machines even when physical resources are fully utilized.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machines
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux virtual machines] using one of the following methods: 
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
@@ -1,4 +1,6 @@
 = Custom SUSE Virtual Machine Images
+:revdate: 2024-11-29
+:page-revdate: {revdate}
 
 SUSE provides https://www.suse.com/download/sles/[SUSE Linux Enterprise (SLE)] and https://get.opensuse.org/leap/[openSUSE Leap] virtual machine images suitable for use in {harvester-product-name}. These images are built on the https://build.opensuse.org/[openSUSE Build Service] (OBS) using the https://osinside.github.io/kiwi/[Kiwi] image building tool, and can be used immediately after downloading.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/vm-images/image-security.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/vm-images/image-security.adoc
@@ -1,4 +1,6 @@
 = Image Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 {harvester-product-name} allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.4/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.4/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,4 +1,6 @@
 = Upload Images
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 

--- a/versions/v1.5/modules/en/pages/add-ons/add-ons.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/add-ons.adoc
@@ -1,4 +1,6 @@
 = Add-ons
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 SUSE® Virtualization makes optional functionality available as add-ons.
 

--- a/versions/v1.5/modules/en/pages/add-ons/harvester-seeder.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/harvester-seeder.adoc
@@ -1,4 +1,6 @@
 = Harvester Seeder
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 The *harvester-seeder* add-on allows you to perform out-of-band operations on Harvester hosts using the Intelligent Platform Management Interface (IPMI).
 

--- a/versions/v1.5/modules/en/pages/add-ons/lvm-local-storage.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/lvm-local-storage.adoc
@@ -1,4 +1,6 @@
 = Local Storage Support
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester v1.4.0 allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
 

--- a/versions/v1.5/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,4 +1,6 @@
 = NVIDIA Driver Toolkit
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing SUSE® Virtualization clusters.
 

--- a/versions/v1.5/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,4 +1,6 @@
 = PCI Devices Controller
+:revdate: 2025-05-23
+:page-revdate: {revdate}
 
 A `PCIDevice` in SUSE® Virtualization represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, or by using the UI to enable passthrough. Passing a device through the hypervisor means that the VM can directly access the device, and effectively owns the device. A VM can even install its own drivers for that device.

--- a/versions/v1.5/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,4 +1,6 @@
 = Rancher Manager (Experimental)
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 The `rancher-vcluster` add-on allows you to run Rancher Manager as a workload on the underlying SUSE® Virtualization cluster and is implemented using https://www.vcluster.com/[vcluster].
 

--- a/versions/v1.5/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,4 +1,6 @@
 = VM DHCP Controller (Managed DHCP)
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 You can configure IP pool information and serve IP addresses to VMs running on {harvester-product-name} clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.5/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.5/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,4 +1,6 @@
 = VM Import Controller
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 You can import virtual machines from VMware and OpenStack into {harvester-product-name} using the vm-import-controller add-on. The add-on must be enabled before you start importing virtual machines.
 

--- a/versions/v1.5/modules/en/pages/api.adoc
+++ b/versions/v1.5/modules/en/pages/api.adoc
@@ -1,5 +1,7 @@
 ++++
 <div class="api-doc">
+:revdate: 2025-07-09
+:page-revdate: {revdate}
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>

--- a/versions/v1.5/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.5/modules/en/pages/developer/addon-development.adoc
@@ -1,4 +1,6 @@
 = Add-on Development Guide
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 {harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
 

--- a/versions/v1.5/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.5/modules/en/pages/hosts/hosts.adoc
@@ -1,4 +1,6 @@
 = Host Management
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 Users can view and manage {harvester-product-name} nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 

--- a/versions/v1.5/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.5/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,4 +1,6 @@
 = vGPU Support
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 {harvester-product-name} is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
 

--- a/versions/v1.5/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.5/modules/en/pages/hosts/witness-node.adoc
@@ -1,4 +1,6 @@
 = Witness Node
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 {harvester-product-name} clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in {harvester-product-name}) to ensure that a quorum is maintained.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/airgap.adoc
@@ -1,4 +1,6 @@
 = Air-Gapped Environment
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/authentication.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/authentication.adoc
@@ -1,4 +1,6 @@
 = Authentication
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,4 +1,6 @@
 = CloudInit CRD
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 You can use the `CloudInit` CRD to configure {harvester-product-name} operating system settings either manually or using GitOps solutions.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,4 +1,6 @@
 = Configuration File
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Configuration Example
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,4 +1,6 @@
 = Settings
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,4 +1,6 @@
 = Update the Configuration After Installation
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/external-disk.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/external-disk.adoc
@@ -1,4 +1,6 @@
 = External Disk Support
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.5/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/management-address.adoc
@@ -1,4 +1,6 @@
 = Management Address
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 {harvester-product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,4 +1,6 @@
 = Install Binaries Only
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 You can install and configure binaries only, which is ideal for cloud and edge use cases.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/media/net-install.adoc
@@ -1,4 +1,6 @@
 = Net Install ISO
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 The net install ISO is a minimal installation image that contains only the core operating system components, allowing the installer to boot and then install the operating system on a disk. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 

--- a/versions/v1.5/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,4 +1,6 @@
 = ISO Installation
+:revdate: 2025-04-16
+:page-revdate: {revdate}
 
 {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,4 +1,6 @@
 = PXE Boot Installation
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 {harvester-product-name} can be installed automatically with PXE boot.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/methods/usb-install.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/methods/usb-install.adoc
@@ -1,4 +1,6 @@
 = USB Installation
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 == Create a bootable USB flash drive
 

--- a/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
@@ -1,4 +1,6 @@
 = Hardware and Network Requirements
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
 

--- a/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,4 +1,6 @@
 = Single-Node Clusters
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:/installation-setup/methods/iso-install.adoc[ISO], xref:/installation-setup/methods/usb-install.adoc[USB], and xref:/installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -1,4 +1,6 @@
 = Harvester Cloud Provider
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 xref:../../integrations/rancher/node-driver/rke1-cluster.adoc[RKE1] and xref:../../integrations/rancher/node-driver/rke2-cluster.adoc[RKE2] clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides <<Load Balancer Support,load balancer>> and Harvester cluster xref:./csi-driver.adoc[storage passthrough] support to the guest Kubernetes cluster.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester CSI Driver
+:revdate: 2025-03-12
+:page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the host cluster and hot-plugs host volumes to the virtual machines to provide native storage performance.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
@@ -1,4 +1,6 @@
 = Harvester UI Extension
+:revdate: 2025-07-02
+:page-revdate: {revdate}
 
 {rancher-short-name} 2.10.0 and later versions integrate with {harvester-product-name} using the https://github.com/harvester/harvester-ui-extension[Harvester UI Extension], which is built on the https://www.npmjs.com/package/@rancher/shell[@rancher/shell] library.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/import-vm.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/import-vm.adoc
@@ -1,4 +1,6 @@
 = Import a Cluster Built on a SUSE® Virtualization VM
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 Rancher allows you to import SUSE® Virtualization virtual machines in which you installed Kubernetes.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an K3s Kubernetes Cluster
+:revdate: 2025-02-13
+:page-revdate: {revdate}
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester Node Driver
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 The https://github.com/harvester/docker-machine-driver-harvester[Harvester Node Driver], similar to the Docker Machine driver, is used to provision VMs in the {harvester-product-name} cluster, and {rancher-short-name} uses it to launch and manage Kubernetes clusters.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE1 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 [WARNING]
 ====

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE2 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 You can now provision {rke2-product-name} Kubernetes clusters on top of the {harvester-product-name} cluster in {rancher-product-name} using the built-in Harvester Node Driver.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,4 +1,6 @@
 = {rancher-product-name} Integration
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Rancher Terraform
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 The https://registry.terraform.io/providers/rancher/rancher2/[Rancher Terraform Provider] allows administrators to create and manage RKE2 guest clusters using Terraform.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -1,4 +1,6 @@
 = Resource Quotas
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota] is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/virtualization-management.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/virtualization-management.adoc
@@ -1,4 +1,6 @@
 = Virtualization Management
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 With {rancher-short-name}'s virtualization management capabilities, you can import and manage multiple {harvester-product-name} clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.
 

--- a/versions/v1.5/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Terraform Provider
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 == Support Matrix
 

--- a/versions/v1.5/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a High-Availability Cluster
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:/hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:/installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.5/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a Single-Node Cluster
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.5/modules/en/pages/introduction/document-conventions.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/document-conventions.adoc
@@ -1,4 +1,6 @@
 = Document Conventions
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Release Types
 

--- a/versions/v1.5/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/glossary.adoc
@@ -1,4 +1,6 @@
 = Glossary
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 == *guest cluster* / *guest Kubernetes cluster*
 

--- a/versions/v1.5/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/overview.adoc
@@ -1,4 +1,6 @@
 = Overview
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versions/v1.5/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.5/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,6 @@
 = Networking Best Practices
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Replace Ethernet NICs
 

--- a/versions/v1.5/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.5/modules/en/pages/networking/cluster-network.adoc
@@ -1,4 +1,6 @@
 = Cluster Network
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 == Concepts
 

--- a/versions/v1.5/modules/en/pages/networking/deep-dive.adoc
+++ b/versions/v1.5/modules/en/pages/networking/deep-dive.adoc
@@ -1,4 +1,6 @@
 = Networking Deep Dive
+:revdate: 2025-05-20
+:page-revdate: {revdate}
 
 == Network topology
 

--- a/versions/v1.5/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.5/modules/en/pages/networking/ip-pool.adoc
@@ -1,4 +1,6 @@
 = IP Pool
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 

--- a/versions/v1.5/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.5/modules/en/pages/networking/load-balancer.adoc
@@ -1,4 +1,6 @@
 = Load Balancer
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 

--- a/versions/v1.5/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.5/modules/en/pages/networking/storage-network.adoc
@@ -1,4 +1,6 @@
 = Storage Network
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 

--- a/versions/v1.5/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.5/modules/en/pages/networking/vm-network.adoc
@@ -1,4 +1,6 @@
 = VM Network
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester provides three types of networks for virtual machines (VMs), including:
 

--- a/versions/v1.5/modules/en/pages/observability/logging.adoc
+++ b/versions/v1.5/modules/en/pages/observability/logging.adoc
@@ -1,4 +1,6 @@
 = Logging
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 

--- a/versions/v1.5/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/observability/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring
+:revdate: 2025-06-16
+:page-revdate: {revdate}
 
 The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 

--- a/versions/v1.5/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.5/modules/en/pages/storage/csidriver.adoc
@@ -1,4 +1,6 @@
 = Third-Party Storage Support
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 {harvester-product-name} now supports provisioning of root volumes and data volumes using external https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] drivers. This enhancement allows you to select drivers that meet specific requirements, such as performance optimization or seamless integration with existing internal storage solutions.
 

--- a/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -1,4 +1,6 @@
 = Longhorn V2 Data Engine
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.
 

--- a/versions/v1.5/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.5/modules/en/pages/storage/storageclass.adoc
@@ -1,4 +1,6 @@
 = StorageClass
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. {longhorn-product-name} StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as _profiles_ in other storage systems.
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/clone-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/clone-volume.adoc
@@ -1,4 +1,6 @@
 = Clone a Volume
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 == How to Clone a Volume
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/create-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/create-volume.adoc
@@ -1,4 +1,6 @@
 = Create a Volume
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 == Create an Empty Volume
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -1,4 +1,6 @@
 = Edit a Volume
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/export-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/export-volume.adoc
@@ -1,4 +1,6 @@
 = Export a Volume to Image
+:revdate: 2025-05-06
+:page-revdate: {revdate}
 
 You can select and export an existing volume to an image by following the steps below:
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/volume-security.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/volume-security.adoc
@@ -1,4 +1,6 @@
 = Volume Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/volume-snapshots.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/volume-snapshots.adoc
@@ -1,4 +1,6 @@
 = Volume Snapshots
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
@@ -1,4 +1,6 @@
 = Cluster Issues
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 == Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/faq.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/faq.adoc
@@ -1,4 +1,6 @@
 = FAQ
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/installation.adoc
@@ -1,4 +1,6 @@
 = Installation Issues
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring Issues
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Monitoring is unusable
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/operating-system.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/operating-system.adoc
@@ -1,4 +1,6 @@
 = Operating System Issues
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the https://github.com/rancher/elemental-toolkit[elemental-toolkit]. The following sections contain information and tips to help users troubleshoot OS-related issues.
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/rancher.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/rancher.adoc
@@ -1,4 +1,6 @@
 = Rancher Issues
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 == Guest Cluster Log Collection
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/virtual-machines.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Issues
+:revdate: 2025-02-18
+:page-revdate: {revdate}
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.
 

--- a/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,4 +1,6 @@
 = Troubleshooting
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
@@ -1,4 +1,6 @@
 = Upgrades
+:revdate: 2025-07-02
+:page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2 to v1.2.0 (not recommended)
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 [CAUTION]
 ====

--- a/versions/v1.5/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 == Important changes to this version
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.1 to v1.2.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.2/v1.3.0 to v1.3.1
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.1 to v1.3.2
+:revdate: 2025-05-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.2 to v1.4.0
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.0 to v1.4.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 to v1.4.2
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 or v1.4.2 to v1.4.3
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.2 or v1.4.3 to v1.5.0
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.2 or v1.4.3 to v1.5.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.5.0 to v1.5.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/access-vm.adoc
@@ -1,4 +1,6 @@
 = Access to the Virtual Machine
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 Once the virtual machine is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the {harvester-product-name} UI.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Backup, Snapshot & Restore
+:revdate: 2025-05-06
+:page-revdate: {revdate}
 
 == Virtual Machine Backup & Restore
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,4 +1,6 @@
 = Clone a Virtual Machine
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 Virtual machines can be cloned with or without data. This function doesn't need to take a virtual machine snapshot or set up a backup target first.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/cpu-pinning.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/cpu-pinning.adoc
@@ -1,4 +1,6 @@
 = CPU Pinning
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 {harvester-product-name} supports virtual machine CPU pinning. To use this feature, you must first enable the CPU Manager on the nodes, and then enable CPU pinning when you create the virtual machine.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/create-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Virtual Machine
+:revdate: 2025-05-08
+:page-revdate: {revdate}
 
 == How to Create a Virtual Machine
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/create-windows-vm.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/create-windows-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Windows Virtual Machine
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 Create one or more virtual machines from the *Virtual Machines* page.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/edit-vm.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/edit-vm.adoc
@@ -1,4 +1,6 @@
 = Edit a Virtual Machine
+:revdate: 2025-05-06
+:page-revdate: {revdate}
 
 == How to Edit a Virtual Machine
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/hotplug-volume.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/hotplug-volume.adoc
@@ -1,4 +1,6 @@
 = Hot-Plug Volumes
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 {harvester-product-name} supports adding hot-plug volumes to a running virtual machine.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/live-migration.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/live-migration.adoc
@@ -1,4 +1,6 @@
 = Live Migration
+:revdate: 2025-05-06
+:page-revdate: {revdate}
 
 Live migration means moving a virtual machine to a different host without downtime.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/resource-overcommit.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/resource-overcommit.adoc
@@ -1,4 +1,6 @@
 = Resource Overcommit
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 {harvester-product-name} supports global configuration of resource overload percentages on CPU, memory, and storage. By setting xref:../installation-setup/config/settings.adoc#_overcommit_config[`overcommit-config`], this will allow scheduling of additional virtual machines even when physical resources are fully utilized.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machines
+:revdate: 2025-04-25
+:page-revdate: {revdate}
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux virtual machines] using one of the following methods: 
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
@@ -1,4 +1,6 @@
 = Custom SUSE Virtual Machine Images
+:revdate: 2024-12-23
+:page-revdate: {revdate}
 
 SUSE provides https://www.suse.com/download/sles/[SUSE Linux Enterprise (SLE)] and https://get.opensuse.org/leap/[openSUSE Leap] virtual machine images suitable for use in {harvester-product-name}. These images are built on the https://build.opensuse.org/[openSUSE Build Service] (OBS) using the https://osinside.github.io/kiwi/[Kiwi] image building tool, and can be used immediately after downloading.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/vm-images/image-security.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/vm-images/image-security.adoc
@@ -1,4 +1,6 @@
 = Image Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 {harvester-product-name} allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.5/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.5/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,4 +1,6 @@
 = Upload Images
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 

--- a/versions/v1.6/modules/en/pages/add-ons/add-ons.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/add-ons.adoc
@@ -1,4 +1,6 @@
 = Add-ons
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 SUSE® Virtualization makes optional functionality available as add-ons.
 

--- a/versions/v1.6/modules/en/pages/add-ons/harvester-seeder.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/harvester-seeder.adoc
@@ -1,4 +1,6 @@
 = Harvester Seeder
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 The *harvester-seeder* add-on allows you to perform out-of-band operations on Harvester hosts using the Intelligent Platform Management Interface (IPMI).
 

--- a/versions/v1.6/modules/en/pages/add-ons/lvm-local-storage.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/lvm-local-storage.adoc
@@ -1,4 +1,6 @@
 = Local Storage Support
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester v1.4.0 allows you to use local storage on the host to create persistent volumes for your workloads with better performance and latency. This functionality is made possible by LVM, which provides logical volume management facilities on Linux.
 

--- a/versions/v1.6/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/nvidia-driver-toolkit.adoc
@@ -1,4 +1,6 @@
 = NVIDIA Driver Toolkit
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 nvidia-driver-toolkit is an add-on that allows you to deploy out-of-band NVIDIA GRID KVM drivers to your existing SUSE® Virtualization clusters.
 

--- a/versions/v1.6/modules/en/pages/add-ons/pcidevices-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/pcidevices-controller.adoc
@@ -1,4 +1,6 @@
 = PCI Devices Controller
+:revdate: 2025-05-23
+:page-revdate: {revdate}
 
 A `PCIDevice` in SUSE® Virtualization represents a host device with a PCI address.
 The devices can be passed through the hypervisor to a VM by creating a `PCIDeviceClaim` resource, or by using the UI to enable passthrough. Passing a device through the hypervisor means that the VM can directly access the device, and effectively owns the device. A VM can even install its own drivers for that device.

--- a/versions/v1.6/modules/en/pages/add-ons/rancher-vcluster.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/rancher-vcluster.adoc
@@ -1,4 +1,6 @@
 = Rancher Manager (Experimental)
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 The `rancher-vcluster` add-on allows you to run Rancher Manager as a workload on the underlying SUSE® Virtualization cluster and is implemented using https://www.vcluster.com/[vcluster].
 

--- a/versions/v1.6/modules/en/pages/add-ons/vm-dhcp-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-dhcp-controller.adoc
@@ -1,4 +1,6 @@
 = VM DHCP Controller (Managed DHCP)
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 You can configure IP pool information and serve IP addresses to VMs running on {harvester-product-name} clusters using the embedded Managed DHCP feature. This feature, which is an alternative to the standalone DHCP server, leverages the vm-dhcp-controller add-on to simplify guest cluster deployment.
 

--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,4 +1,6 @@
 = VM Import Controller
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 You can import virtual machines from VMware and OpenStack into {harvester-product-name} using the vm-import-controller add-on. The add-on must be enabled before you start importing virtual machines.
 

--- a/versions/v1.6/modules/en/pages/api.adoc
+++ b/versions/v1.6/modules/en/pages/api.adoc
@@ -1,5 +1,7 @@
 ++++
 <div class="api-doc">
+:revdate: 2025-07-14
+:page-revdate: {revdate}
     <redoc id='redoc-container'></redoc>
     <script src="https://cdn.redoc.ly/redoc/latest/bundles/redoc.standalone.js"></script>
     <script>

--- a/versions/v1.6/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.6/modules/en/pages/developer/addon-development.adoc
@@ -1,4 +1,6 @@
 = Add-on Development Guide
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 {harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
 

--- a/versions/v1.6/modules/en/pages/hosts/hosts.adoc
+++ b/versions/v1.6/modules/en/pages/hosts/hosts.adoc
@@ -1,4 +1,6 @@
 = Host Management
+:revdate: 2025-06-17
+:page-revdate: {revdate}
 
 Users can view and manage {harvester-product-name} nodes from the host page. The first node always defaults to be a management node of the cluster. When there are three or more nodes, the two other nodes that first joined are automatically promoted to management nodes to form a HA cluster.
 

--- a/versions/v1.6/modules/en/pages/hosts/vgpu-support.adoc
+++ b/versions/v1.6/modules/en/pages/hosts/vgpu-support.adoc
@@ -1,4 +1,6 @@
 = vGPU Support
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} is capable of sharing NVIDIA GPU support for Single Root IO Virtualization (SR-IOV). This additional capability, which is provided by the **pcidevices-controller** add-on, leverages `sriov-manage` for GPU management. 
 

--- a/versions/v1.6/modules/en/pages/hosts/witness-node.adoc
+++ b/versions/v1.6/modules/en/pages/hosts/witness-node.adoc
@@ -1,4 +1,6 @@
 = Witness Node
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} clusters deployed in production environments require a control plane for node and pod management. A typical three-node cluster has three management nodes that each contain the complete set of control plane components. One key component is etcd, which Kubernetes uses to store its data (configuration, state, and metadata). The etcd node count must always be an odd number (for example, 3 is the default count in {harvester-product-name}) to ensure that a quorum is maintained.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/airgap.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/airgap.adoc
@@ -1,4 +1,6 @@
 = Air-Gapped Environment
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 This section describes how to use {harvester-product-name} in an air-gapped environment. Some use cases could be where {harvester-product-name} will be installed offline, behind a firewall, or behind a proxy.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/authentication.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/authentication.adoc
@@ -1,4 +1,6 @@
 = Authentication
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 After installation, user will be prompted to set the password for the default `admin` user on the first-time login.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/cloudinitcrd.adoc
@@ -1,4 +1,6 @@
 = CloudInit CRD
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 You can use the `CloudInit` CRD to configure {harvester-product-name} operating system settings either manually or using GitOps solutions.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -1,4 +1,6 @@
 = Configuration File
+:revdate: 2025-08-01
+:page-revdate: {revdate}
 
 == Configuration Example
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,4 +1,6 @@
 = Settings
+:revdate: 2025-08-01
+:page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,4 +1,6 @@
 = Update the Configuration After Installation
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the  OS revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/external-disk.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/external-disk.adoc
@@ -1,4 +1,6 @@
 = External Disk Support
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.6/modules/en/pages/installation-setup/management-address.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/management-address.adoc
@@ -1,4 +1,6 @@
 = Management Address
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 {harvester-product-name} provides a fixed virtual IP (VIP) as the management address, VIP must be different from any Node IP. You can find the management address on the console dashboard after the installation.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/media/install-binaries-mode.adoc
@@ -1,4 +1,6 @@
 = Install Binaries Only
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 You can install and configure binaries only, which is ideal for cloud and edge use cases.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/media/net-install.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/media/net-install.adoc
@@ -1,4 +1,6 @@
 = Net Install ISO
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 The net install ISO is a minimal installation image that contains only the core operating system components, allowing the installer to boot and then install the operating system on a disk. After installation is completed, the operating system pulls all required container images from the internet (mostly from Docker Hub).
 

--- a/versions/v1.6/modules/en/pages/installation-setup/methods/iso-install.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/methods/iso-install.adoc
@@ -1,4 +1,6 @@
 = ISO Installation
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the ISO image. To get the ISO image, download *💿 harvester-v1.x.x-amd64.iso* from the https://github.com/harvester/harvester/releases[Releases] page.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -1,4 +1,6 @@
 = PXE Boot Installation
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 {harvester-product-name} can be installed automatically with PXE boot.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/methods/usb-install.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/methods/usb-install.adoc
@@ -1,4 +1,6 @@
 = USB Installation
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == Create a bootable USB flash drive
 

--- a/versions/v1.6/modules/en/pages/installation-setup/post-installation.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/post-installation.adoc
@@ -1,4 +1,6 @@
 = Post-Installation Tasks
+:revdate: 2025-05-23
+:page-revdate: {revdate}
 
 You can enhance the security and performance of your {harvester-product-name} cluster by performing the following procedures after installation is completed.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
@@ -1,4 +1,6 @@
 = Hardware and Network Requirements
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
 

--- a/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -1,4 +1,6 @@
 = Single-Node Clusters
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} supports single-node clusters for implementations that can tolerate lower resilience or require minimal initial deployment resources. You can create single-node clusters using the standard installation methods (xref:/installation-setup/methods/iso-install.adoc[ISO], xref:/installation-setup/methods/usb-install.adoc[USB], and xref:/installation-setup/methods/pxe-boot-install.adoc[PXE boot]).
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/cloud-provider.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/cloud-provider.adoc
@@ -1,4 +1,6 @@
 = Harvester Cloud Provider
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 xref:../../integrations/rancher/node-driver/rke1-cluster.adoc[RKE1] and xref:../../integrations/rancher/node-driver/rke2-cluster.adoc[RKE2] clusters can be provisioned in Rancher using the built-in Harvester Node Driver. Harvester provides <<Load Balancer Support,load balancer>> and Harvester cluster xref:./csi-driver.adoc[storage passthrough] support to the guest Kubernetes cluster.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester CSI Driver
+:revdate: 2025-08-01
+:page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the host cluster and hot-plugs host volumes to the virtual machines to provide native storage performance.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/harvester-ui-extension.adoc
@@ -1,4 +1,6 @@
 = Harvester UI Extension
+:revdate: 2025-07-02
+:page-revdate: {revdate}
 
 {rancher-short-name} 2.10.0 and later versions integrate with {harvester-product-name} using the https://github.com/harvester/harvester-ui-extension[Harvester UI Extension], which is built on the https://www.npmjs.com/package/@rancher/shell[@rancher/shell] library.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/import-vm.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/import-vm.adoc
@@ -1,4 +1,6 @@
 = Import a Cluster Built on a SUSE® Virtualization VM
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Rancher allows you to import SUSE® Virtualization virtual machines in which you installed Kubernetes.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/k3s-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an K3s Kubernetes Cluster
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 You can now provision K3s Kubernetes clusters on top of the Harvester cluster in Rancher using the built-in Harvester node driver.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/node-driver.adoc
@@ -1,4 +1,6 @@
 = Harvester Node Driver
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 The https://github.com/harvester/docker-machine-driver-harvester[Harvester Node Driver], similar to the Docker Machine driver, is used to provision VMs in the {harvester-product-name} cluster, and {rancher-short-name} uses it to launch and manage Kubernetes clusters.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE1 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 [WARNING]
 ====

--- a/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/node-driver/rke2-cluster.adoc
@@ -1,4 +1,6 @@
 = Creating an RKE2 Kubernetes Cluster
+:revdate: 2025-06-09
+:page-revdate: {revdate}
 
 You can now provision {rke2-product-name} Kubernetes clusters on top of the {harvester-product-name} cluster in {rancher-product-name} using the built-in Harvester Node Driver.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,4 +1,6 @@
 = {rancher-product-name} Integration
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/rancher-terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Rancher Terraform
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 The https://registry.terraform.io/providers/rancher/rancher2/[Rancher Terraform Provider] allows administrators to create and manage RKE2 guest clusters using Terraform.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/resource-quota.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/resource-quota.adoc
@@ -1,4 +1,6 @@
 = Resource Quotas
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 https://kubernetes.io/docs/concepts/policy/resource-quotas/[ResourceQuota] is used to limit the usage of resources within a namespace. It helps administrators control and restrict the allocation of cluster resources to ensure fairness and controlled resource distribution among namespaces.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/virtualization-management.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/virtualization-management.adoc
@@ -1,4 +1,6 @@
 = Virtualization Management
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 With {rancher-short-name}'s virtualization management capabilities, you can import and manage multiple {harvester-product-name} clusters. It provides a solution that unifies virtualization and container management from a single pane of glass.
 

--- a/versions/v1.6/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,4 +1,6 @@
 = Terraform Provider
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == Support Matrix
 

--- a/versions/v1.6/modules/en/pages/introduction/deploy-ha-cluster.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/deploy-ha-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a High-Availability Cluster
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:/hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:/installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.6/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/deploy-singlenode-cluster.adoc
@@ -1,4 +1,6 @@
 = Deploy a Single-Node Cluster
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 A {harvester-product-name} cluster with three or more nodes is required to fully realize multi-node features such as high availability. The latest versions allow you to create clusters with two management nodes and one xref:../hosts/witness-node.adoc[witness node] (and optionally, one or more worker nodes). You can also create xref:../installation-setup/single-node-clusters.adoc[single-node clusters] that support most features (excluding high availability, multi-replica support, and live migration).
 

--- a/versions/v1.6/modules/en/pages/introduction/document-conventions.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/document-conventions.adoc
@@ -1,4 +1,6 @@
 = Document Conventions
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Release Types
 

--- a/versions/v1.6/modules/en/pages/introduction/glossary.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/glossary.adoc
@@ -1,4 +1,6 @@
 = Glossary
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 == *guest cluster* / *guest Kubernetes cluster*
 

--- a/versions/v1.6/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/overview.adoc
@@ -1,4 +1,6 @@
 = Overview
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 

--- a/versions/v1.6/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.6/modules/en/pages/networking/best-practices.adoc
@@ -1,4 +1,6 @@
 = Networking Best Practices
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Replace Ethernet NICs
 

--- a/versions/v1.6/modules/en/pages/networking/cluster-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/cluster-network.adoc
@@ -1,4 +1,6 @@
 = Cluster Network
+:revdate: 2025-06-23
+:page-revdate: {revdate}
 
 == Concepts
 

--- a/versions/v1.6/modules/en/pages/networking/deep-dive.adoc
+++ b/versions/v1.6/modules/en/pages/networking/deep-dive.adoc
@@ -1,4 +1,6 @@
 = Networking Deep Dive
+:revdate: 2025-05-20
+:page-revdate: {revdate}
 
 == Network topology
 

--- a/versions/v1.6/modules/en/pages/networking/ip-pool.adoc
+++ b/versions/v1.6/modules/en/pages/networking/ip-pool.adoc
@@ -1,4 +1,6 @@
 = IP Pool
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Harvester IP Pool is a built-in IP address management (IPAM) solution exclusively available to Harvester load balancers (LBs).
 

--- a/versions/v1.6/modules/en/pages/networking/load-balancer.adoc
+++ b/versions/v1.6/modules/en/pages/networking/load-balancer.adoc
@@ -1,4 +1,6 @@
 = Load Balancer
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 The Harvester load balancer (LB) is a built-in Layer 4 load balancer that distributes incoming traffic across workloads deployed on Harvester virtual machines (VMs) or guest Kubernetes clusters.
 

--- a/versions/v1.6/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/storage-network.adoc
@@ -1,4 +1,6 @@
 = Storage Network
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from the Kubernetes cluster network (for example, the management network) or other cluster-wide workloads, you can allocate a dedicated storage network for {longhorn-product-name} replication traffic to get better network bandwidth and performance.
 

--- a/versions/v1.6/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/vm-network.adoc
@@ -1,4 +1,6 @@
 = VM Network
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester provides three types of networks for virtual machines (VMs), including:
 

--- a/versions/v1.6/modules/en/pages/observability/logging.adoc
+++ b/versions/v1.6/modules/en/pages/observability/logging.adoc
@@ -1,4 +1,6 @@
 = Logging
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 It is important to know what is happening/has happened in the `Harvester Cluster`.
 

--- a/versions/v1.6/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/observability/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring
+:revdate: 2025-06-16
+:page-revdate: {revdate}
 
 The monitoring feature is now implemented with an add-on and is disabled by default in new installations.
 

--- a/versions/v1.6/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.6/modules/en/pages/storage/csidriver.adoc
@@ -1,4 +1,6 @@
 = Third-Party Storage Support
+:revdate: 2025-07-17
+:page-revdate: {revdate}
 
 {harvester-product-name} now supports provisioning of root volumes and data volumes using external https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] drivers. This enhancement allows you to select drivers that meet specific requirements, such as performance optimization or seamless integration with existing internal storage solutions.
 

--- a/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -1,4 +1,6 @@
 = Longhorn V2 Data Engine
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.
 

--- a/versions/v1.6/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.6/modules/en/pages/storage/storageclass.adoc
@@ -1,4 +1,6 @@
 = StorageClass
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 {harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. {longhorn-product-name} StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as _profiles_ in other storage systems.
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/clone-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/clone-volume.adoc
@@ -1,4 +1,6 @@
 = Clone a Volume
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == How to Clone a Volume
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/create-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/create-volume.adoc
@@ -1,4 +1,6 @@
 = Create a Volume
+:revdate: 2025-06-18
+:page-revdate: {revdate}
 
 == Create an Empty Volume
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -1,4 +1,6 @@
 = Edit a Volume
+:revdate: 2025-07-31
+:page-revdate: {revdate}
 
 After creating a volume, you can edit your volume by clicking the `⋮` button and selecting the `Edit Config` option.
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/export-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/export-volume.adoc
@@ -1,4 +1,6 @@
 = Export a Volume to Image
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 You can select and export an existing volume to an image by following the steps below:
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/volume-security.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/volume-security.adoc
@@ -1,4 +1,6 @@
 = Volume Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 Harvester allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/volume-snapshots.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/volume-snapshots.adoc
@@ -1,4 +1,6 @@
 = Volume Snapshots
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 A volume snapshot represents a snapshot of a volume on a storage system. After creating a volume, you can create a volume snapshot and restore a volume to the snapshot's state. With volume snapshots, you can easily copy or restore a volume's configuration.
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
@@ -1,4 +1,6 @@
 = Cluster Issues
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 == Fail to Deploy a Multi-node Cluster Due to Incorrect HTTP Proxy Setting
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/faq.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/faq.adoc
@@ -1,4 +1,6 @@
 = FAQ
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 This FAQ is a work in progress designed to answer the questions our users most frequently ask about Harvester.
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/installation.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/installation.adoc
@@ -1,4 +1,6 @@
 = Installation Issues
+:revdate: 2025-06-04
+:page-revdate: {revdate}
 
 The following sections contain tips to troubleshoot or get assistance with failed installations.
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -1,4 +1,6 @@
 = Monitoring Issues
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Monitoring is unusable
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/operating-system.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/operating-system.adoc
@@ -1,4 +1,6 @@
 = Operating System Issues
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Harvester runs on an OpenSUSE-based OS. The OS is an artifact produced by the https://github.com/rancher/elemental-toolkit[elemental-toolkit]. The following sections contain information and tips to help users troubleshoot OS-related issues.
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/rancher.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/rancher.adoc
@@ -1,4 +1,6 @@
 = Rancher Issues
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 == Guest Cluster Log Collection
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/virtual-machines.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Issues
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 The following sections contain information useful in troubleshooting issues related to Harvester VM management.
 

--- a/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,4 +1,6 @@
 = Troubleshooting
+:revdate: 2025-07-16
+:page-revdate: {revdate}
 
 == Overview
 

--- a/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
@@ -1,4 +1,6 @@
 = Upgrades
+:revdate: 2025-07-02
+:page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-1-2-to-v1-2-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2 to v1.2.0 (not recommended)
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 [CAUTION]
 ====

--- a/versions/v1.6/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-2-0-to-v1-2-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.1.2/v1.1.3/v1.2.0 to v1.2.1
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == Important changes to this version
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-2-1-to-v1-2-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.1 to v1.2.2
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-2-2-to-v1-3-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.2.2/v1.3.0 to v1.3.1
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-3-1-to-v1-3-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.1 to v1.3.2
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-3-2-to-v1-4-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.3.2 to v1.4.0
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-0-to-v1-4-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.0 to v1.4.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-2.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 to v1.4.2
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-1-to-v1-4-3.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.1 or v1.4.2 to v1.4.3
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.2 or v1.4.3 to v1.5.0
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.4.2 or v1.4.3 to v1.5.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -1,4 +1,6 @@
 = Upgrade from v1.5.0 to v1.5.1
+:revdate: 2025-07-07
+:page-revdate: {revdate}
 
 == General information
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/access-vm.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/access-vm.adoc
@@ -1,4 +1,6 @@
 = Access to the Virtual Machine
+:revdate: 2025-05-15
+:page-revdate: {revdate}
 
 Once the virtual machine is up and running, you can access it using either the Virtual Network Computing (VNC) client or the serial console from the {harvester-product-name} UI.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/backup-restore.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/backup-restore.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Backup, Snapshot & Restore
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == Virtual Machine Backup & Restore
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/clone-vm.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/clone-vm.adoc
@@ -1,4 +1,6 @@
 = Clone a Virtual Machine
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Virtual machines can be cloned with or without data. This function doesn't need to take a virtual machine snapshot or set up a backup target first.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/cpu-pinning.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/cpu-pinning.adoc
@@ -1,4 +1,6 @@
 = CPU Pinning
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} supports virtual machine CPU pinning. To use this feature, you must first enable the CPU Manager on the nodes, and then enable CPU pinning when you create the virtual machine.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/create-vm.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/create-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Virtual Machine
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 == How to Create a Virtual Machine
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/create-windows-vm.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/create-windows-vm.adoc
@@ -1,4 +1,6 @@
 = Create a Windows Virtual Machine
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Create one or more virtual machines from the *Virtual Machines* page.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/edit-vm.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/edit-vm.adoc
@@ -1,4 +1,6 @@
 = Edit a Virtual Machine
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 == How to Edit a Virtual Machine
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/hotplug-volume.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/hotplug-volume.adoc
@@ -1,4 +1,6 @@
 = Hot-Plug Volumes
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} supports adding hot-plug volumes to a running virtual machine.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/live-migration.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/live-migration.adoc
@@ -1,4 +1,6 @@
 = Live Migration
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 Live migration means moving a virtual machine to a different host without downtime.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/resource-overcommit.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/resource-overcommit.adoc
@@ -1,4 +1,6 @@
 = Resource Overcommit
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 {harvester-product-name} supports global configuration of resource overload percentages on CPU, memory, and storage. By setting xref:../installation-setup/config/settings.adoc#_overcommit_config[`overcommit-config`], this will allow scheduling of additional virtual machines even when physical resources are fully utilized.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -1,4 +1,6 @@
 = Virtual Machines
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux virtual machines] using one of the following methods: 
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/vm-images/custom-suse-images.adoc
@@ -1,4 +1,6 @@
 = Custom SUSE Virtual Machine Images
+:revdate: 2025-05-09
+:page-revdate: {revdate}
 
 SUSE provides https://www.suse.com/download/sles/[SUSE Linux Enterprise (SLE)] and https://get.opensuse.org/leap/[openSUSE Leap] virtual machine images suitable for use in {harvester-product-name}. These images are built on the https://build.opensuse.org/[openSUSE Build Service] (OBS) using the https://osinside.github.io/kiwi/[Kiwi] image building tool, and can be used immediately after downloading.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/vm-images/image-security.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/vm-images/image-security.adoc
@@ -1,4 +1,6 @@
 = Image Security
+:revdate: 2025-06-10
+:page-revdate: {revdate}
 
 {harvester-product-name} allows you to encrypt and decrypt virtual machine images. The encryption mechanism utilizes the Linux kernel module dm_crypt and the command-line utility cryptsetup.
 

--- a/versions/v1.6/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,4 +1,6 @@
 = Upload Images
+:revdate: 2025-06-20
+:page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
 


### PR DESCRIPTION
I added the `:revdate:` and `:page-revdate:` attribute to all content files in all doc versions using [this script](https://github.com/rancher/kubewarden-product-docs/blob/main/bin/add_initial_revdate).