### PR TITLE
Add content for updates to the VM Import Controller add-on (792, 793, 850)

### DIFF
--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -135,6 +135,8 @@ spec:
     destinationNetwork: "default/vlan1"
   - sourceNetwork: "dvSwitch 2"
     destinationNetwork: "default/vlan2"
+    networkInterfaceModel: "e1000"
+  defaultNetworkInterfaceModel: "virtio"
   skipPreflightChecks: false
   storageClass: "my-storage-class"
   defaultDiskBusType: "scsi"
@@ -154,6 +156,15 @@ The duration of the import process depends on the size of the virtual machine. W
 If the source virtual machine is placed in a folder, you can specify the folder name in the optional `folder` field.
 
 The list of items in `networkMapping` will define how the source network interfaces are mapped to the {harvester-product-name} Networks.
+
+If necessary, you can specify the model of each source network interface individually using the `networkInterfaceModel` field. The valid values are `e1000`, `e1000e`, `ne2k_pci`, `pcnet`, `rtl8139` and `virtio`.
+
+Specifying the default interface model using the `defaultNetworkInterfaceModel` field is particularly useful in the following situations:
+
+* You want to override the default model used when the automatic detection does not work for VMware imports or the default model used for all network interfaces for OpenStack imports.
+* No network mapping is provided and the `pod-network` network interface is automatically created.
+
+If you do not specify a value, `virtio` is used by default.
 
 If a match is not found, each unmatched network interface is attached to the default `managementNetwork`.
 

--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -170,6 +170,20 @@ If a match is not found, each unmatched network interface is attached to the def
 
 The `storageClass` field specifies the xref:storage/storageclass.adoc[StorageClass] to be used for images and provisioning of persistent volumes during the import process. If no value is specified, {harvester-product-name} uses the default StorageClass.
 
+By default, the vm-import-controller attempts to gracefully shut down the guest operating system of the source virtual machine before starting the import process. If the virtual machine is not gracefully shut down within a specific period, a hard power off is forced. You can adjust this time period for the graceful shutdown by changing the value of the `gracefulShutdownTimeoutSeconds` field, which is set to `60` seconds by default. A hard power off without attempting a graceful shutdown can be forced by setting the `forcePowerOff` field to `true`.
+
+If you are importing a VMware-based virtual machine, the vm-import-controller's behavior depends on whether https://knowledge.broadcom.com/external/article/315382/overview-of-vmware-tools.html[VMware Tools] is installed on the virtual machine.
+
+|===
+| VMware Tools Status | vm-import-controller Behavior
+
+| Installed
+| Attempts the described graceful shutdown before starting the import process.
+
+| Not installed
+| Displays logs similar to `handler virtualmachine-import-job-change: failed to shutdown the guest OS of the source VM: ServerFaultCode: Cannot complete operation because VMware Tools is not running in this virtual machine., requeuing`
+|===
+
 The `defaultDiskBusType` field allows you to specify the bus type for imported disks. {harvester-product-name} uses this field in the following ways:
 
 * VMware sources: The value is used only if {harvester-product-name} is unable to automatically detect the bus type.
@@ -215,6 +229,22 @@ spec:
 OpenStack allows users to have multiple instances with the same name. In such a scenario, users are advised to use the Instance ID. The reconciliation logic tries to perform a name-to-ID lookup when a name is used.
 ====
 
-==== Known Issues
+==== Known issues
 
-* *Source virtual machine name is not RFC1123-compliant*: When creating a virtual machine object, the vm-import-controller add-on uses the name of the source virtual machine, which may not meet the Kubernetes object https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names[naming criteria]. You may need to rename the source virtual machine to allow successful completion of the import.
+===== Source virtual machine name is not RFC1123-compliant
+
+When creating a virtual machine object, the vm-import-controller add-on uses the name of the source virtual machine, which may not meet the Kubernetes object https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#dns-subdomain-names[naming criteria]. You may need to rename the source virtual machine to allow successful completion of the import.
+
+===== VMware-based virtual machine without VMware Tools is not migrated
+
+When you attempt to import a VMware-based virtual machine in Harvester v1.6.0, the following occur if https://knowledge.broadcom.com/external/article/315382/overview-of-vmware-tools.html[VMware Tools] is not installed on the virtual machine:
+
+* The vm-import-controller does not gracefully shut down the guest operating system.
+* When the graceful shutdown period (`gracefulShutdownTimeoutSeconds`) lapses, the vm-import-controller does not force a hard poweroff.
+* The virtual machine is not migrated from VMware.
+
+To address the issue, perform one of the following workarounds:
+
+* Shut down the virtual machine before migrating it to Harvester 
+* In the `VirtualMachineImport` CRD spec, set the `forcePowerOff` field to `true`.  
+* Install VMware Tools or https://knowledge.broadcom.com/external/article?legacyId=2073803[open-vm-tools].

