### PR TITLE
Update SLES version (YES-certified hardware) and validated guest operating systems

### DIFF
--- a/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
@@ -1,5 +1,5 @@
 = Hardware and Network Requirements
-:revdate: 2025-06-10
+:revdate: 2025-09-25
 :page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
@@ -47,7 +47,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 [IMPORTANT]
 ====
 * Mixed-architecture clusters are not supported. Deploy separate clusters to avoid unexpected system behavior.
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP5. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].

--- a/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
@@ -1,5 +1,5 @@
 = Hardware and Network Requirements
-:revdate: 2025-09-18
+:revdate: 2025-09-25
 :page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
@@ -47,7 +47,7 @@ The latest versions support the deployment of xref:./single-node-clusters.adoc[s
 [IMPORTANT]
 ====
 * Mixed-architecture clusters are not supported. Deploy separate clusters to avoid unexpected system behavior.
-* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP3 or SP4. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
+* For best results, use https://www.suse.com/partners/ihv/yes/[YES-certified hardware] for SUSE Linux Enterprise Server (SLES) 15 SP5. {harvester-product-name} is built on SLE technology and YES-certified hardware has additional validation of driver and system board compatibility. Laptops and nested virtualization are not supported.
 * Nested virtualization is not supported on virtual machines running on {harvester-product-name}.
 * Each node must have a unique `product_uuid` (fetched from `/sys/class/dmi/id/product_uuid`) to prevent errors from occurring during VM live migration and other operations. For more information, see https://github.com/harvester/harvester/issues/4025[Issue #4025].
 * {harvester-product-name} has a xref:../networking/cluster-network.adoc#_built_in_cluster_network[built-in management cluster network] (`mgmt`). To achieve high availability and the best performance in production environments, use at least two NICs in each node to set up a bonded NIC for the management network (see step 6 in xref:../installation-setup/methods/iso-install.adoc#_installation_steps[ISO Installation]). You can also create xref:../networking/cluster-network.adoc#_custom_cluster_network[custom cluster networks] for VM workloads. Each custom cluster network requires at least two additional NICs to set up a bonded NIC in every involved node of the cluster. The xref:../hosts/witness-node.adoc[witness node] does not require additional NICs. For more information, see xref:../networking/cluster-network.adoc#_concepts[Cluster Network].

--- a/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -1,5 +1,5 @@
 = Virtual Machines
-:revdate: 2025-05-09
+:revdate: 2025-09-25
 :page-revdate: {revdate}
 
 You can create xref:../virtual-machines/create-vm.adoc[Linux virtual machines] using one of the following methods: 

--- a/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
+++ b/versions/v1.6/modules/en/pages/virtual-machines/virtual-machines.adoc
@@ -14,12 +14,10 @@ Creating xref:../virtual-machines/create-windows-vm.adoc[Windows virtual machine
 
 The following operating systems have been validated to run in {harvester-product-name} virtual machines:
 
-* SUSE Linux Enterprise Micro 6
-* SUSE Linux Enterprise Server 15 SP6
-* Red Hat Enterprise Linux 9.5
-* Ubuntu 24.04
-* Windows 11
-* Windows Server 2025
+* SUSE Linux Enterprise Micro 6.0 and 6.1
+* SUSE Linux Enterprise Server 15 SP6 and 15 SP7
+* Red Hat Enterprise Linux 9 and 10
+* Ubuntu 22.04 and 24.04
 
 [NOTE]
 ====


### PR DESCRIPTION
Scope: v1.5, v1.6

Information sources:
- PR [866](https://github.com/harvester/docs/pull/866): Guest operating systems
- Thread in #discuss-suse-virtualization

Changes:
- Updated list of guest operating systems validated for v1.6.0
- Updated note about using YES-certified hardware for SLES