### PR TITLE
Fix broken links flagged by Siteimprove

### DIFF
--- a/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/config/configuration-file.adoc
@@ -565,7 +565,7 @@ install:
 
 Using the default value is recommended for high system availability. When deploying single-node clusters, you can specify a value less than 12.
 
-For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
+For more information about how to set the correct value, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_guaranteed_instance_manager_cpu[Guaranteed Instance Manager CPU] in the {longhorn-product-name} documentation.
 
 *Default value*: 12
 
@@ -586,7 +586,7 @@ For more information about how to set the correct value, see https://documentati
 
 Using the default value is recommended for high storage availability. When deploying single-node clusters, you must set the value to 1.
 
-For more information, see https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
+For more information, see https://documentation.suse.com/cloudnative/storage/1.9/en/longhorn-system/settings.html#_default_replica_count[Default Replica Count] in the {longhorn-product-name} documentation.
 
 *Default value*: 3
 

--- a/versions/v1.5/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.5/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -337,15 +337,17 @@ UEFI firmware supports loading a boot image from an HTTP server. This section de
 
 === Serve the iPXE Program
 
-Download the iPXE UEFI program from http://boot.ipxe.org/ipxe.efi and make sure `ipxe.efi` can be downloaded from the HTTP server. For example:
-
+. Download the http://boot.ipxe.org[iPXE] UEFI program that matches your system's architecture. 
++
+Example:
++
 [,bash]
 ----
 cd /usr/share/nginx/html/harvester/
-wget http://boot.ipxe.org/ipxe.efi
+wget http://boot.ipxe.org/x86_64-efi/ipxe.efi
 ----
 
-The file now can be downloaded from `http://10.100.0.10/harvester/ipxe.efi` locally.
+. Verify that you can download `ipxe.efi` from the HTTP server (`+http://10.100.0.10/harvester/ipxe.efi+`).
 
 === DHCP Server Configuration
 
