### PR TITLE
Address storage-related content issues

### DIFF
--- a/versions/v1.6/modules/en/nav.adoc
+++ b/versions/v1.6/modules/en/nav.adoc
@@ -82,6 +82,7 @@
 // Folder: storage:
 
 * Storage
+** xref:storage/storage.adoc[]
 ** Volumes
 *** xref:storage/volumes/create-volume.adoc[]
 *** xref:storage/volumes/edit-volume.adoc[]

--- a/versions/v1.6/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.6/modules/en/pages/storage/csidriver.adoc
@@ -1,5 +1,5 @@
 = Third-Party Storage Support
-:revdate: 2026-05-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 
 {harvester-product-name} supports provisioning of root volumes and data volumes using external https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] drivers. This enhancement allows you to select drivers that meet specific requirements, such as performance optimization or seamless integration with existing internal storage solutions.
@@ -61,7 +61,7 @@ These validated CSI drivers have the following capabilities:
 ====
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability. 
 
-You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the {rancher-product-name} documentation, which is accessible through the https://scc.suse.com/home[SUSE Customer Center].
+You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].
 ====
 
 == Prerequisites
@@ -238,12 +238,6 @@ mountOptions:
 ----
 +
 Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-== References
-
-* https://harvesterhci.io/kb/use_rook_ceph_external_storage[Use Rook Ceph External Storage with Harvester]
-* https://harvesterhci.io/kb/install_netapp_trident_csi[Using NetApp Storage on Harvester]
-* https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md[Third Party Storage Support]
 
 == Known issues
 

--- a/versions/v1.6/modules/en/pages/storage/storage.adoc
+++ b/versions/v1.6/modules/en/pages/storage/storage.adoc
@@ -1,0 +1,19 @@
+= Storage
+:revdate: 2026-05-12
+:page-revdate: {revdate}
+
+{harvester-product-name} supports distributed block storage and tiering.
+
+== Built-in storage
+
+https://www.suse.com/products/rancher/storage/[{longhorn-product-name}], the built-in storage system, provides block device volumes to virtual machines and other pods in a {harvester-product-name} cluster. {longhorn-product-name} creates a dedicated storage controller for each volume and synchronously replicates the volume across nodes.
+
+You can create volumes using virtual machine images or StorageClasses. When using a xref:storage/volumes/create-volume.adoc#_create_an_image_volume[virtual machine image] (qcow2, raw, or ISO file) as your source, you must ensure that the volume size is greater than or equal to the image size. When using a xref:storage/storageclass.adoc[StorageClass] to describe how {longhorn-product-name} must provision volumes, you must ensure that the replica count matches the cluster's configuration.
+
+For optimal results, use a dedicated disk (instead of the root disk) for {longhorn-product-name} volumes and a dedicated xref:networking/storage-network.adoc[storage network] to improve I/O performance and stability.
+
+== Third-party storage
+
+{harvester-product-name} supports provisioning of root volumes and data volumes using xref:storage/csidriver.adoc[external Container Storage Interface (CSI) drivers]. Once the CSI driver is installed and the {harvester-product-name} cluster is configured, you can use an external storage solution to store and manage virtual machine images, store virtual machine disks on volumes provisioned by the CSI driver, and perform other critical storage functions.
+
+Storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability through the https://www.suse.com/product-certification/suse-certified/virtualization-certification/[SUSE Certified Storage for Virtualization] certification. You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].

--- a/versions/v1.7/modules/en/nav.adoc
+++ b/versions/v1.7/modules/en/nav.adoc
@@ -85,6 +85,7 @@
 // Folder: storage:
 
 * Storage
+** xref:storage/storage.adoc[]
 ** Volumes
 *** xref:storage/volumes/create-volume.adoc[]
 *** xref:storage/volumes/edit-volume.adoc[]

--- a/versions/v1.7/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.7/modules/en/pages/storage/csidriver.adoc
@@ -1,5 +1,5 @@
 = Third-Party Storage Support
-:revdate: 2026-05-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 
 {harvester-product-name} supports provisioning of root volumes and data volumes using external https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] drivers. This enhancement allows you to select drivers that meet specific requirements, such as performance optimization or seamless integration with existing internal storage solutions.
@@ -61,7 +61,7 @@ These validated CSI drivers have the following capabilities:
 ====
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability. 
 
-You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the {rancher-product-name} documentation, which is accessible through the https://scc.suse.com/home[SUSE Customer Center].
+You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].
 ====
 
 == Prerequisites
@@ -243,12 +243,6 @@ mountOptions:
 ----
 +
 Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-== References
-
-* https://harvesterhci.io/kb/use_rook_ceph_external_storage[Use Rook Ceph External Storage with Harvester]
-* https://harvesterhci.io/kb/install_netapp_trident_csi[Using NetApp Storage on Harvester]
-* https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md[Third Party Storage Support]
 
 == Known issues
 

