### PR TITLE
Port content from community doc PRs (1087, 1090, 1092, 1093, 1094)

### DIFF
--- a/versions/v1.6/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.6/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -5,7 +5,7 @@
 == Support Matrix
 
 |===
-| Harvester Version | Supported Terraform Provider | Supported Terraformer
+| {harvester-product-name} Version | Supported Terraform Provider | Supported Terraformer
 
 | https://github.com/harvester/harvester/releases/tag/v1.6.0[v1.6.0]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.6.0[v1.6.0]

--- a/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-06-05
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -97,9 +97,80 @@ Non-migratable virtual machines experience downtime during migration.
 
 For more information, see xref:upgrades/troubleshooting.adoc#_phase_4_upgrade_nodes[Phase 4: Upgrade Nodes].
 
+[#_planned_shutdown_live_migration]
+=== Planned shutdown vs. live migration
+
+Live-migratable virtual machines are automatically migrated during an upgrade. Live migration is recommended for most workloads because it avoids downtime. However, for sensitive or complex workloads requiring predictability, gracefully shutting down virtual machines before the upgrade is the safest approach.
+
+==== When live migration may not converge
+
+Live migration copies a virtual machine's memory pages to the target node while the virtual machine continues to run. If a virtual machine writes to memory faster than its pages can be transferred across the network (a high *dirty rate*), the migration cannot converge. {harvester-product-name} then aborts the migration upon reaching the xref:virtual-machines/live-migration.adoc#_migration_timeouts[completion or progress timeout].
+
+This issue commonly affects write-heavy workloads (such as active databases) where the memory dirty rate exceeds available bandwidth. If these migrations fail to converge within the maintenance window, the upgrade may stall.
+
+==== Comparison
+
+|===
+| Aspect | Live Migration | Planned Shutdown
+
+| Downtime
+| None
+| Brief service interruption
+
+| Convergence risk for write-heavy virtual machines
+| High (risk of failure to converge and abort)
+| None (no migration involved)
+
+| Maintenance window predictability
+| Low (completion time depends on dirty rate and bandwidth)
+| High (predictable shutdown and restart times)
+
+| Operational effort
+| Low (automatic)
+| High (requires planning and downtime coordination)
+
+| Resource overhead during upgrade
+| High (target node required to host the virtual machine during migration)
+| Low (no concurrent copy of virtual machine state)
+|===
+
+[TIP]
+====
+Based on these trade-offs, use live migration by default for any virtual machine that can complete migration within the maintenance window.
+
+Gracefully shut down business-critical or write-heavy virtual machines before starting the upgrade when:
+* Live migration is unlikely to converge within the maintenance window.
+* A predictable, bounded maintenance window is strictly required.
+====
+
+==== Performing a planned shutdown
+
+Gracefully shut down selected virtual machines _before_ starting the upgrade. Once the upgrade completes, manually power the virtual machines back on.
+
+[CAUTION]
+====
+The following are key post-upgrade restart considerations:
+
+* Avoid powering on a large number of virtual machines simultaneously, which can cause CPU and storage I/O spikes (_a boot storm_) that slow down or destabilize the cluster. Restart virtual machines in batches, prioritizing the most critical workloads first.
+
+* The `restoreVM` option in the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] only applies to xref:virtual-machines/live-migration.adoc#_non_migratable_virtual_machines[non-migratable virtual machines] that {harvester-product-name} automatically powers off. Virtual machines that you manually shut down are not automatically powered on after the upgrade.
+====
+
+==== Mitigation measures for live migration
+
+If you prefer to use live migration for write-heavy virtual machines, consider the following mitigation measures:
+
+* Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
+
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+
+* Perform upgrades during periods of low write activity to minimize memory dirtying.
+
 == Before starting an upgrade
 
-Check out the available xref:../installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] to tweak the upgrade strategies and behaviors that best suit your cluster environment.
+You can customize the upgrade strategy for your environment using the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting].
+
+For write-heavy or business-critical virtual machines that may not converge during live migration, review <<#_planned_shutdown_live_migration>> to determine the best approach for your workloads.
 
 == Start an upgrade
 

