### PR TITLE
Fix broken links flagged by Siteimprove

### DIFF
--- a/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -741,7 +741,7 @@ install:
 
 *Definition*: VIP of the {harvester-product-name} management endpoint.
 
-After installation, you can access the UI at `https://<VIP>`.
+After installation, you can access the UI at `+https://<VIP>+`.
 
 === `install.vip_mode`
 

--- a/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
@@ -68,7 +68,7 @@ If your certificates have expired, you can xref:hosts/hosts.adoc#_rotating_expir
 
 *Definition*: Custom backup target used to store VM backups.
 
-For more information, see the https://documentation.suse.com/cloudnative/storage/1.8/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
+For more information, see the https://documentation.suse.com/cloudnative/storage/1.9/en/snapshots-backups/volume-snapshots-backups/configure-backup-target.html#_set_up_aws_s3_backupstore[{longhorn-product-name} documentation].
 
 *Default value*: None
 

--- a/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/single-node-clusters.adoc
@@ -35,8 +35,8 @@ In high-availability clusters, *Replica Hard Anti-Affinity* ensures volume redun
 
 If you want {longhorn-product-name} to create multiple replicas on a node with multiple disks, perform the following steps:
 
-. Enable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
-. Disable https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
+. Enable https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_node_level_soft_anti_affinity[`Replica Node Level Soft Anti-Affinity`]: When this setting is enabled, {longhorn-product-name} schedules new replicas on nodes with existing healthy replicas of the same volume.
+. Disable https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_disk_level_soft_anti_affinity[`Replica Disk Level Soft Anti-Affinity`]: When this setting is disabled, {longhorn-product-name} does not schedule new replicas on disks with existing healthy replicas of the same volume. Disabling this setting provides failure tolerance for disks in single-node clusters.
 . (Optional) xref:../storage/storageclass.adoc#_creating_a_storageclass[Create a new StorageClass] and specify the disk tags that must be matched during volume scheduling.
 
 == Upgrades and Maintenance

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -23,7 +23,7 @@ image::rancher/rke1-node-driver.png[rke1-cluster]
 * For port requirements of guest clusters deployed within {harvester-product-name}, please refer to the xref:../../../installation-setup/requirements.adoc#_port_requirements_for_k3s_or_rkerke2_clusters[port requirements for guest clusters].
 ====
 
-When you create a Kubernetes cluster hosted by the {harvester-product-name} infrastructure, https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates[node templates] are used to provision the cluster nodes. These templates use Docker Machine configuration options to define an operating system image and settings/parameters for the node.
+When you create a Kubernetes cluster hosted by the {harvester-product-name} infrastructure, https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-deployment/infra-providers/infra-providers.html#_node_templates[node templates] are used to provision the cluster nodes. These templates use Docker Machine configuration options to define an operating system image and settings/parameters for the node.
 
 Node templates can use `cloud credentials` to access the credentials information required to provision nodes in the infrastructure providers. The same `cloud credentials` can be used by multiple node templates. By using `cloud credentials`, you do not have to re-enter access keys for the same cloud provider. `Cloud credentials` are stored as Kubernetes secrets.
 

--- a/versions/v1.5/modules/en/pages/networking/best-practices.adoc
+++ b/versions/v1.5/modules/en/pages/networking/best-practices.adoc
@@ -249,14 +249,14 @@ The Longhorn Engine recognizes that it can no longer communicate with the replic
 
  ** Scenario 2: Some {longhorn-product-name} volumes have _fewer_ than three active replicas, or you manually attached volumes using the {harvester-product-name} UI or {longhorn-product-name} UI.
 +