--- a/versions/v1.7/modules/en/pages/storage/storage.adoc
+++ b/versions/v1.7/modules/en/pages/storage/storage.adoc
@@ -1,0 +1,19 @@
+= Storage
+:revdate: 2026-05-12
+:page-revdate: {revdate}
+
+{harvester-product-name} supports distributed block storage and tiering.
+
+== Built-in storage
+
+https://www.suse.com/products/rancher/storage/[{longhorn-product-name}], the built-in storage system, provides block device volumes to virtual machines and other pods in a {harvester-product-name} cluster. {longhorn-product-name} creates a dedicated storage controller for each volume and synchronously replicates the volume across nodes.
+
+You can create volumes using virtual machine images or StorageClasses. When using a xref:storage/volumes/create-volume.adoc#_create_an_image_volume[virtual machine image] (qcow2, raw, or ISO file) as your source, you must ensure that the volume size is greater than or equal to the image size. When using a xref:storage/storageclass.adoc[StorageClass] to describe how {longhorn-product-name} must provision volumes, you must ensure that the replica count matches the cluster's configuration.
+
+For optimal results, use a dedicated disk (instead of the root disk) for {longhorn-product-name} volumes and a dedicated xref:networking/storage-network.adoc[storage network] to improve I/O performance and stability.
+
+== Third-party storage
+
+{harvester-product-name} supports provisioning of root volumes and data volumes using xref:storage/csidriver.adoc[external Container Storage Interface (CSI) drivers]. Once the CSI driver is installed and the {harvester-product-name} cluster is configured, you can use an external storage solution to store and manage virtual machine images, store virtual machine disks on volumes provisioned by the CSI driver, and perform other critical storage functions.
+
+Storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability through the https://www.suse.com/product-certification/suse-certified/virtualization-certification/[SUSE Certified Storage for Virtualization] certification. You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].

--- a/versions/v1.8/modules/en/nav.adoc
+++ b/versions/v1.8/modules/en/nav.adoc
@@ -85,6 +85,7 @@
 // Folder: storage:
 
 * Storage
+** xref:storage/storage.adoc[]
 ** Volumes
 *** xref:storage/volumes/create-volume.adoc[]
 *** xref:storage/volumes/edit-volume.adoc[]

--- a/versions/v1.8/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.8/modules/en/pages/storage/csidriver.adoc
@@ -1,5 +1,5 @@
 = Third-Party Storage Support
-:revdate: 2026-05-05
+:revdate: 2026-05-12
 :page-revdate: {revdate}
 
 {harvester-product-name} supports provisioning of root volumes and data volumes using external https://kubernetes-csi.github.io/docs/introduction.html[Container Storage Interface (CSI)] drivers. This enhancement allows you to select drivers that meet specific requirements, such as performance optimization or seamless integration with existing internal storage solutions.
@@ -61,7 +61,7 @@ These validated CSI drivers have the following capabilities:
 ====
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability. 
 
-You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the {rancher-product-name} documentation, which is accessible through the https://scc.suse.com/home[SUSE Customer Center].
+You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].
 ====
 
 == Prerequisites
@@ -243,12 +243,6 @@ mountOptions:
 ----
 +
 Once created, you can use the StorageClass to create virtual machine images, root volumes, and data volumes.
-
-== References
-
-* https://harvesterhci.io/kb/use_rook_ceph_external_storage[Use Rook Ceph External Storage with Harvester]
-* https://harvesterhci.io/kb/install_netapp_trident_csi[Using NetApp Storage on Harvester]
-* https://github.com/harvester/harvester/blob/master/enhancements/20250203-third-party-storage-support.md[Third Party Storage Support]
 
 == Known issues
 

--- a/versions/v1.8/modules/en/pages/storage/storage.adoc
+++ b/versions/v1.8/modules/en/pages/storage/storage.adoc
@@ -1,0 +1,19 @@
+= Storage
+:revdate: 2026-05-12
+:page-revdate: {revdate}
+
+{harvester-product-name} supports distributed block storage and tiering.
+
+== Built-in storage
+
+https://www.suse.com/products/rancher/storage/[{longhorn-product-name}], the built-in storage system, provides block device volumes to virtual machines and other pods in a {harvester-product-name} cluster. {longhorn-product-name} creates a dedicated storage controller for each volume and synchronously replicates the volume across nodes.
+
+You can create volumes using virtual machine images or StorageClasses. When using a xref:storage/volumes/create-volume.adoc#_create_an_image_volume[virtual machine image] (qcow2, raw, or ISO file) as your source, you must ensure that the volume size is greater than or equal to the image size. When using a xref:storage/storageclass.adoc[StorageClass] to describe how {longhorn-product-name} must provision volumes, you must ensure that the replica count matches the cluster's configuration.
+
+For optimal results, use a dedicated disk (instead of the root disk) for {longhorn-product-name} volumes and a dedicated xref:networking/storage-network.adoc[storage network] to improve I/O performance and stability.
+
+== Third-party storage
+
+{harvester-product-name} supports provisioning of root volumes and data volumes using xref:storage/csidriver.adoc[external Container Storage Interface (CSI) drivers]. Once the CSI driver is installed and the {harvester-product-name} cluster is configured, you can use an external storage solution to store and manage virtual machine images, store virtual machine disks on volumes provisioned by the CSI driver, and perform other critical storage functions.
+
+Storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability through the https://www.suse.com/product-certification/suse-certified/virtualization-certification/[SUSE Certified Storage for Virtualization] certification. You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].


### PR DESCRIPTION
Related issue: #179 + [SURE-11220](https://jira.suse.com/browse/SURE-11220) + issues in documentation feedback file

Scope: v1.6, v1.7, v1.8

Changes:
- `csidriver.adoc`: Updated note about enterprise-grade storage solutions (added link to Partner Certification & Solutions Catalog) 
- `csidriver.adoc`: Removed *References* section containing links to outdated community KB articles (in harvesterhci.io) and Harvester enhancement proposal for third-party storage (in GitHub repo)
- `storage.adoc`: Added this file, which provides an overview of storage in SUSE Virtualization