### PR TITLE
Updated files with broken links

### DIFF
--- a/versions/v1.5/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.5/modules/en/pages/developer/addon-development.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-06-17
 :page-revdate: {revdate}
 
-{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
+{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/add-ons/helm.html#_using_the_helm_crd[Using the Helm CRD].
 
 == Prerequisites
 

--- a/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/requirements.adoc
@@ -28,8 +28,8 @@ The latest versions support the deployment of xref:installation-setup/single-nod
 | 500 GB minimum; 1 TB or more recommended
 
 | Disk performance
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
 
 | Network card count
 | Management cluster network: 1 NIC required, 2 NICs recommended; VM workload network: 1 NIC required, at least 2 NICs recommended (does not apply to the xref:hosts/witness-node.adoc[witness node])

--- a/versions/v1.5/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.5/modules/en/pages/introduction/overview.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-07-16
 :page-revdate: {revdate}
 
-{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
@@ -11,7 +11,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
@@ -20,7 +20,7 @@ image::architecture.svg[]
 
 {harvester-product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the xref:installation-setup/methods/iso-install.adoc[ISO image] or automatically install it using xref:installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/versions/v1.6/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.6/modules/en/pages/developer/addon-development.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-06-17
 :page-revdate: {revdate}
 
-{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
+{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/add-ons/helm.html#_using_the_helm_crd[Using the Helm CRD].
 
 == Prerequisites
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -565,7 +565,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -586,7 +586,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
@@ -68,7 +68,7 @@ If your certificates have expired, you can xref:hosts/hosts.adoc#_rotating_expir
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.9/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/requirements.adoc
@@ -28,8 +28,8 @@ The latest versions support the deployment of xref:installation-setup/single-nod
 | 500 GB minimum; 1 TB or more recommended
 
 | Disk performance
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
 
 | Network card count
 | Management cluster network: 1 NIC required, 2 NICs recommended; VM workload network: 1 NIC required, at least 2 NICs recommended (does not apply to the xref:hosts/witness-node.adoc[witness node])

--- a/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -35,8 +35,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.6/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.6/modules/en/pages/introduction/overview.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-07-16
 :page-revdate: {revdate}
 
-{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
@@ -11,7 +11,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
@@ -20,7 +20,7 @@ image::architecture.svg[]
 
 {harvester-product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the xref:installation-setup/methods/iso-install.adoc[ISO image] or automatically install it using xref:installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/versions/v1.6/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.6/modules/en/pages/networking/best-practices.adoc
@@ -249,14 +249,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.9/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.6/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.6/modules/en/pages/networking/storage-network.adoc
@@ -4,7 +4,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.6/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -60,7 +60,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.6/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.6/modules/en/pages/storage/storageclass.adoc
@@ -136,7 +136,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Containerized Data Importer (CDI) settings
 

--- a/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.6/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -6,7 +6,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.9/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/monitoring.adoc
@@ -70,7 +70,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.9/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/troubleshooting.adoc
@@ -264,7 +264,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.7/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.7/modules/en/pages/developer/addon-development.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-06-17
 :page-revdate: {revdate}
 
-{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
+{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/add-ons/helm.html#_using_the_helm_crd[Using the Helm CRD].
 
 == Prerequisites
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -640,7 +640,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -681,7 +681,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/settings.adoc
@@ -68,7 +68,7 @@ If your certificates have expired, you can xref:hosts/hosts.adoc#_rotating_expir
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.10/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.7/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/requirements.adoc
@@ -28,8 +28,8 @@ The latest versions support the deployment of xref:installation-setup/single-nod
 | 500 GB minimum; 1 TB or more recommended
 
 | Disk performance
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
 
 | Network card count
 | Management cluster network: 1 NIC required, 2 NICs recommended; VM workload network: 1 NIC required, at least 2 NICs recommended (does not apply to the xref:hosts/witness-node.adoc[witness node])

--- a/versions/v1.7/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -35,8 +35,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.7/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/en/pages/introduction/overview.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-07-16
 :page-revdate: {revdate}
 
-{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
@@ -11,7 +11,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
@@ -20,7 +20,7 @@ image::architecture.svg[]
 
 {harvester-product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the xref:installation-setup/methods/iso-install.adoc[ISO image] or automatically install it using xref:installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/versions/v1.7/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.7/modules/en/pages/networking/best-practices.adoc
@@ -246,14 +246,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.10/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.7/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.7/modules/en/pages/networking/storage-network.adoc
@@ -4,7 +4,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.7/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.7/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -54,7 +54,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.7/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.7/modules/en/pages/storage/storageclass.adoc
@@ -136,7 +136,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.10/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Containerized Data Importer (CDI) settings
 

--- a/versions/v1.7/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.7/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -6,7 +6,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.10/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.7/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.7/modules/en/pages/troubleshooting/monitoring.adoc
@@ -70,7 +70,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.10/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.7/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/troubleshooting.adoc
@@ -264,7 +264,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.10/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.8/modules/en/pages/developer/addon-development.adoc
+++ b/versions/v1.8/modules/en/pages/developer/addon-development.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-06-17
 :page-revdate: {revdate}
 
-{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/helm.html#_using_the_helm_crd[{rke2-product-name} HelmChart resource definition (CRD)].
+{harvester-product-name} add-ons allow you to enable and disable specific product and third-party components based on your requirements. Add-ons function as a wrapper for the https://documentation.suse.com/cloudnative/rke2/latest/en/add-ons/helm.html#_using_the_helm_crd[Using the Helm CRD].
 
 == Prerequisites
 

--- a/versions/v1.8/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -633,7 +633,7 @@ When installing via PXE, use `/dev/disk/by-id/$id` or `/dev/disk/by-path/$path` 
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -674,7 +674,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.8/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/settings.adoc
@@ -75,7 +75,7 @@ If your certificates have expired, you can xref:hosts/hosts.adoc#_rotating_expir
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.11/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.8/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/requirements.adoc
@@ -28,8 +28,8 @@ The latest versions support the deployment of xref:installation-setup/single-nod
 | 500 GB minimum; 1 TB or more recommended
 
 | Disk performance
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
-| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet https://support.scc.suse.com/s/kb/360045276411[etcd] speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
+| 5,000+ random IOPS per disk (SSD/NVMe); management node storage must meet etcd speed requirements. Only local disks and hardware RAID are supported.
 
 | Network card count
 | Management cluster network: 1 NIC required, 2 NICs recommended; VM workload network: 1 NIC required, at least 2 NICs recommended (does not apply to the xref:hosts/witness-node.adoc[witness node])

--- a/versions/v1.8/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -35,8 +35,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.8/modules/en/pages/introduction/overview.adoc
+++ b/versions/v1.8/modules/en/pages/introduction/overview.adoc
@@ -2,7 +2,7 @@
 :revdate: 2025-07-16
 :page-revdate: {revdate}
 
-{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/integrations/harvester/harvester.html[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
+{harvester-product-name-tm} is a modern, open, interoperable, https://en.wikipedia.org/wiki/Hyper-converged_infrastructure[hyperconverged infrastructure (HCI)] solution built on Kubernetes. It is an open-source alternative designed for operators seeking a https://about.gitlab.com/topics/cloud-native/[cloud-native] HCI solution. {harvester-product-name} runs on bare metal servers and provides integrated virtualization and distributed storage capabilities. In addition to traditional virtual machines (VMs), {harvester-product-name} supports containerized environments automatically through integration with https://documentation.suse.com/cloudnative/rancher-manager/[{rancher-product-name-tm}]. It offers a solution that unifies legacy virtualized infrastructure while enabling the adoption of containers from core to edge locations.
 
 == Architecture
 
@@ -11,7 +11,7 @@ The architecture consists of cutting-edge open-source technologies:
 * *Linux OS.* https://documentation.suse.com/cloudnative/os-manager/[{elemental-product-name}] for SUSE Linux Enterprise Micro is at the core of {harvester-product-name} and is an immutable Linux distribution designed to remove as much OS maintenance as possible in a Kubernetes cluster.
 * *Built on top of Kubernetes.* https://kubernetes.io/[Kubernetes] has become the predominant infrastructure language across all form factors, and {harvester-product-name} is an HCI solution with Kubernetes under the hood.
 * *Virtualization management with KubeVirt.* https://kubevirt.io/[KubeVirt] provides virtualization management using KVM on top of Kubernetes.
-* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] provides distributed block storage and tiering.
+* *Storage management with {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/[{longhorn-product-name}] provides distributed block storage and tiering.
 * *Observability with Grafana and Prometheus.* https://grafana.com/[Grafana] and https://prometheus.io/[Prometheus] provide robust monitoring and logging.
 
 image::architecture.svg[]
@@ -20,7 +20,7 @@ image::architecture.svg[]
 
 {harvester-product-name} is an enterprise-ready, easy-to-use infrastructure platform that leverages local, direct attached storage instead of complex external SANs. It utilizes Kubernetes API as a unified automation language across container and VM workloads. Some key features include:
 
-* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the https://github.com/harvester/harvester/releases[ISO image] or automatically install it using xref:../installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
+* *Easy to get started.* Since {harvester-product-name} ships as a bootable appliance image, you can install it directly on a bare metal server with the xref:installation-setup/methods/iso-install.adoc[ISO image] or automatically install it using xref:installation-setup/methods/pxe-boot-install.adoc[iPXE] scripts.
 * *VM lifecycle management.* Easily create, edit, clone, and delete VMs, including SSH-Key injection, cloud-init, and graphic and serial port console.
 * *VM live migration.* Move a VM to a different host or node with zero downtime.
 * *VM backup, snapshot, and restore.* Back up your VMs from NFS, S3 servers, or NAS devices. Use your backup to restore a failed VM or create a new VM on a different cluster.

--- a/versions/v1.8/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.8/modules/en/pages/networking/best-practices.adoc
@@ -246,14 +246,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.11/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.8/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.8/modules/en/pages/networking/storage-network.adoc
@@ -4,7 +4,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.8/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.8/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -54,7 +54,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.8/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.8/modules/en/pages/storage/storageclass.adoc
@@ -136,7 +136,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.11/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Containerized Data Importer (CDI) settings
 

--- a/versions/v1.8/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.8/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -6,7 +6,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.11/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.8/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.8/modules/en/pages/troubleshooting/monitoring.adoc
@@ -70,7 +70,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.11/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.8/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/troubleshooting.adoc
@@ -264,7 +264,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.11/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume


### PR DESCRIPTION
Scope: v1.5, v1.6, v1.7, v1.8

Changes:
- Replaced/removed broken links
- Updated version in SUSE Storage doc URLs
  | SUSE Virtualization version | SUSE Storage version |
  | --- | --- |
  | v1.5 | v1.8 |
  | v1.6 | v1.9 |
  | v1.7 | v1.10 |
  | v1.8 | v1.11 |