-You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.8/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
+You must manually detach the replicas or move them to other nodes, and then https://documentation.suse.com/cloudnative/storage/1.9/en/troubleshooting-maintenance/maintenance.html#_updating_the_node_os_or_container_runtime[drain the node] using the command `kubectl drain --ignore-daemonsets <node name>`. The option `--ignore-daemonsets` is required because {longhorn-product-name} deploys daemonsets such as Longhorn Manager, Longhorn CSI plugin, and Longhorn Engine image.
 +
 Replicas running on the node are stopped and marked as `Failed`. Longhorn Engine processes running on the node are migrated with the pod to other nodes. Once the node is fully drained, no replicas and engine processes should remain running on the node.
 . Replenish replicas.
 +
 After a node is shut down, {longhorn-product-name} does not start rebuilding the replicas on other nodes until the `replica-replenishment-wait-interval` (default value: 600 seconds) is reached. If the node comes back online before the wait interval value is reached, {longhorn-product-name} reuses the replicas. Otherwise, {longhorn-product-name} rebuilds the replicas on another node.
 +
-During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
+During system maintenance, you can modify the https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_replica_replenishment_wait_interval[`replica-replenishment-wait-interval`] value using the xref:/troubleshooting/cluster.adoc#_access_embedded_rancher_and_longhorn_dashboards[embedded {longhorn-product-name} UI] to enable faster replica rebuilding.
 
 === Replace the Nics
 

--- a/versions/v1.5/modules/en/pages/networking/storage-network.adoc
+++ b/versions/v1.5/modules/en/pages/networking/storage-network.adoc
@@ -4,7 +4,7 @@
 
 {harvester-product-name} uses {longhorn-product-name} to provide block device volumes for virtual machines and pods. If you want to isolate {longhorn-product-name} replication traffic from `mgmt` (the built-in cluster network) or other cluster-wide workloads, you can use a dedicated storage network for better network bandwidth and performance.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/networking/storage-network.html[Storage Network] in the {longhorn-product-name} documentation.
 
 [NOTE]
 ====

--- a/versions/v1.5/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/observability/monitoring.adoc
@@ -277,11 +277,7 @@ We have already created a https://github.com/harvester/harvester/issues/2760[Git
 
 ==== From Alertmanager Dashboard
 
-You can visit the original dashboard of `Alertmanager` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts
-____
+You can view the Alertmanager dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The overall view of the `Alertmanager` dashboard is as follows.
 
@@ -293,10 +289,7 @@ image::monitoring/alert-view-detail.png[]
 
 ==== From Prometheus Dashboard
 
-You can visit the original dashboard of `Prometheus` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/
-____
+You can view the Prometheus dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The `Alerts` menu in the top navigation bar shows all defined rules in Prometheus. You can use the filters `Inactive`, `Pending`, and `Firing` to quickly find the information that you need.
 

--- a/versions/v1.5/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.5/modules/en/pages/storage/csidriver.adoc
@@ -61,7 +61,7 @@ These validated CSI drivers have the following capabilities:
 ====
 Support for third-party storage equates to support for provisioning of root volumes and data volumes using external container storage interface (CSI) drivers. This means that storage vendors can validate their storage appliances with {harvester-product-name} to ensure greater interoperability. 
 
-You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the {rancher-product-name} documentation, which is accessible through the https://scc.suse.com/home[SUSE Customer Center].
+You can find information about enterprise-grade storage solutions that are certified to be compatible with {harvester-product-name} in the https://www.suse.com/pcsc/home[Partner Certification and Solutions Catalog].
 ====
 
 == Prerequisites
@@ -106,8 +106,6 @@ image::third-party-storage/csi-driver-config-external.png[]
 [NOTE]
 ====
 Backup currently only works with the Longhorn v1 Data Engine. If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration.
-
-For more information, see https://documentation.suse.com/cloudnative/virtualization/v1.4/en/storage/csidriver.html#_virtual_machine_backup_compatibility[Virtual Machine Backup Compatibility].
 ====
 
 == Use the CSI driver

--- a/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.5/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -61,7 +61,7 @@ Set the `Provisioner` of each extra disk to `Longhorn V2 (CSI)`.
 +
 [NOTE]
 ====
