### PR TITLE
Fix image path in translated files

### DIFF
--- a/versions/v1.7/modules/de/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/de/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@ Die Architektur besteht aus modernsten Open-Source-Technologien:
 * *Speicherverwaltung mit {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] bietet verteilten Blockspeicher und Tiering.
 * *Einblick mit Grafana und Prometheus.* https://grafana.com/[Grafana] und https://prometheus.io/[Prometheus] bieten robustes Monitoring und Logging.
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == Funktionen
 

--- a/versions/v1.7/modules/es/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/es/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@ La arquitectura consiste en tecnologías de código abierto de vanguardia:
 * *Gestión de almacenamiento con {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] proporciona almacenamiento en bloques distribuido y jerarquización.
 * *Observabilidad con Grafana y Prometheus.* https://grafana.com/[Grafana] y https://prometheus.io/[Prometheus] proporcionan monitoreo y registro robustos.
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == Funciones
 

--- a/versions/v1.7/modules/fr/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/fr/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@ L'architecture se compose de technologies Open Source de pointe{nbsp}:
 * *Gestion du stockage avec {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] fournit un stockage de blocs distribué et un tiering.
 * *Observabilité avec Grafana et Prometheus.* https://grafana.com/[Grafana] et https://prometheus.io/[Prometheus] fournissent une surveillance et une journalisation robustes.
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == Fonctions
 

--- a/versions/v1.7/modules/ja/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/ja/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@
 * *ストレージ管理は{longhorn-product-name}によって行われます。* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}]は、分散ブロックストレージと階層化を提供します。
 * *GrafanaとPrometheusによる監視。* https://grafana.com/[Grafana]と https://prometheus.io/[Prometheus]は、堅牢な監視とログ記録を提供します。
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == 機能
 

--- a/versions/v1.7/modules/pt/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/pt/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@ A arquitetura consiste em tecnologias de código aberto de ponta:
 * *Gerenciamento de armazenamento com {longhorn-product-name}.* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] fornece armazenamento em blocos distribuído e gerenciamento de níveis.
 * *Observabilidade com Grafana e Prometheus.* https://grafana.com/[Grafana] e https://prometheus.io/[Prometheus] fornecem monitoramento robusto e registro robusto.
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == Recursos
 

--- a/versions/v1.7/modules/zh/pages/introduction/overview.adoc
+++ b/versions/v1.7/modules/zh/pages/introduction/overview.adoc
@@ -15,7 +15,7 @@
 * *使用 {longhorn-product-name} 进行存储管理。* https://documentation.suse.com/cloudnative/storage/1.8/en/longhorn-documentation.html[{longhorn-product-name}] 提供分布式块存储和分层。
 * *使用 Grafana 和 Prometheus 进行可观测性。* https://grafana.com/[Grafana] 和 https://prometheus.io/[Prometheus] 提供强大的监控和日志记录。
 
-image::architecture.svg[]
+image::en:introduction/architecture.svg[]
 
 == 功能
 


### PR DESCRIPTION
- Scope: v1.7
- Affected files: `overview.adoc` in `de`, `es`, `fr`, `ja`, `pt`, `zh` modules
- Issue: The subdirectory `introduction/` was dropped from the path during translation.

> Note: This fix was triggered by @pmkovar's [comment in #285](https://github.com/rancher/harvester-product-docs/pull/285#pullrequestreview-4772363615). The build still fails because of internal cross-reference issues in the translated files. Nevertheless, we can safely merge the changes in this PR because the logs show no errors in the English source files. 