--- a/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.6/modules/en/pages/upgrades/upgrades.adoc
@@ -162,7 +162,7 @@ If you prefer to use live migration for write-heavy virtual machines, consider t
 
 * Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
 
-* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
 
 * Perform upgrades during periods of low write activity to minimize memory dirtying.
 

--- a/versions/v1.7/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.7/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,5 +1,5 @@
 = Harvester CSI Driver
-:revdate: 2026-07-24
+:revdate: 2026-07-29
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -42,6 +42,12 @@ The Harvester CSI Driver supports the following features:
 | &#10004;
 | &#10004;
 |===
+
+For **ReadWriteOnce (RWO)** volumes, the Harvester CSI Driver hotplugs underlying persistent volumes directly to virtual machines acting as guest nodes.
+
+KubeVirt enforces a hard limit of 256 volumes per virtual machine instance, including non-CSI disks such as the root disk and cloud-init disk. Consequently, a single guest node can realistically host a maximum of 256 CSI volumes.
+
+If too many PVC-dependent workloads are scheduled on the same guest node, volume attachment will fail with the error `VM Schema Invalid: Max Disk Limit (256) Exceeded on Guest Cluster`. To prevent this issue, distribute PVC-dependent workloads across multiple guest nodes or add guest worker nodes.
 
 [CAUTION]
 ====

--- a/versions/v1.7/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.7/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -7,7 +7,7 @@
 == Support Matrix
 
 |===
-| Harvester Version | Supported Terraform Provider | Supported Terraformer
+| {harvester-product-name} Version | Supported Terraform Provider | Supported Terraformer
 
 | https://github.com/harvester/harvester/releases/tag/v1.7.1[v1.7.1]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.7.1[v1.7.1]

--- a/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
@@ -179,7 +179,7 @@ If you prefer to use live migration for write-heavy virtual machines, consider t
 
 * Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
 
-* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
 
 * Perform upgrades during periods of low write activity to minimize memory dirtying.
 

--- a/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-06-05
+:revdate: 2026-07-29
 :page-languages: [en, de, es, fr, ja, pt, zh]
 :page-revdate: {revdate}
 
@@ -114,9 +114,80 @@ Non-migratable virtual machines experience downtime during migration.
 
 For more information, see xref:upgrades/troubleshooting.adoc#_phase_4_upgrade_nodes[Phase 4: Upgrade Nodes].
 
+[#_planned_shutdown_live_migration]
+=== Planned shutdown vs. live migration
+
+Live-migratable virtual machines are automatically migrated during an upgrade. Live migration is recommended for most workloads because it avoids downtime. However, for sensitive or complex workloads requiring predictability, gracefully shutting down virtual machines before the upgrade is the safest approach.
+
+==== When live migration may not converge
+
+Live migration copies a virtual machine's memory pages to the target node while the virtual machine continues to run. If a virtual machine writes to memory faster than its pages can be transferred across the network (a high *dirty rate*), the migration cannot converge. {harvester-product-name} then aborts the migration upon reaching the xref:virtual-machines/live-migration.adoc#_migration_timeouts[completion or progress timeout].
+
+This issue commonly affects write-heavy workloads (such as active databases) where the memory dirty rate exceeds available bandwidth. If these migrations fail to converge within the maintenance window, the upgrade may stall.
+
+==== Comparison
+
+|===
+| Aspect | Live Migration | Planned Shutdown
+
+| Downtime
+| None
+| Brief service interruption
+
+| Convergence risk for write-heavy virtual machines
+| High (risk of failure to converge and abort)
+| None (no migration involved)
+
+| Maintenance window predictability
+| Low (completion time depends on dirty rate and bandwidth)
+| High (predictable shutdown and restart times)
+
+| Operational effort
+| Low (automatic)
+| High (requires planning and downtime coordination)
+
+| Resource overhead during upgrade
+| High (target node required to host the virtual machine during migration)
+| Low (no concurrent copy of virtual machine state)
+|===
+
+[TIP]
+====
+Based on these trade-offs, use live migration by default for any virtual machine that can complete migration within the maintenance window.
+
+Gracefully shut down business-critical or write-heavy virtual machines before starting the upgrade when:
+* Live migration is unlikely to converge within the maintenance window.
+* A predictable, bounded maintenance window is strictly required.
+====
+
+==== Performing a planned shutdown
+
+Gracefully shut down selected virtual machines _before_ starting the upgrade. Once the upgrade completes, manually power the virtual machines back on.
+
+[CAUTION]
+====
+The following are key post-upgrade restart considerations:
+
+* Avoid powering on a large number of virtual machines simultaneously, which can cause CPU and storage I/O spikes (_a boot storm_) that slow down or destabilize the cluster. Restart virtual machines in batches, prioritizing the most critical workloads first.
+
+* The `restoreVM` option in the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] only applies to xref:virtual-machines/live-migration.adoc#_non_migratable_virtual_machines[non-migratable virtual machines] that {harvester-product-name} automatically powers off. Virtual machines that you manually shut down are not automatically powered on after the upgrade.
+====
+
+==== Mitigation measures for live migration
+
+If you prefer to use live migration for write-heavy virtual machines, consider the following mitigation measures:
+
+* Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
+
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+
+* Perform upgrades during periods of low write activity to minimize memory dirtying.
+
 == Before starting an upgrade
 