-{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
+{harvester-product-name} sets the https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/v2-data-engine/features/node-disk-support.html[Longhorn Disk Driver] to `auto` so that NVMe disks use the SPDK NVMe bdev driver, which provides the best performance and also supports advanced operations such as trim (also known as discard).
 
 SSDs and other non-NVMe disks are managed using the SPDK AIO bdev driver, which requires a disk size that is an _even multiple of 4096 bytes_. Non-NVMe disks that do not meet this size requirement cannot be added. Additionally, the SPDK AIO bdev driver does not support the unmap operation. If you are using non-NVMe disks, avoid trimming the filesystem because this results in I/O errors and paused virtual machines.
 ====

--- a/versions/v1.5/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.5/modules/en/pages/storage/storageclass.adoc
@@ -131,7 +131,7 @@ image::storageclass/data-locality.png[]
 {longhorn-product-name} provides a third option called `strict-local`, which forces {longhorn-product-name} to keep only one replica on the same node as the pod that uses the volume. {harvester-product-name} does not support this option because it can affect certain operations such as xref:virtual-machines/live-migration.adoc[VM Live Migration].
 ====
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/high-availability/data-locality.html[Data Locality] in the {longhorn-product-name} documentation.
 
 == Appendix - Use Case
 

--- a/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
+++ b/versions/v1.5/modules/en/pages/storage/volumes/edit-volume.adoc
@@ -6,7 +6,7 @@ After creating a volume, you can edit your volume by clicking the `⋮` button a
 
 == Expand a Volume
 
-You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.8/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
+You can expand a volume by increasing the value of the `Size` parameter directly. To prevent the expansion from interference by unexpected data R/W, {harvester-product-name} supports `offline` expansion only. You must shut down the VM or detach the volume first if it is attached to a VM, and the detached volume will automatically attach to a random node with https://documentation.suse.com/cloudnative/storage/1.9/en/introduction/concepts.html#_2_volumes_and_primary_storage[maintenance mode] to expand automatically.
 
 image::volume/expand-volume.png[expand-volume]
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
@@ -133,11 +133,11 @@ The file is ready for downloading when the value of `progress` is "100" and the 
  ** xref:/installation-setup/management-address.adoc[VIP] or DNS name
  ** Resource name of the file
  ** Parameter `?retain=true`: If you do not include this parameter, resources related to the support bundle are automatically deleted after the file is successfully downloaded.
-
 +
 Example:
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true`
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true+`
+
 . Download the file using either a command-line tool (for example, curl and wget) or a web browser.
 +
 Example:

--- a/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/troubleshooting.adoc
@@ -264,7 +264,7 @@ $ kubectl -n harvester-system scale deployment hvst-upgrade-xxxxx-upgradelog-dow
 deployment.apps/hvst-upgrade-xxxxx-upgradelog-downloader scaled
 ----
 
-. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+. Expand the volume size using the {longhorn-product-name} UI. For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 +
 ----
 # Here's how to find out the actual name of the target volume

--- a/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
@@ -196,7 +196,7 @@ Make sure to check <<Upgrade paths>> section first about upgradable versions.
 
 . Save the ISO to a local HTTP server.
 +
-Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
+Assume the file is hosted at `+http://10.10.0.1/harvester.iso+`.
 
 === Prepare the Version
 
@@ -217,7 +217,7 @@ Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
     releaseDate: '20250425'
 ----
 +
-Assume the file is hosted at `http://10.10.0.1/version.yaml`. If you require customizations, see <<Customize the version>>.
+Assume the file is hosted at `+http://10.10.0.1/version.yaml+`. If you require customizations, see <<Customize the version>>.
 
 . Access one of the control plane nodes via SSH and log in using the root account.
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-0.adoc
@@ -215,7 +215,7 @@ Related issue: https://github.com/harvester/harvester/issues/8163[#8163]
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-4-2-to-v1-5-1.adoc
@@ -126,7 +126,7 @@ Related issue: https://github.com/harvester/harvester/issues/7955[#7955]
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.1** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -746,7 +746,7 @@ install:
 
 *Definition*: VIP of the {harvester-product-name} management endpoint.
 
-After installation, you can access the UI at `https://<VIP>`.
+After installation, you can access the UI at `+https://<VIP>+`.
 
 === `install.vip_mode`
 

--- a/versions/v1.6/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.6/modules/en/pages/observability/monitoring.adoc
@@ -314,11 +314,7 @@ We have already created a https://github.com/harvester/harvester/issues/2760[Git
 
 ==== From Alertmanager Dashboard
 
-You can visit the original dashboard of `Alertmanager` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts
-____
+You can view the Alertmanager dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The overall view of the `Alertmanager` dashboard is as follows.
 
@@ -330,10 +326,7 @@ image::monitoring/alert-view-detail.png[]
 
 ==== From Prometheus Dashboard
 
-You can visit the original dashboard of `Prometheus` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/
-____
+You can view the Prometheus dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The `Alerts` menu in the top navigation bar shows all defined rules in Prometheus. You can use the filters `Inactive`, `Pending`, and `Firing` to quickly find the information that you need.
 

--- a/versions/v1.6/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.6/modules/en/pages/storage/csidriver.adoc
@@ -105,7 +105,7 @@ image::third-party-storage/csi-driver-config-external.png[]
 
 [NOTE]
 ====
-Backup currently only works with the Longhorn v1 Data Engine. If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration. For more information, see https://documentation.suse.com/cloudnative/virtualization/v1.4/en/storage/csidriver.html#_virtual_machine_backup_compatibility[Virtual Machine Backup Compatibility].
+Backup currently only works with the Longhorn v1 Data Engine. If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration.
 
 If the StorageClass provisioner is not in the CDI's list of https://github.com/kubevirt/containerized-data-importer/blob/v1.61.1/pkg/storagecapabilities/storagecapabilities.go#L35-L127[provisioners with default access and volume modes], you must annotate the StorageClass with `cdi.harvesterhci.io/storageProfileVolumeModeAccessModes`. Without this annotation, the Helm installation may fail. Check the CSI driver's Helm chart documentation for instructions on how to annotate the StorageClass. For more information, see xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[Containerized Data Importer (CDI) Settings].
 ====

--- a/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
@@ -133,11 +133,11 @@ The file is ready for downloading when the value of `progress` is "100" and the 
  ** xref:/installation-setup/management-address.adoc[VIP] or DNS name
  ** Resource name of the file
  ** Parameter `?retain=true`: If you do not include this parameter, resources related to the support bundle are automatically deleted after the file is successfully downloaded.
-
 +
 Example:
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true`
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true+`
+
 . Download the file using either a command-line tool (for example, curl and wget) or a web browser.
 +
 Example:

--- a/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
@@ -194,7 +194,7 @@ Make sure to check <<Upgrade paths>> section first about upgradable versions.
 
 . Save the ISO to a local HTTP server.
 +
-Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
+Assume the file is hosted at `+http://10.10.0.1/harvester.iso+`.
 
 === Prepare the Version
 
@@ -215,7 +215,7 @@ Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
     releaseDate: '20250425'
 ----
 +
-Assume the file is hosted at `http://10.10.0.1/version.yaml`. If you require customizations, see <<Customize the version>>.
+Assume the file is hosted at `+http://10.10.0.1/version.yaml+`. If you require customizations, see <<Customize the version>>.
 
 . Access one of the control plane nodes via SSH and log in using the root account.
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.1** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.2** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -841,7 +841,7 @@ install:
 
 *Definition*: VIP of the {harvester-product-name} management endpoint.
 
-After installation, you can access the UI at `https://<VIP>`.
+After installation, you can access the UI at `+https://<VIP>+`.
 
 === `install.vip_mode`
 

--- a/versions/v1.7/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.7/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -525,7 +525,7 @@ Starting with *v0.1.25*, the Harvester CSI Driver supports https://kubernetes.io
 The Harvester CSI Driver supports volume snapshots starting with version *v0.1.25*. Using this feature may require additional steps depending on your Kubernetes distribution.
 
 * RKE2 (recommended): The CSI snapshot controller is deployed by default.
-* Other Kubernetes distributions: You must install the CSI snapshot controller on the guest cluster before upgrading the Harvester CSI Driver to *v0.1.25*. For installation instructions, refer to your distribution's documentation (example: https://documentation.suse.com/cloudnative/storage/latest/en/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.html({longhorn-product-name}).
+* Other Kubernetes distributions: You must install the CSI snapshot controller on the guest cluster before upgrading the Harvester CSI Driver to *v0.1.25*. For installation instructions, refer to your distribution's documentation (example: https://documentation.suse.com/cloudnative/storage/1.10/en/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.html[{longhorn-product-name}]).
 ====
 
 === Upgrade RKE2

--- a/versions/v1.7/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.7/modules/en/pages/observability/monitoring.adoc
@@ -314,11 +314,7 @@ We have already created a https://github.com/harvester/harvester/issues/2760[Git
 
 ==== From Alertmanager Dashboard
 
-You can visit the original dashboard of `Alertmanager` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts
-____
+You can view the Alertmanager dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The overall view of the `Alertmanager` dashboard is as follows.
 
@@ -330,10 +326,7 @@ image::monitoring/alert-view-detail.png[]
 
 ==== From Prometheus Dashboard
 
-You can visit the original dashboard of `Prometheus` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/
-____
+You can view the Prometheus dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The `Alerts` menu in the top navigation bar shows all defined rules in Prometheus. You can use the filters `Inactive`, `Pending`, and `Firing` to quickly find the information that you need.
 

--- a/versions/v1.7/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.7/modules/en/pages/storage/csidriver.adoc
@@ -110,7 +110,7 @@ Backup currently only works with the following:
 * Longhorn V1 Data Engine
 * Longhorn V2 Data Engine (non-root disks only)
 
-If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration. For more information, see https://documentation.suse.com/cloudnative/virtualization/v1.4/en/storage/csidriver.html#_virtual_machine_backup_compatibility[Virtual Machine Backup Compatibility].
+If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration.
 
 If the StorageClass provisioner is not in the CDI's list of https://github.com/kubevirt/containerized-data-importer/blob/v1.61.1/pkg/storagecapabilities/storagecapabilities.go#L35-L127[provisioners with default access and volume modes], you must annotate the StorageClass with `cdi.harvesterhci.io/storageProfileVolumeModeAccessModes`. Without this annotation, the Helm installation may fail. Check the CSI driver's Helm chart documentation for instructions on how to annotate the StorageClass. For more information, see xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[Containerized Data Importer (CDI) Settings].
 ====

--- a/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
@@ -133,11 +133,11 @@ The file is ready for downloading when the value of `progress` is "100" and the 
  ** xref:/installation-setup/management-address.adoc[VIP] or DNS name
  ** Resource name of the file
  ** Parameter `?retain=true`: If you do not include this parameter, resources related to the support bundle are automatically deleted after the file is successfully downloaded.
-
 +
 Example:
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true`
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true+`
+
 . Download the file using either a command-line tool (for example, curl and wget) or a web browser.
 +
 Example:
@@ -295,7 +295,7 @@ The name of the regenerated file is different from the file name recorded in the
 +
 The following download URL cannot be used to access the regenerated file.
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true`.
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true+`.
 
 * Retained support bundle files may affect system and node rebooting, node draining, and system upgrades.
 +

--- a/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
@@ -214,7 +214,7 @@ Make sure to check <<Upgrade paths>> section first about upgradable versions.
 
 . Save the ISO to a local HTTP server.
 +
-Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
+Assume the file is hosted at `+http://10.10.0.1/harvester.iso+`.
 
 === Prepare the Version
 
@@ -235,7 +235,7 @@ Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
     releaseDate: '20250425'
 ----
 +
-Assume the file is hosted at `http://10.10.0.1/version.yaml`. If you require customizations, see <<Customize the version>>.
+Assume the file is hosted at `+http://10.10.0.1/version.yaml+`. If you require customizations, see <<Customize the version>>.
 
 . Access one of the control plane nodes via SSH and log in using the root account.
 

--- a/versions/v1.7/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.1** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.7/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.2** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.10/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.8/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -834,7 +834,7 @@ install:
 
 *Definition*: VIP of the {harvester-product-name} management endpoint.
 
-After installation, you can access the UI at `https://<VIP>`.
+After installation, you can access the UI at `+https://<VIP>+`.
 
 === `install.vip_mode`
 

--- a/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -525,7 +525,7 @@ Starting with *v0.1.25*, the Harvester CSI Driver supports https://kubernetes.io
 The Harvester CSI Driver supports volume snapshots starting with version *v0.1.25*. Using this feature may require additional steps depending on your Kubernetes distribution.
 
 * RKE2 (recommended): The CSI snapshot controller is deployed by default.
-* Other Kubernetes distributions: You must install the CSI snapshot controller on the guest cluster before upgrading the Harvester CSI Driver to *v0.1.25*. For installation instructions, refer to your distribution's documentation (example: https://documentation.suse.com/cloudnative/storage/latest/en/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.html({longhorn-product-name}).
+* Other Kubernetes distributions: You must install the CSI snapshot controller on the guest cluster before upgrading the Harvester CSI Driver to *v0.1.25*. For installation instructions, refer to your distribution's documentation (example: https://documentation.suse.com/cloudnative/storage/1.11/en/snapshots-backups/csi-snapshots/enable-csi-snapshot-creation.html[{longhorn-product-name}]).
 ====
 
 === Upgrade RKE2

--- a/versions/v1.8/modules/en/pages/observability/monitoring.adoc
+++ b/versions/v1.8/modules/en/pages/observability/monitoring.adoc
@@ -314,11 +314,7 @@ We have already created a https://github.com/harvester/harvester/issues/2760[Git
 
 ==== From Alertmanager Dashboard
 
-You can visit the original dashboard of `Alertmanager` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts
-____
+You can view the Alertmanager dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-alertmanager:9093/proxy/#/alerts+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The overall view of the `Alertmanager` dashboard is as follows.
 
@@ -330,10 +326,7 @@ image::monitoring/alert-view-detail.png[]
 
 ==== From Prometheus Dashboard
 
-You can visit the original dashboard of `Prometheus` from the link below. Note that you need to replace `the-cluster-vip` with the actual cluster-vip:
-____
-https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/
-____
+You can view the Prometheus dashboard at `+https://the-cluster-vip/api/v1/namespaces/cattle-monitoring-system/services/http:rancher-monitoring-prometheus:9090/proxy/+`. Replace `the-cluster-vip` with the actual cluster VIP.
 
 The `Alerts` menu in the top navigation bar shows all defined rules in Prometheus. You can use the filters `Inactive`, `Pending`, and `Firing` to quickly find the information that you need.
 

--- a/versions/v1.8/modules/en/pages/storage/csidriver.adoc
+++ b/versions/v1.8/modules/en/pages/storage/csidriver.adoc
@@ -110,7 +110,7 @@ Backup currently only works with the following:
 * Longhorn V1 Data Engine
 * Longhorn V2 Data Engine (non-root disks only)
 
-If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration. For more information, see https://documentation.suse.com/cloudnative/virtualization/v1.4/en/storage/csidriver.html#_virtual_machine_backup_compatibility[Virtual Machine Backup Compatibility].
+If you are using other storage providers, you can skip the *Backup VolumeSnapshot Class Name* configuration.
 
 If the StorageClass provisioner is not in the CDI's list of https://github.com/kubevirt/containerized-data-importer/blob/v1.61.1/pkg/storagecapabilities/storagecapabilities.go#L35-L127[provisioners with default access and volume modes], you must annotate the StorageClass with `cdi.harvesterhci.io/storageProfileVolumeModeAccessModes`. Without this annotation, the Helm installation may fail. Check the CSI driver's Helm chart documentation for instructions on how to annotate the StorageClass. For more information, see xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[Containerized Data Importer (CDI) Settings].
 ====

--- a/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
@@ -133,11 +133,11 @@ The file is ready for downloading when the value of `progress` is "100" and the 
  ** xref:/installation-setup/management-address.adoc[VIP] or DNS name
  ** Resource name of the file
  ** Parameter `?retain=true`: If you do not include this parameter, resources related to the support bundle are automatically deleted after the file is successfully downloaded.
-
 +
 Example:
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true`
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true+`
+
 . Download the file using either a command-line tool (for example, curl and wget) or a web browser.
 +
 Example:
@@ -295,7 +295,7 @@ The name of the regenerated file is different from the file name recorded in the
 +
 The following download URL cannot be used to access the regenerated file.
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true`.
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true+`.
 
 * Retained support bundle files may affect system and node rebooting, node draining, and system upgrades.
 +

--- a/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
@@ -219,7 +219,7 @@ Make sure to check <<Upgrade paths>> section first about upgradable versions.
 
 . Save the ISO to a local HTTP server.
 +
-Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
+Assume the file is hosted at `+http://10.10.0.1/harvester.iso+`.
 
 === Prepare the Version
 
@@ -240,7 +240,7 @@ Assume the file is hosted at `http://10.10.0.1/harvester.iso`.
     releaseDate: '20250425'
 ----
 +
-Assume the file is hosted at `http://10.10.0.1/version.yaml`. If you require customizations, see <<Customize the version>>.
+Assume the file is hosted at `+http://10.10.0.1/version.yaml+`. If you require customizations, see <<Customize the version>>.
 
 . Access one of the control plane nodes via SSH and log in using the root account.
 

--- a/versions/v1.8/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/v1-5-0-to-v1-5-1.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.1** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 

--- a/versions/v1.8/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/v1-5-0-to-v1-5-2.adoc
@@ -30,7 +30,7 @@ You must use **v1.5.2** of the Harvester UI Extension to import {harvester-produ
 
 Virtual machines that use migratable xref:integrations/rancher/csi-driver.adoc#_rwx_volumes_support[RWX volumes] restart unexpectedly when the CSI plugin pods are restarted. This issue affects {harvester-product-name} v1.4.x, v1.5.0, and v1.5.1.
 
-The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
+The workaround is to disable the setting https://documentation.suse.com/cloudnative/storage/1.11/en/longhorn-system/settings.html#_automatically_delete_workload_pod_when_the_volume_is_detached_unexpectedly[Automatically Delete Workload Pod When The Volume Is Detached Unexpectedly] on the {longhorn-product-name} UI before starting the upgrade. You must enable the setting again once the upgrade is completed.
 
 The issue will be fixed in {longhorn-product-name} v1.8.3, v1.9.1, and later versions. {harvester-product-name} v1.6.0 will include {longhorn-product-name} v1.9.1. 
 


### PR DESCRIPTION
Scope: v1.5, v1.6, v1.7, v1.8

Changes:
- Escaped URLs
- Replaced/removed broken URLs
- Updated version in SUSE Storage doc URLs (SUSE Virtualization uses SUSE Storage v1.8, but that version has reached its EOL and the corresponding doc has been archived. The SV v1.5 doc now points to the SS v1.9 doc.)
  | SUSE Virtualization version | SUSE Storage version |
  | --- | --- |
  | v1.5 | v1.8 |
  | v1.6 | v1.9 |
  | v1.7 | v1.10 |
  | v1.8 | v1.11 |