@@ -435,4 +437,4 @@ Installation is stopped if the hardware checks fail (because the minimum require
 
 === `harvester.install.with_net_images=true`
 
-The installer does not preload images during installation and instead pulls all required images from the internet after installation is completed. Usage of this parameter is not recommended in most cases. For more information, see xref:/installation-setup/media/net-install.adoc[Net Install ISO].
+The installer does not preload images during installation and instead pulls all required images from the internet after installation is completed. Usage of this parameter is not recommended in most cases. For more information, see xref:installation-setup/media/net-install.adoc[Net Install ISO].

--- a/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
+++ b/versions/v1.5/modules/en/pages/integrations/rancher/node-driver/rke1-cluster.adoc
@@ -29,7 +29,7 @@ Node templates can use `cloud credentials` to access the credentials information
 
 You can create `cloud credentials` in two contexts:
 
-* https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/#node-templates[During the creation of a node template] for a cluster.
+* During the creation of a https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-deployment/infra-providers/infra-providers.html#_node_templates[node template] for a cluster.
 * In the User Settings page
 
 All `cloud credentials` are bound to your user profile and cannot be shared with other users.
@@ -61,7 +61,7 @@ You can use the Harvester Node Driver to create node templates and eventually no
 
 image::rancher/node-template.png[]
 
-See https://rancher.com/docs/rancher/v2.6/en/cluster-provisioning/rke-clusters/node-pools/[nodes hosted by an infrastructure provider] for more information.
+For more information, see https://documentation.suse.com/cloudnative/rancher-manager/v2.11/en/cluster-admin/manage-clusters/nodes-and-node-pools.html[Nodes and Node Pools] in the {rancher-short-name} documentation.
 
 === Add node affinity
 

--- a/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/cluster.adoc
@@ -142,7 +142,10 @@ Example:
 +
 Example:
 +
-`curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+[,shell]
+----
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip
+----
 
 . Verify that resources related to the support bundle were not deleted.
 +
@@ -170,12 +173,13 @@ You can delete the related resources using the following methods:
 +
 Example:
 +
+[,shell]
 ----
-  $ kubectl delete supportbundle -n harvester-system bundle-htl5f
-  supportbundle.harvesterhci.io "bundle-htl5f" deleted
+kubectl delete supportbundle -n harvester-system bundle-htl5f
+supportbundle.harvesterhci.io "bundle-htl5f" deleted
 
-  $ kubectl get supportbundle -A
-  No resources found
+kubectl get supportbundle -A
+No resources found
 ----
 
 * Automatic: The related resources are deleted based on how the following settings are configured:
@@ -295,7 +299,7 @@ The name of the regenerated file is different from the file name recorded in the
 +
 The following download URL cannot be used to access the regenerated file.
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true`.
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true+`.
 
 * Retained support bundle files may affect system and node rebooting, node draining, and system upgrades.
 +

--- a/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
+++ b/versions/v1.5/modules/en/pages/troubleshooting/monitoring.adoc
@@ -70,7 +70,7 @@ rancher-monitoring-grafana-d9c56d79b-cp86w               3/3     Running   0    
 
 {harvester-product-name} Monitoring uses Persistent Volume (PV) to store running data. When a cluster has been running for a certain time, the Persistent Volume may need to expand its size.
 
-For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.8/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
+For information about how to increase the volume size, see https://documentation.suse.com/cloudnative/storage/1.9/en/volumes/volume-expansion.html[Volume Expansion] in the {longhorn-product-name} documentation.
 
 === View Volume
 

--- a/versions/v1.6/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.6/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -337,15 +337,17 @@ UEFI firmware supports loading a boot image from an HTTP server. This section de
 
 === Serve the iPXE Program
 
-Download the iPXE UEFI program from http://boot.ipxe.org/ipxe.efi and make sure `ipxe.efi` can be downloaded from the HTTP server. For example:
-
+. Download the http://boot.ipxe.org[iPXE] UEFI program that matches your system's architecture. 
++
+Example:
++
 [,bash]
 ----
 cd /usr/share/nginx/html/harvester/
-wget http://boot.ipxe.org/ipxe.efi
+wget http://boot.ipxe.org/x86_64-efi/ipxe.efi
 ----
 
-The file now can be downloaded from `http://10.100.0.10/harvester/ipxe.efi` locally.
+. Verify that you can download `ipxe.efi` from the HTTP server (`+http://10.100.0.10/harvester/ipxe.efi+`).
 
 === DHCP Server Configuration
 

--- a/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.6/modules/en/pages/troubleshooting/cluster.adoc
@@ -142,7 +142,10 @@ Example:
 +
 Example:
 +
-`curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+[,shell]
+----
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip
+----
 
 . Verify that resources related to the support bundle were not deleted.
 +
@@ -170,12 +173,13 @@ You can delete the related resources using the following methods:
 +
 Example:
 +
+[,shell]
 ----
-  $ kubectl delete supportbundle -n harvester-system bundle-htl5f
+kubectl delete supportbundle -n harvester-system bundle-htl5f
   supportbundle.harvesterhci.io "bundle-htl5f" deleted
 
-  $ kubectl get supportbundle -A
-  No resources found
+kubectl get supportbundle -A
+No resources found
 ----
 
 * Automatic: The related resources are deleted based on how the following settings are configured:
@@ -295,7 +299,7 @@ The name of the regenerated file is different from the file name recorded in the
 +
 The following download URL cannot be used to access the regenerated file.
 +
-`https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true`.
+`+https://{vip/dns-name}/v1/harvester/supportbundles/bundle-yr2vq/download?retain=true+`.
 
 * Retained support bundle files may affect system and node rebooting, node draining, and system upgrades.
 +

--- a/versions/v1.7/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.7/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -338,15 +338,17 @@ UEFI firmware supports loading a boot image from an HTTP server. This section de
 
 === Serve the iPXE Program
 
-Download the iPXE UEFI program from http://boot.ipxe.org/ipxe.efi and make sure `ipxe.efi` can be downloaded from the HTTP server. For example:
-
+. Download the http://boot.ipxe.org[iPXE] UEFI program that matches your system's architecture. 
++
+Example:
++
 [,bash]
 ----
 cd /usr/share/nginx/html/harvester/
-wget http://boot.ipxe.org/ipxe.efi
+wget http://boot.ipxe.org/x86_64-efi/ipxe.efi
 ----
 
-The file now can be downloaded from `http://10.100.0.10/harvester/ipxe.efi` locally.
+. Verify that you can download `ipxe.efi` from the HTTP server (`+http://10.100.0.10/harvester/ipxe.efi+`).
 
 === DHCP Server Configuration
 

--- a/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
@@ -145,7 +145,7 @@ Example:
 +
 [,shell]
 ----
-curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip
 ----
 
 . Verify that resources related to the support bundle were not deleted.

--- a/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.7/modules/en/pages/troubleshooting/cluster.adoc
@@ -143,7 +143,10 @@ Example:
 +
 Example:
 +
-`curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+[,shell]
+----
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+----
 
 . Verify that resources related to the support bundle were not deleted.
 +
@@ -171,12 +174,13 @@ You can delete the related resources using the following methods:
 +
 Example:
 +
+[,shell]
 ----
-  $ kubectl delete supportbundle -n harvester-system bundle-htl5f
-  supportbundle.harvesterhci.io "bundle-htl5f" deleted
+kubectl delete supportbundle -n harvester-system bundle-htl5f
+supportbundle.harvesterhci.io "bundle-htl5f" deleted
 
-  $ kubectl get supportbundle -A
-  No resources found
+kubectl get supportbundle -A
+No resources found
 ----
 
 * Automatic: The related resources are deleted based on how the following settings are configured:

--- a/versions/v1.8/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/methods/pxe-boot-install.adoc
@@ -342,15 +342,17 @@ UEFI firmware supports loading a boot image from an HTTP server. This section de
 
 === Serve the iPXE Program
 
-Download the iPXE UEFI program from http://boot.ipxe.org/ipxe.efi and make sure `ipxe.efi` can be downloaded from the HTTP server. For example:
-
+. Download the http://boot.ipxe.org[iPXE] UEFI program that matches your system's architecture. 
++
+Example:
++
 [,bash]
 ----
 cd /usr/share/nginx/html/harvester/
-wget http://boot.ipxe.org/ipxe.efi
+wget http://boot.ipxe.org/x86_64-efi/ipxe.efi
 ----
 
-The file now can be downloaded from `http://10.100.0.10/harvester/ipxe.efi` locally.
+. Verify that you can download `ipxe.efi` from the HTTP server (`+http://10.100.0.10/harvester/ipxe.efi+`).
 
 === DHCP Server Configuration
 

--- a/versions/v1.8/modules/en/pages/networking/vpc-nat-gateway.adoc
+++ b/versions/v1.8/modules/en/pages/networking/vpc-nat-gateway.adoc
@@ -615,6 +615,13 @@ test nginx locally on the VM
 curl http://127.0.0.1
 ----
 
-To validate the DNAT configuration, run `curl -k http://10.115.55.200:8888` from an external host. The request should return a valid response from the internal service.
+To validate the DNAT configuration, run the following command from an external host.
+
+[,shell]
+----
+curl -k http://10.115.55.200:8888
+----
+
+The request should return a valid response from the internal service.
 
 image::networking/kubeovnDNATFlow.png[Kube-OVN DNAT flow]

--- a/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
@@ -144,7 +144,7 @@ Example:
 +
 [,shell]
 ----
-curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip
 ----
 
 . Verify that resources related to the support bundle were not deleted.

--- a/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
+++ b/versions/v1.8/modules/en/pages/troubleshooting/cluster.adoc
@@ -142,7 +142,10 @@ Example:
 +
 Example:
 +
-`curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+[,shell]
+----
+curl -k https://{vip/dns-name}/v1/harvester/supportbundles/bundle-htl5f/download?retain=true -o sb2.zip`
+----
 
 . Verify that resources related to the support bundle were not deleted.
 +
@@ -170,12 +173,13 @@ You can delete the related resources using the following methods:
 +
 Example:
 +
+[,shell]
 ----
-  $ kubectl delete supportbundle -n harvester-system bundle-htl5f
-  supportbundle.harvesterhci.io "bundle-htl5f" deleted
+kubectl delete supportbundle -n harvester-system bundle-htl5f
+supportbundle.harvesterhci.io "bundle-htl5f" deleted
 
-  $ kubectl get supportbundle -A
-  No resources found
+kubectl get supportbundle -A
+No resources found
 ----
 
 * Automatic: The related resources are deleted based on how the following settings are configured:

--- a/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
@@ -236,7 +236,7 @@ The {harvester-product-name} UI includes a dedicated screen for importing an upg
 . Select a source type.
 +
 ** *File*: Click *Upload File* and select an ISO file in a local directory.
-** *URL*: Specify the URL of the target ISO file (for example, `http://10.10.0.1/harvester.iso`).
+** *URL*: Specify the URL of the target ISO file (for example, `+http://10.10.0.1/harvester.iso+`).
 
 . Click *Upgrade*.
 


### PR DESCRIPTION
Scope: v1.5, v1.6, v1.7, v1.8

Files:
- `installation-setup/config/configuration-file.adoc`
- `installation-setup/methods/pxe-boot-install.adoc`
- `integrations/rancher/node-driver/rke1-cluster.adoc`
- `networking/vpc-nat-gateway.adoc`
- `troubleshooting/cluster.adoc`
- `troubleshooting/monitoring.adoc`
- `upgrades/upgrades.adoc`

Note: We can ignore the issues in the translated files. These will be addressed separately.