### PR TITLE
Update revdate so SU notices.

### DIFF
--- a/versions/v1.3/modules/en/pages/api.adoc
+++ b/versions/v1.3/modules/en/pages/api.adoc
@@ -1,4 +1,4 @@
-:revdate: 2024-09-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = Harvester APIs

--- a/versions/v1.4/modules/en/pages/api.adoc
+++ b/versions/v1.4/modules/en/pages/api.adoc
@@ -1,4 +1,4 @@
-:revdate: 2024-09-25
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = Harvester APIs

--- a/versions/v1.5/modules/en/pages/api.adoc
+++ b/versions/v1.5/modules/en/pages/api.adoc
@@ -1,4 +1,4 @@
-:revdate: 2025-07-09
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = Harvester APIs

--- a/versions/v1.6/modules/en/pages/api.adoc
+++ b/versions/v1.6/modules/en/pages/api.adoc
@@ -1,4 +1,4 @@
-:revdate: 2025-07-14
+:revdate: 2025-10-27
 :page-revdate: {revdate}
 
 = Harvester APIs


### PR DESCRIPTION
Update the revdate for those files that had heading levels changed to avoid untitled HTML docs occasionally occurring. Need a revdate bump as well, so that SU notices. Probably.