### PR TITLE
Fix markup, add revdate attributes, update Kube-OVN sample code (853, 862)

### DIFF
--- a/versions/v1.6/modules/en/pages/add-ons/kubeovn-operator.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/kubeovn-operator.adoc
@@ -1,4 +1,6 @@
 = Kube-OVN Operator
+:revdate: 2025-09-15
+:page-revdate: {revdate}
 
 https://github.com/harvester/kubeovn-operator[`kubeovn-operator`] is used to manage the lifecycle of https://github.com/kubeovn/kube-ovn[Kube-OVN] as a secondary CNI on underlying {harvester-product-name} clusters.
 

--- a/versions/v1.6/modules/en/pages/add-ons/kubeovn-operator.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/kubeovn-operator.adoc
@@ -194,13 +194,13 @@ You can disable `kubeovn-operator` using the following commands:
 ----
 kubectl delete configuration kubeovn -n kube-system --wait=false
 
-kubectl delete validatingwebhookconfiguration kube-ovn-webhook
+kubectl delete validatingwebhookconfiguration kube-ovn-webhook --ignore-not-found
 
 kubectl delete ips --all
 
-kubectl delete subnets join ovn-default
+kubectl delete subnets join ovn-default --ignore-not-found
 
-kubectl delete vpc ovn-cluster
+kubectl delete vpc ovn-cluster --ignore-not-found
 
 # Remove annotations/labels in namespaces and nodes
 kubectl annotate node --all ovn.kubernetes.io/cidr-

--- a/versions/v1.6/modules/en/pages/networking/kubeovn-vpc.adoc
+++ b/versions/v1.6/modules/en/pages/networking/kubeovn-vpc.adoc
@@ -1,4 +1,6 @@
 = Virtual Private Cloud
+:revdate: 2025-09-15
+:page-revdate: {revdate}
 
 A virtual private cloud (VPC) is a logically isolated network that provides full control over IP addresses, subnets, route tables, firewalls, and gateways within a cloud infrastructure. VPCs allow the secure and scalable deployment of virtualized resources such as compute, storage, and container services.
 

--- a/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
+++ b/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
@@ -192,9 +192,9 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
-  - Egress
+    policyTypes:
+    - Ingress
+    - Egress
 ----
 
 * Example 2: `VM1` and `VM2` are allowed to communicate with each other and with other virtual machines in the subnet `172.20.10.0/24`. However, other virtual machines in that subnet cannot communicate with `VM1`, `VM2`, and each other. This is because the ingress policy only allows traffic originating from `172.20.10.0/30`.

--- a/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
+++ b/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
@@ -211,8 +211,8 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
+    policyTypes:
+    - Ingress
 ----
 
 * Example 3: `VM1` and `VM2` are allowed to communicate with each other, but not with other virtual machines in the subnet `172.20.10.0/24`. The other virtual machines in the same subnet can communicate with `VM1` and `VM2`. This is because the egress policy allows traffic to be sent to `172.20.10.0/30`.
@@ -229,8 +229,8 @@ The following virtual machines are created in the `default` namespace and are at
     - to:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - egress
+    policyTypes:
+    - egress
 ----
 
 * Example 4: `VM2` is allowed to communicate with `VM1`, but not with other virtual machines in the subnet `172.20.10.0/24`. This is because a pod selector label is applied to `VM2`. All other virtual machines in the same subnet can communicate with `VM1` and each other.
@@ -254,7 +254,7 @@ The following virtual machines are created in the `default` namespace and are at
     - from:
       - ipBlock:
           cidr: 172.20.10.0/30
-  policyTypes:
-  - Ingress
-  - Egress
+    policyTypes:
+    - Ingress
+    - Egress
 ----

--- a/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
+++ b/versions/v1.6/modules/en/pages/networking/vm-isolation.adoc
@@ -1,4 +1,6 @@
 = Virtual Machine Isolation
+:revdate: 2025-09-15
+:page-revdate: {revdate}
 
 Isolation between virtual machines is typically achieved using either VLANs (in traditional networks) or virtual switches (in Kube-OVN). If you want to isolate virtual machines within the same virtual switch network, you can use either of the following to achieve the required micro-segmentation:
 

--- a/versions/v1.6/modules/en/pages/networking/vm-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/vm-network.adoc
@@ -1,5 +1,5 @@
 = VM Network
-:revdate: 2025-06-10
+:revdate: 2025-09-15
 :page-revdate: {revdate}
 
 {harvester-product-name} provides three types of networks for virtual machines (VMs), including:

--- a/versions/v1.6/modules/en/pages/virtual-machines/live-migration.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/live-migration.adoc
@@ -65,7 +65,7 @@ Live migration will also be aborted when copying memory doesn't make any progres
 
 == Limitations
 
-### CPU models
+=== CPU models
 
 `host-model` only allows migration of the virtual machine to a node with same CPU model. However, specifying a CPU model is not always required. When no CPU model is specified, you must shut down the virtual machine, assign a CPU model that is supported by all nodes, and then restart the virtual machine.
 


### PR DESCRIPTION
Scope: v1.6

Changes:
- Fixed [markup issue](https://github.com/rancher/harvester-product-docs/pull/101#discussion_r2353896595) in `live-migration.adoc`
- Added revdate attributes to `kubeovn-operator.adoc`, `kubeovn-vpc.adoc`, and `vm-isolation.adoc` 
- Added flag to commands in `kubeovn-operator.adoc` (PR [853](https://github.com/harvester/docs/pull/853))
- Fixed format of network policy YAML in `vm-isolation.adoc` (PR [862](https://github.com/harvester/docs/pull/862))