-Check out the available xref:../installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] to tweak the upgrade strategies and behaviors that best suit your cluster environment.
+You can customize the upgrade strategy for your environment using the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting].
+
+For write-heavy or business-critical virtual machines that may not converge during live migration, review <<#_planned_shutdown_live_migration>> to determine the best approach for your workloads.
 
 == Start an upgrade
 

--- a/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,5 +1,5 @@
 = Harvester CSI Driver
-:revdate: 2026-07-24
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the {harvester-product-name} cluster and hot-plugs volumes to the virtual machines to provide native storage performance.
@@ -45,6 +45,12 @@ The Harvester CSI Driver supports the following features:
 | &#10004;
 | &#10004;
 |===
+
+For **ReadWriteOnce (RWO)** volumes, the Harvester CSI Driver hotplugs underlying persistent volumes directly to virtual machines acting as guest nodes.
+
+KubeVirt enforces a hard limit of 256 volumes per virtual machine instance, including non-CSI disks such as the root disk and cloud-init disk. Consequently, a single guest node can realistically host a maximum of 256 CSI volumes.
+
+If too many PVC-dependent workloads are scheduled on the same guest node, volume attachment will fail with the error `VM Schema Invalid: Max Disk Limit (256) Exceeded on Guest Cluster`. To prevent this issue, distribute PVC-dependent workloads across multiple guest nodes or add guest worker nodes.
 
 [CAUTION]
 ====

--- a/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -5,7 +5,7 @@
 == Support Matrix
 
 |===
-| Harvester Version | Supported Terraform Provider | Supported Terraformer
+| {harvester-product-name} Version | Supported Terraform Provider | Supported Terraformer
 
 | https://github.com/harvester/harvester/releases/tag/v1.8.1[v1.8.1]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.1[v1.8.1]

--- a/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,5 +1,5 @@
 = Terraform Provider
-:revdate: 2026-05-06
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 == Support Matrix

--- a/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -7,6 +7,14 @@
 |===
 | Harvester Version | Supported Terraform Provider | Supported Terraformer
 
+| https://github.com/harvester/harvester/releases/tag/v1.8.1[v1.8.1]
+| https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.1[v1.8.1]
+| https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]
+
+| https://github.com/harvester/harvester/releases/tag/v1.8.0[v1.8.0]
+| https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.0[v1.8.0]
+| https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]
+
 | https://github.com/harvester/harvester/releases/tag/v1.7.1[v1.7.1]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.7.1[v1.7.1]
 | https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]

--- a/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-06-05
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -121,9 +121,80 @@ Non-migratable virtual machines experience downtime during migration.
 
 For more information, see xref:upgrades/troubleshooting.adoc#_phase_4_upgrade_nodes[Phase 4: Upgrade Nodes].
 