--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -1,5 +1,5 @@
 = VM Import Controller
-:revdate: 2025-07-17
+:revdate: 2025-09-19
 :page-revdate: {revdate}
 
 You can import virtual machines from VMware and OpenStack into {harvester-product-name} using the vm-import-controller add-on. The add-on must be enabled before you start importing virtual machines.
@@ -137,6 +137,7 @@ spec:
     destinationNetwork: "default/vlan2"
   skipPreflightChecks: false
   storageClass: "my-storage-class"
+  defaultDiskBusType: "scsi"
   sourceCluster:
     name: vcsim
     namespace: default
@@ -156,7 +157,14 @@ The list of items in `networkMapping` will define how the source network interfa
 
 If a match is not found, each unmatched network interface is attached to the default `managementNetwork`.
 
-The `storageClass` field specifies the xref:../storage/storageclass.adoc[StorageClass] to be used for images and provisioning of persistent volumes during the import process. If no value is specified, {harvester-product-name} uses the default StorageClass.
+The `storageClass` field specifies the xref:storage/storageclass.adoc[StorageClass] to be used for images and provisioning of persistent volumes during the import process. If no value is specified, {harvester-product-name} uses the default StorageClass.
+
+The `defaultDiskBusType` field allows you to specify the bus type for imported disks. {harvester-product-name} uses this field in the following ways:
+
+* VMware sources: The value is used only if {harvester-product-name} is unable to automatically detect the bus type.
+* OpenStack sources: The value is used for all imported disks.
+
+The valid values are `sata`, `scsi`, `usb`, and `virtio`. If you do not specify a value, `virtio` is used by default.
 
 Once the virtual machine has been imported successfully, the object will reflect the status:
 

--- a/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
+++ b/versions/v1.6/modules/en/pages/add-ons/vm-import-controller.adoc
@@ -170,6 +170,13 @@ If a match is not found, each unmatched network interface is attached to the def
 
 The `storageClass` field specifies the xref:storage/storageclass.adoc[StorageClass] to be used for images and provisioning of persistent volumes during the import process. If no value is specified, {harvester-product-name} uses the default StorageClass.
 
+The `defaultDiskBusType` field allows you to specify the bus type for imported disks. {harvester-product-name} uses this field in the following ways:
+
+* VMware sources: The value is used only if {harvester-product-name} is unable to automatically detect the bus type.
+* OpenStack sources: The value is used for all imported disks.
+
+The valid values are `sata`, `scsi`, `usb`, and `virtio`. If you do not specify a value, `virtio` is used by default.
+
 By default, the vm-import-controller attempts to gracefully shut down the guest operating system of the source virtual machine before starting the import process. If the virtual machine is not gracefully shut down within a specific period, a hard power off is forced. You can adjust this time period for the graceful shutdown by changing the value of the `gracefulShutdownTimeoutSeconds` field, which is set to `60` seconds by default. A hard power off without attempting a graceful shutdown can be forced by setting the `forcePowerOff` field to `true`.
 
 If you are importing a VMware-based virtual machine, the vm-import-controller's behavior depends on whether https://knowledge.broadcom.com/external/article/315382/overview-of-vmware-tools.html[VMware Tools] is installed on the virtual machine.
@@ -184,12 +191,10 @@ If you are importing a VMware-based virtual machine, the vm-import-controller's 
 | Displays logs similar to `handler virtualmachine-import-job-change: failed to shutdown the guest OS of the source VM: ServerFaultCode: Cannot complete operation because VMware Tools is not running in this virtual machine., requeuing`
 |===
 
-The `defaultDiskBusType` field allows you to specify the bus type for imported disks. {harvester-product-name} uses this field in the following ways:
-
-* VMware sources: The value is used only if {harvester-product-name} is unable to automatically detect the bus type.
-* OpenStack sources: The value is used for all imported disks.
-
-The valid values are `sata`, `scsi`, `usb`, and `virtio`. If you do not specify a value, `virtio` is used by default.
+[NOTE]
+====
+The vm-import-controller only supports the `forcePowerOff` and `gracefulShutdownTimeoutSeconds` fields for VMware because OpenStack automatically performs a combination of graceful shutdown and hard power off.
+====
 
 Once the virtual machine has been imported successfully, the object will reflect the status:
 


### PR DESCRIPTION
Scope: v1.6

PRs:
- [792](https://github.com/harvester/docs/pull/792): `defaultDiskBusType` field
- [793](https://github.com/harvester/docs/pull/793): `networkInterfaceModel` and `defaultNetworkInterfaceModel` fields
- [850](https://github.com/harvester/docs/pull/850): VMware Tools and a related known issue