### PR TITLE
Port content from community doc PRs (1009, 1033)

### DIFF
--- a/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,5 +1,5 @@
 = Settings
-:revdate: 2025-12-30
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
@@ -50,7 +50,7 @@ The following example adds disks that match the glob pattern `/dev/sd*` or `/dev
 
 *Definition*: Setting that allows you to automatically rotate certificates for {rke2-product-name} services. This setting is disabled by default.
 
-Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). If the certificate expires within the specified period, Harvester automatically replaces the certificate.
+Use the field `expiringInHours` to specify the validity period of each certificate (`1` to `8759` hours). If the certificate expires within the specified period, {harvester-product-name} automatically replaces the certificate.
 
 For more information, see the *Certificate Rotation* section of the https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-admin/manage-clusters/rotate-certificates.html[{rancher-product-name}] and https://documentation.suse.com/cloudnative/rke2/latest/en/advanced.html#_certificate_rotation[{rke2-product-name}] documentation.
 
@@ -92,12 +92,19 @@ For more information, see the https://documentation.suse.com/cloudnative/storage
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
+
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-short-name}. The `related-version` is usually the same as the {rancher-short-name} version. For example, when you register {harvester-product-name} to {rancher-short-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your {rancher-short-name} version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
 * {harvester-product-name} containerd-registry: You can configure a <<_containerd_registry, private registry for the cluster>>.
-* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-product-name}.
+* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-short-name}.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
 

--- a/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,8 +1,15 @@
 = {rancher-product-name} Integration
-:revdate: 2026-05-15
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
+
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
 
 You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 

--- a/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.5/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2025-12-08
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -86,7 +86,7 @@ Check out the available xref:../installation-setup/config/settings.adoc#_upgrade
 * Do not operate the cluster during an upgrade. For example, creating new VMs, uploading new images, etc.
 * Make sure your hardware meets the *preferred* xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements]. This is due to there will be intermediate resources consumed by an upgrade.
 * Make sure each node has at least 30 GiB of free system partition space (`df -h /usr/local/`). If any node in the cluster has less than 30 GiB of free system partition space, the upgrade will be denied. Check <<Free system partition space requirement,free system partition space requirement>> for more information.
-* Run the pre-check script on a {harvester-product-name} control-plane node. Please pick a script according to your cluster's version: https://github.com/harvester/upgrade-helpers/tree/main/pre-check.
+* Run the https://github.com/harvester/upgrade-helpers/tree/main/pre-check[pre-check script] on a {harvester-product-name} control plane node. Resolve any failed checks before starting the upgrade.
 * A number of one-off privileged pods will be created in the `harvester-system` and `cattle-system` namespaces to perform host-level upgrade operations. If https://kubernetes.io/docs/concepts/security/pod-security-admission/[pod security admission] is enabled, adjust these policies to allow these pods to run.
 ====
 

--- a/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,5 +1,5 @@
 = Settings
-:revdate: 2025-12-30
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
@@ -92,12 +92,19 @@ For more information, see the https://documentation.suse.com/cloudnative/storage
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
+
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-short-name}. The `related-version` is usually the same as the {rancher-short-name} version. For example, when you register {harvester-product-name} to {rancher-short-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your {rancher-short-name} version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
 * {harvester-product-name} containerd-registry: You can configure a <<_containerd_registry, private registry for the cluster>>.
-* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-product-name}.
+* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-short-name}.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
 

--- a/versions/v1.6/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,8 +1,15 @@
 = {rancher-product-name} Integration
-:revdate: 2026-05-15
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
+
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
 
 You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 

--- a/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2025-12-08
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -110,7 +110,7 @@ Check out the available xref:../installation-setup/config/settings.adoc#_upgrade
 * Do not operate the cluster during an upgrade. For example, creating new VMs, uploading new images, etc.
 * Make sure your hardware meets the *preferred* xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements]. This is due to there will be intermediate resources consumed by an upgrade.
 * Make sure each node has at least 30 GiB of free system partition space (`df -h /usr/local/`). If any node in the cluster has less than 30 GiB of free system partition space, the upgrade will be denied. Check <<Free system partition space requirement,free system partition space requirement>> for more information.
-* Run the pre-check script on a {harvester-product-name} control-plane node. Please pick a script according to your cluster's version: https://github.com/harvester/upgrade-helpers/tree/main/pre-check.
+* Run the https://github.com/harvester/upgrade-helpers/tree/main/pre-check[pre-check script] on a {harvester-product-name} control plane node. Resolve any failed checks before starting the upgrade.
 * A number of one-off privileged pods will be created in the `harvester-system` and `cattle-system` namespaces to perform host-level upgrade operations. If https://kubernetes.io/docs/concepts/security/pod-security-admission/[pod security admission] is enabled, adjust these policies to allow these pods to run.
 ====
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,5 +1,5 @@
 = Settings
-:revdate: 2026-01-27
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
@@ -92,12 +92,19 @@ For more information, see the https://documentation.suse.com/cloudnative/storage
 
 *Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
+
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-short-name}. The `related-version` is usually the same as the {rancher-short-name} version. For example, when you register {harvester-product-name} to {rancher-short-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your {rancher-short-name} version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
 * {harvester-product-name} containerd-registry: You can configure a <<_containerd_registry, private registry for the cluster>>.
-* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-product-name}.
+* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-short-name}.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,5 +1,5 @@
 = Update the Configuration After Installation
-:revdate: 2025-12-26
+:revdate: 2026-06-04
 :page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the operating system revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
@@ -23,16 +23,46 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 === Configuration persistence
 
-. Back up the {elemental-product-name} `cloud-init` file `/oem/90_custom.yaml`.
-+
-[,sh]
+Create a `CloudInit` resource to modify the password.
+
+[,yaml]
 ----
- cp /oem/90_custom.yaml /oem/install/90_custom.yaml.$(date --iso-8601=minutes)
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: passwd
+spec:
+  matchSelector: {}
+  filename: 99_passwd.yaml
+  contents: |
+    stages:
+      initramfs.after:
+        - users:
+            rancher:
+              passwd: <PLAIN_OR_SHA512HASHED_PASSWORD>
 ----
 
-. Edit `/oem/90_custom.yaml` and update the yaml path `stages.initramfs[0].users.rancher.passwd`.
+For information about using cloud-init keys to configure users, see https://documentation.suse.com/cloudnative/os-manager/1.9/en/references/cloud-config-reference.html#_configuration_syntax[Configuration syntax] in the {fleet-product-name} documentation.
 
-For information about specifying the `rancher` user account password in an encrypted form, see [`os.password`](./harvester-configuration.md#ospassword).
+[,yaml]
+----
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: passwd
+spec:
+  matchSelector: {}
+  filename: 99_passwd.yaml
+  contents: |
+    #cloud-config
+    users:
+      - name: rancher
+        passwd: <PLAIN_OR_SHA512HASHED_PASSWORD>
+----
+
+Using a `CloudInit` resource is preferable to manually editing the `/oem/90_custom.yaml` configuration file.
+
+For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/host.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
 
 == NTP servers
 

--- a/versions/v1.7/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -62,7 +62,7 @@ spec:
 
 Using a `CloudInit` resource is preferable to manually editing the `/oem/90_custom.yaml` configuration file.
 
-For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/host.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
+For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/hosts.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
 
 == NTP servers
 

--- a/versions/v1.7/modules/en/pages/integrations/rancher/rancher-integration.adoc
+++ b/versions/v1.7/modules/en/pages/integrations/rancher/rancher-integration.adoc
@@ -1,8 +1,15 @@
 = {rancher-product-name} Integration
-:revdate: 2026-05-15
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 https://documentation.suse.com/cloudnative/rancher-manager[{rancher-product-name}] is an open-source multi-cluster management platform. {rancher-short-name} has integrated {harvester-product-name} by default to centrally manage virtual machines and containers.
+
+[WARNING]
+====
+A vulnerability exists in the {harvester-product-name}-{rancher-short-name} integration mechanism where the registration client fails to validate the certificate presented by the remote server during the TLS handshake. This security gap allows an attacker with network-level access between {harvester-product-name} and {rancher-short-name} to execute a man-in-the-middle (MitM) attack against {harvester-product-name}.
+
+To mitigate this, upgrade to v1.8 or restrict access so that only authorized cluster administrators can modify the `cluster-registration-url` setting. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-pgh9-mpwc-8jjf[CVE-2025-71261].
+====
 
 You can import and manage multiple {harvester-product-name} clusters using {rancher-short-name}'s xref:./virtualization-management.adoc[Virtualization Management] feature, which leverages {rancher-short-name}'s https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/authn-and-authz.html[authentication] feature and https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/rancher-admin/users/authn-and-authz/manage-role-based-access-control-rbac/manage-role-based-access-control-rbac.html[RBAC control] for xref:./virtualization-management.adoc#_multi_tenancy[multi-tenancy] support.
 

--- a/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-01-02
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -125,7 +125,7 @@ Check out the available xref:../installation-setup/config/settings.adoc#_upgrade
 * Do not operate the cluster during an upgrade. For example, creating new VMs, uploading new images, etc.
 * Make sure your hardware meets the *preferred* xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements]. This is due to there will be intermediate resources consumed by an upgrade.
 * Make sure each node has at least 30 GiB of free system partition space (`df -h /usr/local/`). If any node in the cluster has less than 30 GiB of free system partition space, the upgrade will be denied. Check <<Free system partition space requirement,free system partition space requirement>> for more information.
-* Run the pre-check script on a {harvester-product-name} control-plane node. Please pick a script according to your cluster's version: https://github.com/harvester/upgrade-helpers/tree/main/pre-check.
+* Run the https://github.com/harvester/upgrade-helpers/tree/main/pre-check[pre-check script] on a {harvester-product-name} control plane node. Resolve any failed checks before starting the upgrade.
 * A number of one-off privileged pods will be created in the `harvester-system` and `cattle-system` namespaces to perform host-level upgrade operations. If https://kubernetes.io/docs/concepts/security/pod-security-admission/[pod security admission] is enabled, adjust these policies to allow these pods to run.
 ====
 

--- a/versions/v1.8/modules/en/pages/installation-setup/config/settings.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/settings.adoc
@@ -1,5 +1,5 @@
 = Settings
-:revdate: 2026-06-03
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 The following is a list of advanced settings that you can use. You can modify the `settings.harvesterhci.io` custom resource using both the UI and the `kubectl` command.
@@ -97,23 +97,28 @@ For more information, see the https://documentation.suse.com/cloudnative/storage
 
 === `cluster-registration-url`
 
-*Definition*: URL used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
+*Definition*: JSON object used to import the {harvester-product-name} cluster into {rancher-product-name} for multi-cluster management.
 
-When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-product-name}. The `related-version` is usually the same as the {rancher-product-name} version. For example, when you register {harvester-product-name} to {rancher-product-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your Rancher version].
+The `url` field specifies the {rancher-short-name} registration URL, while the `insecureSkipTLSVerify` field determines whether to skip TLS certificate verification when connecting to that URL.
+
+By default, the registration connection is secured via TLS. {harvester-product-name} validates the server certificate against its trusted system CA certificates. If your environment uses custom CA certificates, you can add them to the trusted list using the <<_additional_ca>> setting. In environments with self-signed or untrusted certificates, you can set `insecureSkipTLSVerify` to `true` to skip the TLS verification. However, this is not recommended for production environments.
+
+When you configure this setting, a new pod called `cattle-cluster-agent-*` is created in the namespace `cattle-system` for registration purposes. This pod uses the container image `rancher/rancher-agent:related-version`, which is not packed into the {harvester-product-name} ISO and is instead determined by {rancher-short-name}. The `related-version` is usually the same as the {rancher-short-name} version. For example, when you register {harvester-product-name} to {rancher-short-name} v2.7.9, the image is `rancher/rancher-agent:v2.7.9`. For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/installation-and-upgrade/other-installation-methods/air-gapped/publish-images.html#_1_find_the_required_assets_for_your_rancher_version[Find the required assets for your {rancher-short-name} version].
 
 Depending on your settings, the image is downloaded from either of the following locations:
 
 * {harvester-product-name} containerd-registry: You can configure a <<_containerd_registry, private registry for the cluster>>.
-* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-product-name}.
+* Docker Hub (docker.io): This is the default option when you do not configure a private registry in {rancher-short-name}.
 
 Alternatively, you can obtain a copy of the image and manually upload it to all nodes.
 
-*Default value*: None
+*Default value*: `{ "url": "", "insecureSkipTLSVerify": false}`
 
 *Example*:
 
+[,json]
 ----
-https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhrc7c_c-m-zxbbbck9.yaml
+{ "url": "https://172.16.0.1/v3/import/w6tp7dgwjj549l88pr7xmxb4x6m54v5kcplvhbp9vv2wzqrrjhrc7c_c-m-zxbbbck9.yaml", "insecureSkipTLSVerify": false}
 ----
 
 === `containerd-registry`

--- a/versions/v1.8/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -1,5 +1,5 @@
 = Update the Configuration After Installation
-:revdate: 2025-12-26
+:revdate: 2026-06-04
 :page-revdate: {revdate}
 
 The {harvester-product-name} operating system has an immutable design, which means most files in the operating system revert to their pre-configured state after a reboot. The operating system loads the pre-configured values of system components from configuration files during the boot time.
@@ -23,16 +23,46 @@ If you upgrade from a version before `v1.1.2`, the `cloud-init` file in examples
 
 === Configuration persistence
 
-. Back up the {elemental-product-name} `cloud-init` file `/oem/90_custom.yaml`.
-+
-[,sh]
+Create a `CloudInit` resource to modify the password.
+
+[,yaml]
 ----
- cp /oem/90_custom.yaml /oem/install/90_custom.yaml.$(date --iso-8601=minutes)
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: passwd
+spec:
+  matchSelector: {}
+  filename: 99_passwd.yaml
+  contents: |
+    stages:
+      initramfs.after:
+        - users:
+            rancher:
+              passwd: <PLAIN_OR_SHA512HASHED_PASSWORD>
 ----
 
-. Edit `/oem/90_custom.yaml` and update the yaml path `stages.initramfs[0].users.rancher.passwd`.
+For information about using cloud-init keys to configure users, see https://documentation.suse.com/cloudnative/os-manager/1.9/en/references/cloud-config-reference.html#_configuration_syntax[Configuration syntax] in the {fleet-product-name} documentation.
 
-For information about specifying the `rancher` user account password in an encrypted form, see [`os.password`](./harvester-configuration.md#ospassword).
+[,yaml]
+----
+apiVersion: node.harvesterhci.io/v1beta1
+kind: CloudInit
+metadata:
+  name: passwd
+spec:
+  matchSelector: {}
+  filename: 99_passwd.yaml
+  contents: |
+    #cloud-config
+    users:
+      - name: rancher
+        passwd: <PLAIN_OR_SHA512HASHED_PASSWORD>
+----
+
+Using a `CloudInit` resource is preferable to manually editing the `/oem/90_custom.yaml` configuration file.
+
+For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/host.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
 
 == NTP servers
 

--- a/versions/v1.8/modules/en/pages/installation-setup/config/update-configuration.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/config/update-configuration.adoc
@@ -62,7 +62,7 @@ spec:
 
 Using a `CloudInit` resource is preferable to manually editing the `/oem/90_custom.yaml` configuration file.
 
-For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/host.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
+For information about specifying the `rancher` user account password in an encrypted form, see xref:hosts/hosts.adoc#_creating_a_cloudinit_resource[Creating a CloudInit resource].
 
 == NTP servers
 

--- a/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-06-04
+:revdate: 2026-06-05
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -130,7 +130,7 @@ Check out the available xref:../installation-setup/config/settings.adoc#_upgrade
 * Do not operate the cluster during an upgrade. For example, creating new VMs, uploading new images, etc.
 * Make sure your hardware meets the *preferred* xref:../installation-setup/requirements.adoc#_hardware_requirements[hardware requirements]. This is due to there will be intermediate resources consumed by an upgrade.
 * Make sure each node has at least 30 GiB of free system partition space (`df -h /usr/local/`). If any node in the cluster has less than 30 GiB of free system partition space, the upgrade will be denied. Check <<Free system partition space requirement,free system partition space requirement>> for more information.
-* Run the pre-check script on a {harvester-product-name} control-plane node. Please pick a script according to your cluster's version: https://github.com/harvester/upgrade-helpers/tree/main/pre-check.
+* Run the https://github.com/harvester/upgrade-helpers/tree/main/pre-check[pre-check script] on a {harvester-product-name} control plane node. Resolve any failed checks before starting the upgrade.
 * A number of one-off privileged pods will be created in the `harvester-system` and `cattle-system` namespaces to perform host-level upgrade operations. If https://kubernetes.io/docs/concepts/security/pod-security-admission/[pod security admission] is enabled, adjust these policies to allow these pods to run.
 ====
 


### PR DESCRIPTION
Scope: v1.5, v1.6, v1.7, v1.8

PRs:
- [1009](https://github.com/harvester/docs/pull/1009): `CloudInit` CR examples
- [1019](https://github.com/harvester/docs/pull/1019): Pre-check script
- [1033](https://github.com/harvester/docs/pull/1033): `cluster-registration-url` TLS config and CVE-2025-71261