+[#_planned_shutdown_live_migration]
+=== Planned shutdown vs. live migration
+
+Live-migratable virtual machines are automatically migrated during an upgrade. Live migration is recommended for most workloads because it avoids downtime. However, for sensitive or complex workloads requiring predictability, gracefully shutting down virtual machines before the upgrade is the safest approach.
+
+==== When live migration may not converge
+
+Live migration copies a virtual machine's memory pages to the target node while the virtual machine continues to run. If a virtual machine writes to memory faster than its pages can be transferred across the network (a high *dirty rate*), the migration cannot converge. {harvester-product-name} then aborts the migration upon reaching the xref:virtual-machines/live-migration.adoc#_migration_timeouts[completion or progress timeout].
+
+This issue commonly affects write-heavy workloads (such as active databases) where the memory dirty rate exceeds available bandwidth. If these migrations fail to converge within the maintenance window, the upgrade may stall.
+
+==== Comparison
+
+|===
+| Aspect | Live Migration | Planned Shutdown
+
+| Downtime
+| None
+| Brief service interruption
+
+| Convergence risk for write-heavy virtual machines
+| High (risk of failure to converge and abort)
+| None (no migration involved)
+
+| Maintenance window predictability
+| Low (completion time depends on dirty rate and bandwidth)
+| High (predictable shutdown and restart times)
+
+| Operational effort
+| Low (automatic)
+| High (requires planning and downtime coordination)
+
+| Resource overhead during upgrade
+| High (target node required to host the virtual machine during migration)
+| Low (no concurrent copy of virtual machine state)
+|===
+
+[TIP]
+====
+Based on these trade-offs, use live migration by default for any virtual machine that can complete migration within the maintenance window.
+
+Gracefully shut down business-critical or write-heavy virtual machines before starting the upgrade when:
+* Live migration is unlikely to converge within the maintenance window.
+* A predictable, bounded maintenance window is strictly required.
+====
+
+==== Performing a planned shutdown
+
+Gracefully shut down selected virtual machines _before_ starting the upgrade. Once the upgrade completes, manually power the virtual machines back on.
+
+[CAUTION]
+====
+The following are key post-upgrade restart considerations:
+
+* Avoid powering on a large number of virtual machines simultaneously, which can cause CPU and storage I/O spikes (_a boot storm_) that slow down or destabilize the cluster. Restart virtual machines in batches, prioritizing the most critical workloads first.
+
+* The `restoreVM` option in the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] only applies to xref:virtual-machines/live-migration.adoc#_non_migratable_virtual_machines[non-migratable virtual machines] that {harvester-product-name} automatically powers off. Virtual machines that you manually shut down are not automatically powered on after the upgrade.
+====
+
+==== Mitigation measures for live migration
+
+If you prefer to use live migration for write-heavy virtual machines, consider the following mitigation measures:
+
+* Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
+
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+
+* Perform upgrades during periods of low write activity to minimize memory dirtying.
+
 == Before starting an upgrade
 
-Check out the available xref:../installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] to tweak the upgrade strategies and behaviors that best suit your cluster environment.
+You can customize the upgrade strategy for your environment using the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting].
+
+For write-heavy or business-critical virtual machines that may not converge during live migration, review <<#_planned_shutdown_live_migration>> to determine the best approach for your workloads.
 
 == Start an upgrade
 

--- a/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/upgrades.adoc
@@ -186,7 +186,7 @@ If you prefer to use live migration for write-heavy virtual machines, consider t
 
 * Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
 
-* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
 
 * Perform upgrades during periods of low write activity to minimize memory dirtying.
 

--- a/versions/v1.9/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.9/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,5 +1,5 @@
 = Harvester CSI Driver
-:revdate: 2026-07-24
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the {harvester-product-name} cluster and hot-plugs volumes to the virtual machines to provide native storage performance.
@@ -45,6 +45,12 @@ The Harvester CSI Driver supports the following features:
 | &#10004;
 | &#10004;
 |===
+
+For **ReadWriteOnce (RWO)** volumes, the Harvester CSI Driver hotplugs underlying persistent volumes directly to virtual machines acting as guest nodes.
+
+KubeVirt enforces a hard limit of 256 volumes per virtual machine instance, including non-CSI disks such as the root disk and cloud-init disk. Consequently, a single guest node can realistically host a maximum of 256 CSI volumes.
+
+If too many PVC-dependent workloads are scheduled on the same guest node, volume attachment will fail with the error `VM Schema Invalid: Max Disk Limit (256) Exceeded on Guest Cluster`. To prevent this issue, distribute PVC-dependent workloads across multiple guest nodes or add guest worker nodes.
 
 [CAUTION]
 ====

--- a/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -5,7 +5,7 @@
 == Support Matrix
 
 |===
-| Harvester Version | Supported Terraform Provider | Supported Terraformer
+| {harvester-product-name} Version | Supported Terraform Provider | Supported Terraformer
 
 | https://github.com/harvester/harvester/releases/tag/v1.8.1[v1.8.1]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.1[v1.8.1]

--- a/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -1,5 +1,5 @@
 = Terraform Provider
-:revdate: 2026-05-06
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 == Support Matrix

--- a/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
+++ b/versions/v1.9/modules/en/pages/integrations/terraform/terraform-provider.adoc
@@ -7,6 +7,14 @@
 |===
 | Harvester Version | Supported Terraform Provider | Supported Terraformer
 
+| https://github.com/harvester/harvester/releases/tag/v1.8.1[v1.8.1]
+| https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.1[v1.8.1]
+| https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]
+
+| https://github.com/harvester/harvester/releases/tag/v1.8.0[v1.8.0]
+| https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.8.0[v1.8.0]
+| https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]
+
 | https://github.com/harvester/harvester/releases/tag/v1.7.1[v1.7.1]
 | https://github.com/harvester/terraform-provider-harvester/releases/tag/v1.7.1[v1.7.1]
 | https://github.com/harvester/terraformer/releases/tag/v1.1.1-harvester[v1.1.1-harvester]

--- a/versions/v1.9/modules/en/pages/storage/storageclass.adoc
+++ b/versions/v1.9/modules/en/pages/storage/storageclass.adoc
@@ -1,5 +1,5 @@
 = StorageClass
-:revdate: 2025-10-20
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 {harvester-product-name} uses StorageClasses to describe how {longhorn-product-name} must provision volumes. {longhorn-product-name} StorageClasses can map to replica policies, node schedule policies, or disk schedule policies created by the cluster administrators. This concept is referred to as _profiles_ in other storage systems.
@@ -208,7 +208,7 @@ The following are the default values for the supported StorageClasses:
 
 * Longhorn V2 Data Engine
 +
-** `cdi.harvesterhci.io/storageProfileCloneStrategy`: `"copy"`
+** `cdi.harvesterhci.io/storageProfileCloneStrategy`: `"csi-clone"`
 ** `cdi.harvesterhci.io/storageProfileVolumeSnapshotClass`: `"longhorn-snapshot"`
 
 * LVM

--- a/versions/v1.9/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.9/modules/en/pages/upgrades/upgrades.adoc
@@ -1,5 +1,5 @@
 = Upgrades
-:revdate: 2026-06-05
+:revdate: 2026-07-29
 :page-revdate: {revdate}
 
 {harvester-product-name} is adopting a new lifecycle strategy that simplifies version management and upgrades. This strategy includes the following:
@@ -121,9 +121,80 @@ Non-migratable virtual machines experience downtime during migration.
 
 For more information, see xref:upgrades/troubleshooting.adoc#_phase_4_upgrade_nodes[Phase 4: Upgrade Nodes].
 
+[#_planned_shutdown_live_migration]
+=== Planned shutdown vs. live migration
+
+Live-migratable virtual machines are automatically migrated during an upgrade. Live migration is recommended for most workloads because it avoids downtime. However, for sensitive or complex workloads requiring predictability, gracefully shutting down virtual machines before the upgrade is the safest approach.
+
+==== When live migration may not converge
+
+Live migration copies a virtual machine's memory pages to the target node while the virtual machine continues to run. If a virtual machine writes to memory faster than its pages can be transferred across the network (a high *dirty rate*), the migration cannot converge. {harvester-product-name} then aborts the migration upon reaching the xref:virtual-machines/live-migration.adoc#_migration_timeouts[completion or progress timeout].
+
+This issue commonly affects write-heavy workloads (such as active databases) where the memory dirty rate exceeds available bandwidth. If these migrations fail to converge within the maintenance window, the upgrade may stall.
+
+==== Comparison
+
+|===
+| Aspect | Live Migration | Planned Shutdown
+
+| Downtime
+| None
+| Brief service interruption
+
+| Convergence risk for write-heavy virtual machines
+| High (risk of failure to converge and abort)
+| None (no migration involved)
+
+| Maintenance window predictability
+| Low (completion time depends on dirty rate and bandwidth)
+| High (predictable shutdown and restart times)
+
+| Operational effort
+| Low (automatic)
+| High (requires planning and downtime coordination)
+
+| Resource overhead during upgrade
+| High (target node required to host the virtual machine during migration)
+| Low (no concurrent copy of virtual machine state)
+|===
+
+[TIP]
+====
+Based on these trade-offs, use live migration by default for any virtual machine that can complete migration within the maintenance window.
+
+Gracefully shut down business-critical or write-heavy virtual machines before starting the upgrade when:
+* Live migration is unlikely to converge within the maintenance window.
+* A predictable, bounded maintenance window is strictly required.
+====
+
+==== Performing a planned shutdown
+
+Gracefully shut down selected virtual machines _before_ starting the upgrade. Once the upgrade completes, manually power the virtual machines back on.
+
+[CAUTION]
+====
+The following are key post-upgrade restart considerations:
+
+* Avoid powering on a large number of virtual machines simultaneously, which can cause CPU and storage I/O spikes (_a boot storm_) that slow down or destabilize the cluster. Restart virtual machines in batches, prioritizing the most critical workloads first.
+
+* The `restoreVM` option in the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] only applies to xref:virtual-machines/live-migration.adoc#_non_migratable_virtual_machines[non-migratable virtual machines] that {harvester-product-name} automatically powers off. Virtual machines that you manually shut down are not automatically powered on after the upgrade.
+====
+
+==== Mitigation measures for live migration
+
+If you prefer to use live migration for write-heavy virtual machines, consider the following mitigation measures:
+
+* Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
+
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+
+* Perform upgrades during periods of low write activity to minimize memory dirtying.
+
 == Before starting an upgrade
 
-Check out the available xref:../installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting] to tweak the upgrade strategies and behaviors that best suit your cluster environment.
+You can customize the upgrade strategy for your environment using the xref:installation-setup/config/settings.adoc#_upgrade_config[`upgrade-config` setting].
+
+For write-heavy or business-critical virtual machines that may not converge during live migration, review <<#_planned_shutdown_live_migration>> to determine the best approach for your workloads.
 
 == Start an upgrade
 

--- a/versions/v1.9/modules/en/pages/upgrades/upgrades.adoc
+++ b/versions/v1.9/modules/en/pages/upgrades/upgrades.adoc
@@ -186,7 +186,7 @@ If you prefer to use live migration for write-heavy virtual machines, consider t
 
 * Configure a dedicated xref:networking/vm-migration-network.adoc[VM migration network] to increase migration bandwidth and isolate migration traffic.
 
-* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information see, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
+* Tune the migration strategy and parameters. You can enable auto-converge or post-copy, adjust the `bandwidthPerMigration` value, or apply migration policies specific to indiviual virtual machines. For more information, see the knowledge base article https://harvesterhci.io/kb/vm_live_migration_policy_and_configuration[VM Live Migration Policy and Configuration].
 
 * Perform upgrades during periods of low write activity to minimize memory dirtying.
 


### PR DESCRIPTION
Scope: v1.6 v1.7, v1.8, v1.9

PRs:
- [1087](https://github.com/harvester/docs/pull/1087): Longhorn V2 CDI `csi-clone`
- [1090](https://github.com/harvester/docs/pull/1090): Planned shutdown vs. live migration
- [1092](https://github.com/harvester/docs/pull/1092): Per-node VM/VMI volume limit for Harvester CSI Driver
- [1093](https://github.com/harvester/docs/pull/1090): Typo fix
- [1094](https://github.com/harvester/docs/pull/1094): Terraform Provider and Terraformer for v1.8.0 and v1.8.1

> Note: The build is failing because of mostly INFO-level errors in the translation files. I cannot fix these issues because they involve other languages. The logs show no errors in the English source files, so we can safely merge the changes in this PR.