### PR TITLE
Add release notes for v1.6.1, v1.7.1, v1.7.2, v1.8.1

### DIFF
--- a/versions/v1.6/modules/en/nav.adoc
+++ b/versions/v1.6/modules/en/nav.adoc
@@ -1,3 +1,8 @@
+// Folder: release-notes:
+
+* Release Notes
+** xref:release-notes/v1.6.1.adoc[]
+
 // Folder: introduction:
 
 * Introduction

--- a/versions/v1.6/modules/en/pages/release-notes/v1.6.1.adoc
+++ b/versions/v1.6/modules/en/pages/release-notes/v1.6.1.adoc
@@ -1,5 +1,5 @@
 = {harvester-product-name} v1.6.1 Release Notes
-:revdate: 2026-07-30
+:revdate: 2026-07-31
 :page-revdate: {revdate}
 
 This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.6/en/introduction/overview.html.
@@ -182,7 +182,7 @@ This section includes only issues identified before the release date. For inform
 |===
 | Component | Version
 
-| CDI
+| Containerized Data Importer (CDI)
 | https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.62.0[v1.62.0]
 
 | KubeVirt

--- a/versions/v1.6/modules/en/pages/release-notes/v1.6.1.adoc
+++ b/versions/v1.6/modules/en/pages/release-notes/v1.6.1.adoc
@@ -1,0 +1,202 @@
+= {harvester-product-name} v1.6.1 Release Notes
+:revdate: 2026-07-30
+:page-revdate: {revdate}
+
+This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.6/en/introduction/overview.html.
+
+== Downloads
+
+=== AMD64
+
+==== Full ISO
+
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-amd64.iso
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-vmlinuz-amd64
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-initrd-amd64
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-rootfs-amd64.squashfs
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-amd64.sha512
+* https://releases.rancher.com/harvester/v1.6.1/version.yaml
+
+==== Net install ISO
+
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-amd64-net-install.iso
+
+=== ARM64
+
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-arm64.iso
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-vmlinuz-arm64
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-initrd-arm64
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-rootfs-arm64.squashfs
+* https://releases.rancher.com/harvester/v1.6.1/harvester-v1.6.1-arm64.sha512
+* https://releases.rancher.com/harvester/v1.6.1/version-arm64.yaml
+
+== Installation
+
+{harvester-product-name} can be installed using the https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/methods/iso-install.html[ISO image], a https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/methods/usb-install.html[bootable USB drive], and https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/methods/pxe-boot-install.html[PXE boot]. For more information, see the https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/requirements.html[Installation] section of the documentation.
+
+[IMPORTANT]
+====
+The {harvester-product-name} installer checks if the hardware meets the https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/requirements.html#_hardware_requirements[minimum requirements] for production use. If any of the checks fail, installation is stopped and warnings are printed to the system console. You can disable this behavior during iPXE installation (for testing purposes) by adding the kernel parameter https://documentation.suse.com/cloudnative/virtualization/v1.6/en/installation-setup/methods/pxe-boot-install.html#_harvester_install_skipcheckstrue[`harvester.install.skipchecks=true`] when you boot the system.
+====
+
+== Upgrades
+
+{harvester-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see https://documentation.suse.com/cloudnative/virtualization/v1.6/en/upgrades/upgrades.html[Upgrades].
+
+== Highlights
+
+=== Experimental features
+
+[NOTE]
+====
+All new features that use Kube-OVN are considered experimental. The Kube-OVN implementation in {harvester-product-name} v1.6 does not support upgrades, virtual machine live migration, and the Harvester Node Driver for guest cluster provisioning.
+====
+
+==== Kube-OVN Operator
+
+The `kubeovn-operator` add-on is a tool for managing Kube-OVN as a secondary container network interface (CNI) on {harvester-product-name} clusters. Kube-OVN provides advanced software-defined networking (SDN) capabilities such as virtual private cloud (VPC) and subnets for virtual machine workloads. When you enable the add-on, it deploys Kube-OVN to your {harvester-product-name} cluster and creates the default `Configuration` CRD, which defines the desired state of the Kube-OVN installation.
+
+https://documentation.suse.com/cloudnative/virtualization/v1.6/en/add-ons/kubeovn-operator.html[Documentation] | https://github.com/harvester/harvester/issues/7397[GitHub issue]
+
+==== Overlay network
+
+The {harvester-product-name} network-controller leverages Kube-OVN to create an OVN-based virtualized network that supports advanced SDN capabilities such as VPCs and subnets for virtual machine workloads. An overlay network represents a virtual layer 2 switch that encapsulates and forwards traffic between virtual machines.
+
+https://documentation.suse.com/cloudnative/virtualization/v1.6/en/networking/vm-network.html#_overlay_network_experimental[Documentation] | https://github.com/harvester/harvester/issues/7397[GitHub issue]
+
+==== Virtual private cloud (VPC)
+
+In {harvester-product-name}, a VPC is a logical network container that you can use to manage and isolate subnets and traffic. {harvester-product-name} provides a default VPC named `ovn-cluster` and allows you to create custom VPCs. At a high level, VPC creation involves enabling the kubeovn-operator add-on, creating an overlay network and a subnet, and linking the two networks.
+
+The VPC implementation in v1.6 enables scalable, isolated L3 and L2 network structures across the cluster. Kube-OVN creates the VPC and its subnets, and manages all L3 logic (routing, NAT, VPC peering, and isolation). {harvester-product-name} defines the overlay networks and provisions virtual machines that are connected to those overlay networks. This architecture provides a clear separation of concerns: Kube-OVN handles SDN, while {harvester-product-name} handles virtualization.
+
+https://youtu.be/CgIKYy4oqms[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/networking/kubeovn-vpc.html[Documentation] | https://github.com/harvester/harvester/issues/7397[GitHub issue]
+
+==== VPC network connectivity
+
+In v1.6, virtual machines can connect with external networks if they are part of a subnet within the default VPC (`ovn-cluster`) and if the `natOutgoing` setting is enabled on that subnet. This setting enables network address translation (NAT) for all traffic leaving the subnet and heading to destinations outside of the VPC.
+
+Communication between virtual machines in different VPCs is also possible. To achieve this, you must configure a VPC peering connection and static routes that define how traffic is forwarded. However, peering is limited to custom VPCs. You cannot establish a peering connection between the default VPC (`ovn-cluster`) and a custom VPC.
+
+https://youtu.be/4AZ2oQ8Ek_A[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/networking/kubeovn-vpc.html#_natoutgoing_setting[Documentation] | https://github.com/harvester/harvester/issues/7397[GitHub issue]
+
+==== Virtual machine isolation
+
+Isolation between virtual machines is typically achieved using either VLANs (in traditional networks) or virtual switches (in Kube-OVN). If you want to isolate virtual machines within the same virtual switch network, you can use subnet access control lists (ACLs) and Kubernetes network policies to achieve the required micro-segmentation.
+
+https://youtu.be/XrZ82q9kdyw[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/networking/vm-isolation.html[Documentation] | https://github.com/harvester/harvester/issues/7397[GitHub issue]
+
+=== Fully supported features
+
+==== Containerized Data Importer (CDI) settings on UI
+
+{harvester-product-name} uses CDI to manage virtual machine image operations for certain StorageClasses. Starting with v1.6, you can use the UI to configure CDI settings when creating or updating a StorageClass. Each field on the *CDI Settings* tab corresponds to an annotation that modifies a specific StorageClass parameter. With this enhancement, you can avoid direct changes to the storage profile or CDI, which may result in unexpected system behavior. Instead, allow the {harvester-product-name} controller to synchronize and persist the storage profile configuration through the use of CDI annotations.
+
+https://youtu.be/yRUjYlS8h-U[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/storage/storageclass.html#_containerized_data_importer_cdi_settings[Documentation] | https://github.com/harvester/harvester/issues/8077[GitHub issue]
+
+==== CPU and memory hotplug
+
+Starting with v1.6, you can increase a virtual machine's CPU and memory resources while it is running. To use this feature, you must enable CPU and memory hotplug when you create the virtual machine. Once the virtual machine is created, you can add more CPU and memory resources at any time. {harvester-product-name} automatically migrates the virtual machine to a node that has the necessary resources.
+
+https://youtu.be/QujSXPH-SfI[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/virtual-machines/cpu-memory-hotplug.html[Documentation] | https://github.com/harvester/harvester/issues/5835[GitHub issue]
+
+==== Live migration progress monitoring
+
+In v1.6, you can monitor the progress of virtual machine live migration directly from the UI. The *Migration* tab of the virtual machine details screen displays migration event information and real-time metrics such as _remaining data_ and _memory transfer rate_. To view the information, you must ensure that the rancher-monitoring add-on is enabled.
+
+https://youtu.be/ZAsYSf7FdXU[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/observability/monitoring.html#_live_migration_status_and_metrics[Documentation] | https://github.com/harvester/harvester/issues/4352[GitHub issue]
+
+==== Online volume expansion
+
+v1.6 allows you to expand volumes that are in use, as long as the underlying storage provider supports the feature. This works for volumes that are attached to a running virtual machine, or that have persistent volume claims (PVCs) connected to a running pod in a guest cluster.
+
+The Longhorn V1 Data Engine fully supports online volume expansion, but the V2 Data Engine currently does not support it. For third-party storage, {harvester-product-name} blocks online volume expansion requests by default. To allow such requests, you must use the `csi-online-expand-validation` setting to validate the storage provider.
+
+https://youtu.be/e273Ve_INjA[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/storage/volumes/edit-volume.html#_online_volume_expansion[Documentation] | GitHub issues: https://github.com/harvester/harvester/issues/2811[#2811] and https://github.com/harvester/harvester/issues/7358[#7358]
+
+==== Third-party storage for guest clusters and workloads
+
+In v1.5, support for third-party storage is limited to provisioning of root and data volumes for virtual machines. v1.6 improves on this by also allowing you to provision guest clusters and their corresponding workloads with third-party storage solutions.
+
+In your guest cluster, you must first create a new StorageClass that references the StorageClass you created in {harvester-product-name} for the third-party storage solution. Then, you must create a PVC using this new StorageClass and mount it to your workload.
+
+https://youtu.be/e273Ve_INjA[Demo] | GitHub issues: https://github.com/harvester/harvester/issues/8075[#8075] and https://github.com/harvester/harvester/issues/8076[#8076]
+
+==== vm-import-controller support for third-party storage
+
+When importing virtual machine images using the vm-import-controller add-on, you can now specify a third-party storage solution instead of using {longhorn-product-name} by default. To use this functionality, simply add the `storageClass` field to the `VirtualMachineImport` spec and specify the StorageClass for the third-party storage solution. {harvester-product-name} handles the import and storage placement without requiring you to perform additional manual steps.
+
+https://youtu.be/nlyrs3jhl2g[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/add-ons/vm-import-controller.html[Documentation] | https://github.com/harvester/harvester/issues/8074[GitHub Issue]
+
+==== Virtual machine migration network
+
+By default, {harvester-product-name} migrates virtual machines over the built-in cluster network `mgmt`, which is limited to one interface and is shared with cluster-wide workloads. If network segregation is required, you can configure a VM migration network to isolate migration traffic and improve bandwidth utilization.
+
+Configuring a VM migration network involves enabling the `vm-migration-network` setting and constructing a Multus `NetworkAttachmentDefinition` CRD. Once the setting is applied, all `virt-handler` pods are restarted to apply the new network configuration.
+
+https://youtu.be/6TSnpNiVZQ0[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.6/en/networking/vm-migration-network.html[Documentation] | https://github.com/harvester/harvester/issues/5848[GitHub issue]
+
+== Enhancements
+
+* https://github.com/harvester/harvester/issues/9222[#9222] [backport v1.6] [ENHANCEMENT] Review the volume detacher behavior
+* https://github.com/harvester/harvester/issues/8766[#8766] [backport v1.6] [ENHANCEMENT] Support reserved memory in terraform-provider-rancher2 and docker-machine-driver-harvester
+
+== Bug fixes
+
+* https://github.com/harvester/harvester/issues/9314[#9314] [backport v1.6] [BUG] VM Image upload issue with 3rd-party storage
+* https://github.com/harvester/harvester/issues/9256[#9256] [backport v1.6] [BUG] v1.6.0-rc6 Cluster Network Config aka Vlan Config for Cluster Network, it's vlan status upon reboot becomes bad
+* https://github.com/harvester/harvester/issues/9249[#9249] [backport v1.6] [BUG] Harvester CDI backend crashes with OOM when HTTP server doesn't support range requests
+* https://github.com/harvester/harvester/issues/9244[#9244] [backport v1.6] [BUG] PCI Passthrough VMs Will Not Boot with Default Harvester Settings in 1.6.0
+* https://github.com/harvester/harvester/issues/9192[#9192] [backport v1.6] [BUG] StorageClass CDI validator miss storage class parameter
+* https://github.com/harvester/harvester/issues/9183[#9183] [BUG] RKE2 Pool & DHCP Guest Cluster LBs Not Working on Harvester v1.6-b192e41f-head + Rancher v2.12.2-alpha4
+* https://github.com/harvester/harvester/issues/9166[#9166] [backport v1.6] [BUG] Fail to create VM with L2VlanNetwork due to "Masquerade interface only implemented with pod network"
+* https://github.com/harvester/harvester/issues/9157[#9157] [backport v1.6] [BUG] Inherit mac address from enslaved interface for mgmt
+* https://github.com/harvester/harvester/issues/9121[#9121] [backport v1.6] [BUG] Network setup error during upgrade from v1.5.1 to v1.6.0
+* https://github.com/harvester/harvester/issues/9106[#9106] [backport v1.6] [BUG] Panic was observed on loadbalancer-harvester webhook
+* https://github.com/harvester/harvester/issues/9049[#9049] [backport v1.6] [BUG] Data Disk dropdown selects the wrong disk
+* https://github.com/harvester/harvester/issues/9038[#9038] [backport v1.6] [BUG] Existing status conditions are not updated
+* https://github.com/harvester/harvester/issues/8993[#8993] [BUG] ui-index and ui-plugin-index settings should use release-harvester-v1.6
+* https://github.com/harvester/harvester/issues/8960[#8960] [backport v1.6] [BUG] VM menu item prompt upward display truncated, can't click on some vm operation button
+* https://github.com/harvester/harvester/issues/8957[#8957] [backport v1.6] [BUG] Deleting a VM Network on mgmt cluster removes the mgmt vlan causing Harvester node to lose connectivity
+* https://github.com/harvester/harvester/issues/8956[#8956] [backport v1.6] [BUG][UI] Soft reboot button in VM VNC console not work
+* https://github.com/harvester/harvester/issues/8952[#8952] [BUG] Unable to select upgrade version on Harvester upgrade dashboard from Rancher v2.12.0
+* https://github.com/harvester/harvester/issues/8942[#8942] [BUG] Can't add member to project in Harvester v1.6.0-rc6 on Rancher v2.12.0 with UI extension v1.6.0-rc6
+* https://github.com/harvester/harvester/issues/8923[#8923] [BUG] Rancher v2.12.0 w/ Harvester v1.6.0-rc6 w/ Harvester UI Extension v1.6.0-rc6 Can't Add Cluster Members to imported Harvester Cluster
+* https://github.com/harvester/harvester/issues/8885[#8885] [BUG] Can't add volume to vm in Harvester from Rancher v2.12.0 integrate mode, available volume is hidden beneath the panel
+* https://github.com/harvester/harvester/issues/8884[#8884] [BUG] Can't migrate vm in Harvester from Rancher v2.12.0 integrate mode, no available target node in the list
+* https://github.com/harvester/harvester/issues/8851[#8851] [BUG] Unable to move namespace to another project on Rancher 2.12.0
+* https://github.com/harvester/harvester/issues/8834[#8834] [backport v1.6] [BUG] Can't add volume, delete and backup vm when vm enabled cpu pinning while cpu manager is `disabled`
+
+== Tasks
+
+* https://github.com/harvester/harvester/issues/9046[#9046] [backport v1.6] [TASK] Should not disable auto-cleanup-system-generated-snapshot during upgrade
+
+== Known issues
+
+This section includes only issues identified before the release date. For information about all issues associated with v1.6.1, https://github.com/harvester/harvester/issues?q=is:issue%20label:known-issue-v1.6.1[this page].
+
+* [BUG] VM Image upload issue with 3rd-party storage [#9313](https://github.com/harvester/harvester/issues/9313)
+
+== Components
+
+|===
+| Component | Version
+
+| CDI
+| https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.62.0[v1.62.0]
+
+| KubeVirt
+| https://github.com/kubevirt/kubevirt/releases/tag/v1.5.2[v1.5.2]
+
+| {longhorn-product-name-tm}
+| https://github.com/longhorn/longhorn/releases/tag/v1.9.2[v1.9.2]
+
+| {rancher-product-name-tm} (embedded)
+| https://github.com/rancher/rancher/releases/tag/v2.12.2[v2.12.2]
+
+| {rke2-product-name}
+| https://github.com/rancher/rke2/releases/tag/v1.33.5%2Brke2r1[v1.33.5]
+
+| SUSE Linux Micro
+| https://github.com/harvester/os2/releases/tag/v1.6-20251015[5.5]
+|===

--- a/versions/v1.7/modules/en/nav.adoc
+++ b/versions/v1.7/modules/en/nav.adoc
@@ -1,3 +1,8 @@
+// Folder: release-notes:
+
+* Release Notes
+** xref:release-notes/v1.7.1.adoc[]
+
 // Folder: introduction:
 
 * Introduction

--- a/versions/v1.7/modules/en/nav.adoc
+++ b/versions/v1.7/modules/en/nav.adoc
@@ -1,6 +1,7 @@
 // Folder: release-notes:
 
 * Release Notes
+** xref:release-notes/v1.7.2.adoc[]
 ** xref:release-notes/v1.7.1.adoc[]
 
 // Folder: introduction:

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
@@ -1,5 +1,5 @@
 = {harvester-product-name} v1.7.1 Release Notes
-:revdate: 2026-07-30
+:revdate: 2026-07-31
 :page-revdate: {revdate}
 
 This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.7/en/introduction/overview.html.
@@ -174,7 +174,7 @@ This section includes only issues identified before the release date. For inform
 |===
 | Component | Version
 
-| CDI
+| Containerized Data Importer (CDI)
 | https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.62.0[v1.62.0]
 
 | Kube-OVN

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
@@ -66,7 +66,7 @@ https://youtu.be/LF_df4GYUxg[Demo] | https://documentation.suse.com/cloudnative/
 
 {harvester-product-name} automatically detects GPUs that support Multi-Instance GPU (MIG)-based partitioning. In v1.7, virtual machines can share vGPU devices backed by NVIDIA GPUs with this capability (such as the A100, H100, and H200). To leverage this feature, you must define the MIG profiles for your GPU, enable the MIG configuration, and enable the vGPU device associated with the MIG configuration.
 
-https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/vgpu-support.html#_mig_backed_vgpu_devices[Documentation] | https://github.com/harvester/harvester/issues/8652[GitHub issue]
+https://youtu.be/lWdVT8SOfPs[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/vgpu-support.html#_mig_backed_vgpu_devices[Documentation] | https://github.com/harvester/harvester/issues/8652[GitHub issue]
 
 ==== Multipath device recognition and management
 
@@ -90,13 +90,13 @@ https://youtu.be/bJ7Ti1-GsU0[Demo] | https://documentation.suse.com/cloudnative/
 
 {harvester-product-name} v1.7 introduces a new option to the `upgrade-config` setting that enables pausing of automatic node upgrades for all or specific cluster nodes. This capability is essential for scenarios requiring manual maintenance or verification on the nodes before the upgrade continues. Once these tasks are completed, you must then explicitly instruct {harvester-product-name} to resume the upgrade process on the target nodes.
 
-https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/upgrades.html#_pausing_node_upgrades[Documentation] | https://github.com/harvester/harvester/issues/8980[GitHub issue]
+https://youtu.be/h4t6WNlaNtw[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/upgrades.html#_pausing_node_upgrades[Documentation] | https://github.com/harvester/harvester/issues/8980[GitHub issue]
 
 ==== Transparent hugepages configuration
 
 Hugepages allow the Linux kernel to allocate memory in chunks larger than the default size. In {harvester-product-name} v1.7, you can configure transparent hugepage settings for each node to increase the overall system performance. Additionally, you can monitor memory allocation for both anonymous (transparent) and persistent (static) hugepages on the {harvester-product-name} UI.
 
-https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/hosts.html#_hugepages[Documentation] | https://github.com/harvester/harvester/issues/5006[GitHub issue]
+https://youtu.be/KqGcbfCoLgo[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/hosts.html#_hugepages[Documentation] | https://github.com/harvester/harvester/issues/5006[GitHub issue]
 
 ==== Virtual machine VLAN trunking
 

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.1.adoc
@@ -1,0 +1,197 @@
+= {harvester-product-name} v1.7.1 Release Notes
+:revdate: 2026-07-30
+:page-revdate: {revdate}
+
+This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.7/en/introduction/overview.html.
+
+== Downloads
+
+=== AMD64
+
+==== Full ISO
+
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-amd64.iso
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-vmlinuz-amd64
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-initrd-amd64
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-rootfs-amd64.squashfs
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-amd64.sha512
+* https://releases.rancher.com/harvester/v1.7.1/version.yaml
+
+==== Net install ISO
+
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-amd64-net-install.iso
+
+=== ARM64
+
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-arm64.iso
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-vmlinuz-arm64
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-initrd-arm64
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-rootfs-arm64.squashfs
+* https://releases.rancher.com/harvester/v1.7.1/harvester-v1.7.1-arm64.sha512
+* https://releases.rancher.com/harvester/v1.7.1/version-arm64.yaml
+
+== Installation
+
+{harvester-product-name} can be installed using the https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/iso-install.html[ISO image], a https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/usb-install.html[bootable USB drive], and https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/pxe-boot-install.html[PXE boot]. For more information, see the https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/requirements.html[Installation] section of the documentation.
+
+[IMPORTANT]
+====
+The {harvester-product-name} installer checks if the hardware meets the https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/requirements.html#_hardware_requirements[minimum requirements] for production use. If any of the checks fail, installation is stopped and warnings are printed to the system console. You can disable this behavior during iPXE installation (for testing purposes) by adding the kernel parameter https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/pxe-boot-install.html#_harvester_install_skipcheckstrue[`harvester.install.skipchecks=true`] when you boot the system.
+
+Starting with v1.7, the installation process includes a mandatory step for configuring the login password for the default `rancher` user account.
+====
+
+== Upgrades
+
+{harvester-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/upgrades.html[Upgrades].
+
+[IMPORTANT]
+====
+{harvester-product-name} v1.7 transitions from wicked to NetworkManager for network management. If the management interface configuration was modified after installation, manual steps are required before upgrading to prevent errors. For more information, see https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/v1-6-x-to-v1-7-x.html#_migration_wicked_to_networkmanager[Migration from wicked to NetworkManager].
+====
+
+== Highlights
+
+=== Experimental features
+
+==== Automatic virtual machine workload rebalancing
+
+The *Virtual Machine Auto Balance* add-on allows {harvester-product-name} to leverage the Kubernetes Descheduler for rebalancing of virtual machine workloads. When enabled on a multi-node cluster, the add-on deploys the Descheduler and a related configuration. The Descheduler evicts pods that are not optimally placed according to administrator-defined policies, enhancing resource utilization and improving cluster performance.
+
+https://youtu.be/LF_df4GYUxg[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/add-ons/virtual-machine-auto-balance.html[Documentation] | https://github.com/harvester/harvester/issues/2311[GitHub issue]
+
+=== Fully supported features
+
+==== MIG-backed vGPU device support
+
+{harvester-product-name} automatically detects GPUs that support Multi-Instance GPU (MIG)-based partitioning. In v1.7, virtual machines can share vGPU devices backed by NVIDIA GPUs with this capability (such as the A100, H100, and H200). To leverage this feature, you must define the MIG profiles for your GPU, enable the MIG configuration, and enable the vGPU device associated with the MIG configuration.
+
+https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/vgpu-support.html#_mig_backed_vgpu_devices[Documentation] | https://github.com/harvester/harvester/issues/8652[GitHub issue]
+
+==== Multipath device recognition and management
+
+Starting with v1.7, {harvester-product-name} supports external storage devices that use multipath I/O (MPIO) to provide redundant data paths while preventing device identification conflicts. Through the `os.externalStorageConfig` setting, you can define the precise configuration (including device blacklisting and whitelisting) that the multipath daemon uses to manage devices and ensure storage stability.
+
+https://youtu.be/CQFf9vbcqX0[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/config/configuration-file.html#_os_externalstorageconfig[Documentation] | https://github.com/harvester/harvester/issues/6975[GitHub issue]
+
+==== NIC hotplugging and hotunplugging
+
+{harvester-product-name} v1.7 allows you to add and remove network interface controllers (NICs) from running live-migratable virtual machines without downtime. When you hotplug a NIC, {harvester-product-name} migrates the virtual machine and connects the specified interface through bridge binding. Virtual machines that were created using the Harvester Node Driver and the Harvester Terraform Provider _do not support_ this feature.
+
+https://youtu.be/x3QA_Bj8lJc[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/virtual-machines/nic-hotplug.html[Documentation] | https://github.com/harvester/harvester/issues/7042[GitHub issue]
+
+==== Open Virtual Format (OVF) support
+
+In {harvester-product-name} v1.7, you can use the *VM Import Controller* add-on to import virtual machines using Open Virtual Appliance (OVA) files, which are a single-file version of OVF packages. {harvester-product-name} supports downloading these OVA files via both HTTP and HTTPS. For endpoints that use HTTPS, you can configure a secret that includes basic authentication credentials for the URL and a CA certificate.
+
+https://youtu.be/bJ7Ti1-GsU0[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/add-ons/vm-import-controller.html[Documentation] | https://github.com/harvester/harvester/issues/4742[GitHub issue]
+
+==== Pausable node upgrades
+
+{harvester-product-name} v1.7 introduces a new option to the `upgrade-config` setting that enables pausing of automatic node upgrades for all or specific cluster nodes. This capability is essential for scenarios requiring manual maintenance or verification on the nodes before the upgrade continues. Once these tasks are completed, you must then explicitly instruct {harvester-product-name} to resume the upgrade process on the target nodes.
+
+https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/upgrades.html#_pausing_node_upgrades[Documentation] | https://github.com/harvester/harvester/issues/8980[GitHub issue]
+
+==== Transparent hugepages configuration
+
+Hugepages allow the Linux kernel to allocate memory in chunks larger than the default size. In {harvester-product-name} v1.7, you can configure transparent hugepage settings for each node to increase the overall system performance. Additionally, you can monitor memory allocation for both anonymous (transparent) and persistent (static) hugepages on the {harvester-product-name} UI.
+
+https://documentation.suse.com/cloudnative/virtualization/v1.7/en/hosts/hosts.html#_hugepages[Documentation] | https://github.com/harvester/harvester/issues/5006[GitHub issue]
+
+==== Virtual machine VLAN trunking
+
+{harvester-product-name} v1.7 allows you to create VLAN trunk networks with multiple, overlapping VLAN ID ranges. When a virtual machine is attached to a VLAN trunk network, the guest operating system and applications are allowed to send and receive packets tagged with any of the VLAN IDs within the specified range.
+
+https://youtu.be/3Gn095RxE-M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/networking/vm-network.html#_vlan_trunk_network[Documentation] | https://github.com/harvester/harvester/issues/766[GitHub issue]
+
+==== Volume snapshots in guest clusters
+
+v0.1.25 of the Harvester CSI Driver supports volume snapshots, providing point-in-time snapshots and restoration for guest cluster workloads. You can create, list, and delete snapshots of persistent volumes, and create new volumes from existing snapshots. To use this feature, you must ensure that the CSI snapshot controller and the required manifests are deployed on the guest cluster.
+
+Harvester CSI Driver v0.1.25 is used in the following {rke2-product-name} versions:
+
+* https://github.com/rancher/rke2/blob/v1.31.14%2Brke2r1/charts/chart_versions.yaml[v1.31.14+rke2r1]
+* https://github.com/rancher/rke2/blob/v1.32.10%2Brke2r1/charts/chart_versions.yaml[v1.32.10+rke2r1]
+* https://github.com/rancher/rke2/blob/v1.33.6%2Brke2r1/charts/chart_versions.yaml[v1.33.6+rke2r1]
+* https://github.com/rancher/rke2/blob/v1.34.2%2Brke2r1/charts/chart_versions.yaml[v1.34.2+rke2r1]
+
+https://youtu.be/VLY-YCIgHsE[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.7/en/integrations/rancher/csi-driver.html#_volume_snapshots[Documentation] | https://github.com/harvester/harvester/issues/3778[GitHub issue]
+
+== Security fixes
+
+The interactive installer now allows you to reset the operating system's default login password before proceeding to other configuration screens, ensuring the password is updated before remote network access to the host is enabled. This prevents attackers from gaining unauthorized network access to the host via a remote shell (SSH) in environments that are exposed to untrusted locations. For more information, see the security advisory for https://github.com/harvester/harvester/security/advisories/GHSA-6g8q-hp2j-gvwv[CVE-2025-62877].
+
+== Deprecations and removals 
+
+=== Legacy BIOS booting
+
+Support for legacy BIOS booting is deprecated in v1.7 and will be removed in a later release. Existing {harvester-product-name} clusters that use this boot mode will continue to function, but upgrading to later versions may require re-installation in UEFI mode. To avoid issues and disruptions, use UEFI in new installations.
+
+== Bug fixes
+
+* https://github.com/harvester/harvester/issues/10012[#10012] [BUG] Can't restore from snapshot replace existing
+* https://github.com/harvester/harvester/issues/9979[#9979] [backport v1.7] [BUG] Upgrading from v1.6.x to v1.7.0 stuck due to the incomplete kubeovn-operator upgrade
+* https://github.com/harvester/harvester/issues/9976[#9976] [BUG] Addon managed DHCP is not working on Harvester 1.7.1-rc2
+* https://github.com/harvester/harvester/issues/9965[#9965] [backport v1.7] [BUG] upgrade stuck due to the mismatch instance-manager checksum
+* https://github.com/harvester/harvester/issues/9947[#9947] [backport v1.7] [BUG] Upgrading to v1.7.1-rc1 is stuck due to longhorn-manager image handle mismatch
+* https://github.com/harvester/harvester/issues/9931[#9931] [BUG] Failed to upload Harvester ISO to create upgrade image in server-version setting
+* https://github.com/harvester/harvester/issues/9926[#9926] [backport v1.7] [BUG] Not able to create VirtualMachines with persistent vTPM and UEFI on Harvester 1.7.0 version 
+* https://github.com/harvester/harvester/issues/9872[#9872] [backport v1.7] [GUI] [BUG] Raw image upload breaks when using external storage
+* https://github.com/harvester/harvester/issues/9869[#9869] [backport v1.7] [BUG] Raw image upload breaks when using external storage
+* https://github.com/harvester/harvester/issues/9861[#9861] [backport v1.7] [BUG] Failed upgrade from 1.6.1 to 1.7.0
+* https://github.com/harvester/harvester/issues/9830[#9830] [backport v1.7] [BUG] VMs cannot get IPs from vm-dhcp-controller when names differ in IPPool and NAD
+* https://github.com/harvester/harvester/issues/9789[#9789] [backport v1.7] [BUG] VMs created from a template which is generated from another VM cannot boot after shutdown 
+* https://github.com/harvester/harvester/issues/9787[#9787] [backport v1.7] [BUG] Fail to enable the kubeovn-operator add-on in Harvester v1.7.0
+* https://github.com/harvester/harvester/issues/9783[#9783] [backport v1.7] [BUG] fine tune UI logic to not inject maxSockets on arm clusters
+* https://github.com/harvester/harvester/issues/9781[#9781] [backport v1.7] [BUG] Upgrade from v1.6.x to v1.7.x may result in host IP address change when using DHCP
+* https://github.com/harvester/harvester/issues/9758[#9758] [BUG] All VMs was Off after migrate from v1.6.0 to v1.7.0-rc7 caused by vm migration failed
+* https://github.com/harvester/harvester/issues/9722[#9722] [backport v1.7] [BUG] Can't completely delete airgapped upgrade image when clicking delete button, prompt error message
+* https://github.com/harvester/harvester/issues/9707[#9707] [backport v1.7] [BUG] Click `View in API` of resource always direct to empty page
+* https://github.com/harvester/harvester/issues/9675[#9675] [backport v1.7] [BUG] Add bridged virtio NIC to VM via Edit Config triggers live migration on single node cluster
+* https://github.com/harvester/harvester/issues/9635[#9635] [backport v1.7] [BUG] Can not hot-plugging on a VM has management network with bridge-bond and virtio
+* https://github.com/harvester/harvester/issues/9634[#9634] [backport v1.7] [BUG] Add Network via Edit Config triggers hotplug NIC before user choosing on popup box
+* https://github.com/harvester/harvester/issues/9591[#9591] [backport v1.7] [BUG] terraform apply same logic storage-network setting cannot pass
+* https://github.com/harvester/harvester/issues/9542[#9542] [backport v1.7] [BUG] Clone VM, but the cloned one stuck in starting
+* https://github.com/harvester/harvester/issues/5186[#5186] [BUG] Cannot create Image from URL with query string
+* https://github.com/harvester/harvester/issues/9760[#9760] [backport v1.7] [BUG] Node status shows Cordoned when the node is powered off
+* https://github.com/harvester/harvester/issues/9756[#9756] [backport v1.7] [BUG] Enable/DisableCPUManager return 500 not 400 when Enable/DisableCPUManager on node already enable/disable
+
+== Known issues
+
+This section includes only issues identified before the release date. For information about all issues associated with v1.7.1, see https://github.com/harvester/harvester/issues?q=is:issue%20label:known-issue-v1.7.1[this page].
+
+* https://github.com/harvester/harvester/issues/9399[#9399] [BUG] PCI vGPU USB device failed to pass through due to . in the hostDevices.name
+* https://github.com/harvester/harvester/issues/9597[#9597] [BUG] Upgrade v1.7.0 stuck in node post-draining
+* https://github.com/harvester/harvester/issues/9619[#9619] [BUG] Add Network via Edit Config triggers hotplug NIC before user choosing on popup box
+* https://github.com/harvester/harvester/issues/9660[#9660] [BUG] Add bridged virtio NIC to VM via Edit Config triggers live migration on single node cluster
+* https://github.com/harvester/harvester/issues/9714[#9714] [BUG] LH v2 Snapshot Stuck in Deletion
+* https://github.com/harvester/harvester/issues/9738[#9738] [BUG] Upgrade stuck indefinitely at the apply-manifest phase due to the pending-upgrade fleet
+* https://github.com/harvester/harvester/issues/9751[#9751] [BUG] After upgrade from v1.6.1 to v1.7.0-rc6, Running VM show message "Restart action is required ..."
+* https://github.com/harvester/harvester/issues/9990[#9990] [BUG] When upgrade, wrong ISO checksum doest not detect and report by the system
+
+== Components
+
+|===
+| Component | Version
+
+| CDI
+| https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.62.0[v1.62.0]
+
+| Kube-OVN
+| https://github.com/kubeovn/kube-ovn/releases/tag/v1.14.10[v1.14.10]
+
+| KubeVirt
+| https://github.com/kubevirt/kubevirt/releases/tag/v1.6.3[v1.6.3]
+
+| {longhorn-product-name-tm}
+| https://github.com/longhorn/longhorn/releases/tag/v1.10.2[v1.10.2]
+
+| {rancher-product-name-tm} (embedded)
+| https://github.com/rancher/rancher/releases/tag/v2.13.1[v2.13.1]
+
+| {rke2-product-name}
+| https://github.com/rancher/rke2/releases/tag/v1.34.3%2Brke2r3[v1.34.3+rke2r3]
+
+| SUSE Linux Micro
+| https://github.com/harvester/os2/releases/tag/v1.7-20260209[6.1]
+|===

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
@@ -1,0 +1,99 @@
+= {harvester-product-name} v1.7.2 Release Notes
+:revdate: 2026-07-30
+:page-revdate: {revdate}
+
+This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.7/en/introduction/overview.html.
+
+== Downloads
+
+=== AMD64
+
+==== Full ISO
+
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-amd64.iso
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-vmlinuz-amd64
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-initrd-amd64
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-rootfs-amd64.squashfs
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-amd64.sha512
+* https://releases.rancher.com/harvester/v1.7.2/version.yaml
+
+==== Net install ISO
+
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-amd64-net-install.iso
+
+=== ARM64
+
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-arm64.iso
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-vmlinuz-arm64
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-initrd-arm64
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-rootfs-arm64.squashfs
+* https://releases.rancher.com/harvester/v1.7.2/harvester-v1.7.2-arm64.sha512
+* https://releases.rancher.com/harvester/v1.7.2/version-arm64.yaml
+
+== Installation
+
+{harvester-product-name} can be installed using the https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/iso-install.html[ISO image], a https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/usb-install.html[bootable USB drive], and https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/methods/pxe-boot-install.html[PXE boot]. For more information, see the https://documentation.suse.com/cloudnative/virtualization/v1.7/en/installation-setup/requirements.html[Installation] section of the documentation.
+
+[IMPORTANT]
+====
+The installation process includes a mandatory step for configuring the login password for the default `rancher` user account.
+====
+
+== Upgrades
+
+{harvester-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see https://documentation.suse.com/cloudnative/virtualization/v1.7/en/upgrades/upgrades.html[Upgrades].
+
+[IMPORTANT]
+====
+The upgrade path was improved to ensure bonded network interfaces (such as `mgmt-bo`) retain their correct names after a reboot. The upgrade script now reads the unique permanent hardware address of each bonded NIC, preventing interface name shifting and potential network outages during cluster upgrades.
+====
+
+== Enhancements
+
+* https://github.com/harvester/harvester/issues/9301[#9301] [ENHANCEMENT] need tool to assist in verifying network config before upgrade to v1.7.x
+
+== Bug fixes
+
+* https://github.com/harvester/harvester/issues/11045[#11045] [BUG] rancher-monitoring hung on v1.7.2-rc3
+* https://github.com/harvester/harvester/issues/10983[#10983] [BUG] VirtualMachine generation is showing as incorrect in VM list after upgrade
+* https://github.com/harvester/harvester/issues/10940[#10940] [BUG] Upgrade does not enter "Upgrade Nodes" after succeeded "Upgrade System Services"
+* https://github.com/harvester/harvester/issues/10790[#10790] [backport v1.7] [BUG] `ifname=` kernel args don't always work to rename network interfaces
+* https://github.com/harvester/harvester/issues/10602[#10602] [backport v1.7] [BUG] VMI has been deleted but VM stucks in Terminating
+* https://github.com/harvester/harvester/issues/10598[#10598] [BUG] Delete VM after upgrade to v1.7.2-rc1, VMI was deleted but VM stucks in Terminating
+* https://github.com/harvester/harvester/issues/10548[#10548] [BUG] CSI volume attachment fails on Rancher 2.13.5 (RKE2 v1.34.7+rke2r1) + Harvester 1.7-head
+* https://github.com/harvester/harvester/issues/10531[#10531] [backport v1.7] [BUG] Upgrade could fail without retrying when entering the node upgrade phase
+* https://github.com/harvester/harvester/issues/10516[#10516] [backport v1.7] [BUG] storage-validator : offline volume expansion test fails for Dell CSI drivers
+* https://github.com/harvester/harvester/issues/10510[#10510] [backport v1.7] [BUG] VM Network disappeared after a v1.7.1 to v1.8.0-rc5 upgrade
+* https://github.com/harvester/harvester/issues/10507[#10507] [backport v1.7] [BUG] Failed to upgrade from v1.7.1 to v1.8.0-rc5, stuck in third node `Pre-draining` state to wait vm migration start
+* https://github.com/harvester/harvester/issues/10505[#10505] [backport v1.7] [BUG] pcidevice passthorugh is broken on VM with hot plugged volume
+* https://github.com/harvester/harvester/issues/10463[#10463] [backport v1.7] [BUG] Harvester 1.7.1 Upgrade (aarch64/arm64) post-drain-* Pods Fail
+* https://github.com/harvester/harvester/issues/10446[#10446] [backport v1.7] [BUG] NIC persistent naming workaround fails in bonded environments
+* https://github.com/harvester/harvester/issues/10445[#10445] [backport v1.7] [BUG] augeas package missing
+* https://github.com/harvester/harvester/issues/10435[#10435] [BUG] Excessive CPU utilization on the first controller plane node
+
+== Components
+
+|===
+| Component | Version
+
+| CDI
+| https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.64.0[v1.64.0]
+
+| Kube-OVN
+| https://github.com/kubeovn/kube-ovn/releases/tag/v1.14.10[v1.14.10]
+
+| KubeVirt
+| https://github.com/kubevirt/kubevirt/releases/tag/v1.6.6[v1.6.6]
+
+| {longhorn-product-name-tm}
+| https://github.com/longhorn/longhorn/releases/tag/v1.10.2[v1.10.2]
+
+| {rancher-product-name-tm} (embedded)
+| https://github.com/rancher/rancher/releases/tag/v2.13.3[v2.13.3]
+
+| {rke2-product-name}
+| https://github.com/rancher/rke2/releases/tag/v1.34.9%2Brke2r1[v1.34.9+rke2r1]
+
+| SUSE Linux Micro
+| https://github.com/harvester/os2/releases/tag/v1.7-20260707[6.1]
+|===

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
@@ -4,6 +4,30 @@
 
 This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.7/en/introduction/overview.html.
 
+[WARNING]
+====
+*Hotfix required for `rancher/harvester:v1.7.2`*
+
+The `rancher/harvester:v1.7.2` image is affected by a https://github.com/harvester/harvester/issues/11129[regression issue] that prevents non-admin {rancher-product-name-tm} users from saving Kubernetes version changes and provisioning downstream clusters for {harvester-product-name}-backed {rke2-short-name} guest clusters.
+
+To mitigate this issue, use the hotfix image `rancher/harvester:v1.7.2-hotfix-11161`. You can retag this image to overwrite `rancher/harvester:v1.7.2`.
+
+. Pull and retag the image on each node.
++
+[,shell]
+----
+docker pull rancher/harvester:v1.7.2-hotfix-11161
+docker tag rancher/harvester:v1.7.2-hotfix-11161 rancher/harvester:v1.7.2
+----
+
+. Restart the {harvester-product-name} deployment.
++
+[,shell]
+----
+kubectl rollout restart deployment/harvester -n harvester-system
+----
+====
+
 == Downloads
 
 === AMD64

--- a/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
+++ b/versions/v1.7/modules/en/pages/release-notes/v1.7.2.adoc
@@ -1,5 +1,5 @@
 = {harvester-product-name} v1.7.2 Release Notes
-:revdate: 2026-07-30
+:revdate: 2026-07-31
 :page-revdate: {revdate}
 
 This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.7/en/introduction/overview.html.
@@ -100,7 +100,7 @@ The upgrade path was improved to ensure bonded network interfaces (such as `mgmt
 |===
 | Component | Version
 
-| CDI
+| Containerized Data Importer (CDI)
 | https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.64.0[v1.64.0]
 
 | Kube-OVN

--- a/versions/v1.8/modules/en/nav.adoc
+++ b/versions/v1.8/modules/en/nav.adoc
@@ -1,7 +1,9 @@
-// Folder: introduction:
+// Folder: release-notes:
 
 * Release Notes
 ** xref:release-notes/v1.8.1.adoc[]
+
+// Folder: introduction:
 
 * Introduction
 ** xref:introduction/overview.adoc[]

--- a/versions/v1.8/modules/en/nav.adoc
+++ b/versions/v1.8/modules/en/nav.adoc
@@ -1,5 +1,8 @@
 // Folder: introduction:
 
+* Release Notes
+** xref:release-notes/v1.8.1.adoc[]
+
 * Introduction
 ** xref:introduction/overview.adoc[]
 ** xref:introduction/deploy-ha-cluster.adoc[]

--- a/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
+++ b/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
@@ -131,46 +131,46 @@ https://youtu.be/KK1VynmMVJo[Demo] | https://documentation.suse.com/cloudnative/
 
 == Features
 
-* [backport v1.8] [FEATURE] Allow particular ports access as default security policy https://github.com/harvester/harvester/issues/10327[#10327]
+* https://github.com/harvester/harvester/issues/10327[#10327] [backport v1.8] [FEATURE] Allow particular ports access as default security policy
 
 == Enhancements
 
-* [backport v1.8] [ENHANCEMENT] Relax LB webhook with more backward compatibility https://github.com/harvester/harvester/issues/10528[#10528]
-* [backport v1.8] [ENHANCEMENT] Block parent vGPU device enable/disable actions https://github.com/harvester/harvester/issues/10439[#10439]
-* [backport v1.8] [ENHANCEMENT] Extra VM live migration during upgrade https://github.com/harvester/harvester/issues/10365[#10365]
-* [backport v1.8] [ENHANCEMENT] Support Storage Migration for VMs Restored from Snapshot or Backup https://github.com/harvester/harvester/issues/10353[#10353]
-* [backport v1.8] [ENHANCEMENT] Enhance the resource-quota processing when overhead-ratio is adjusted https://github.com/harvester/harvester/issues/10246[#10246]
-* [TASK] Bump Go version to 1.26 for v1.8.1 https://github.com/harvester/harvester/issues/10734[#10734]
-* [TASK] Component updates for v1.8.1 https://github.com/harvester/harvester/issues/10566[#10566]
+* https://github.com/harvester/harvester/issues/10528[#10528] [backport v1.8] [ENHANCEMENT] Relax LB webhook with more backward compatibility
+* https://github.com/harvester/harvester/issues/10439[#10439] [backport v1.8] [ENHANCEMENT] Block parent vGPU device enable/disable actions
+* https://github.com/harvester/harvester/issues/10365[#10365] [backport v1.8] [ENHANCEMENT] Extra VM live migration during upgrade
+* https://github.com/harvester/harvester/issues/10353[#10353] [backport v1.8] [ENHANCEMENT] Support Storage Migration for VMs Restored from Snapshot or Backup
+* https://github.com/harvester/harvester/issues/10246[#10246] [backport v1.8] [ENHANCEMENT] Enhance the resource-quota processing when overhead-ratio is adjusted
+* https://github.com/harvester/harvester/issues/10734[#10734] [TASK] Bump Go version to 1.26 for v1.8.1
+* https://github.com/harvester/harvester/issues/10566[#10566] [TASK] Component updates for v1.8.1
 
-== Bug Fixes
+== Bug fixes
 
-* [BUG] rancher-monitoring can't be enabled in v1.8.1-rc2 https://github.com/harvester/harvester/issues/11019[#11019]
-* [Doc] Update the lvm doc with right path to addon yaml https://github.com/harvester/harvester/issues/10798[#10798]
-* [backport v1.8] [BUG] `ifname=` kernel args don't always work to rename network interfaces https://github.com/harvester/harvester/issues/10789[#10789]
-* [BUG] Upgrade from v1.8.0 to v1.8-head stuck at waiting CAPI cluster fleet-local/local generation bump https://github.com/harvester/harvester/issues/10719[#10719]
-* [BUG] Can't enable SR-IOV GPU on https://github.com/harvester/harvester/issues/10707[#10707]
-* [backport v1.8] [BUG] install.wipe_disks_list should not error out if the disk doesn't exist https://github.com/harvester/harvester/issues/10613[#10613]
-* [backport v1.8] [BUG] f29abc8d airgapped master build fails to render dashboard https://github.com/harvester/harvester/issues/10577[#10577]
-* [backport v1.8] [BUG] Upgrade from v1.7.x to v1.8.0 stuck in Post-draining when storage-network is configured with RWX volumes https://github.com/harvester/harvester/issues/10537[#10537]
-* [backport v1.8] [BUG] Upgrade could fail without retrying when entering the node upgrade phase https://github.com/harvester/harvester/issues/10530[#10530]
-* [backport v1.8] [BUG] storage-validator : offline volume expansion test fails for Dell CSI drivers https://github.com/harvester/harvester/issues/10515[#10515]
-* [backport v1.8] [BUG] Stop using `rancher/kubectl` image https://github.com/harvester/harvester/issues/10467[#10467]
-* [backport v1.8] [BUG] pcidevice passthorugh is broken on VM with hot plugged volume https://github.com/harvester/harvester/issues/10371[#10371]
-* [backport v1.8] [BUG] UI shows incorrect info when deleting storage https://github.com/harvester/harvester/issues/10338[#10338]
-* [BUG] node names not listed under node scheduling while creating a VM in UI https://github.com/harvester/harvester/issues/10189[#10189]
-* [BUG] Rancher v2.14.0-alpha9 has chance to fail to provision RKE2 v1.35 guest cluster https://github.com/harvester/harvester/issues/10188[#10188]
-* [BUG] Virtual Machine's Node Scheduling Rules Are Incorrectly Truncated https://github.com/harvester/harvester/issues/9334[#9334]
-* [BUG] Can not reset node scheduling of a VM to `run on all available nodes` https://github.com/harvester/harvester/issues/9142[#9142]
+* https://github.com/harvester/harvester/issues/11019[#11019] [BUG] rancher-monitoring can't be enabled in v1.8.1-rc2
+* https://github.com/harvester/harvester/issues/10798[#10798] [Doc] Update the lvm doc with right path to addon yaml
+* https://github.com/harvester/harvester/issues/10789[#10789] [backport v1.8] [BUG] `ifname=` kernel args don't always work to rename network interfaces
+* https://github.com/harvester/harvester/issues/10719[#10719] [BUG] Upgrade from v1.8.0 to v1.8-head stuck at waiting CAPI cluster fleet-local/local generation bump
+* https://github.com/harvester/harvester/issues/10707[#10707] [BUG] Can't enable SR-IOV GPU on
+* https://github.com/harvester/harvester/issues/10613[#10613] [backport v1.8] [BUG] install.wipe_disks_list should not error out if the disk doesn't exist
+* https://github.com/harvester/harvester/issues/10577[#10577] [backport v1.8] [BUG] f29abc8d airgapped master build fails to render dashboard
+* https://github.com/harvester/harvester/issues/10537[#10537] [backport v1.8] [BUG] Upgrade from v1.7.x to v1.8.0 stuck in Post-draining when storage-network is configured with RWX volumes
+* https://github.com/harvester/harvester/issues/10530[#10530] [backport v1.8] [BUG] Upgrade could fail without retrying when entering the node upgrade phase
+* https://github.com/harvester/harvester/issues/10515[#10515] [backport v1.8] [BUG] storage-validator : offline volume expansion test fails for Dell CSI drivers
+* https://github.com/harvester/harvester/issues/10467[#10467] [backport v1.8] [BUG] Stop using `rancher/kubectl` image
+* https://github.com/harvester/harvester/issues/10371[#10371] [backport v1.8] [BUG] pcidevice passthorugh is broken on VM with hot plugged volume
+* https://github.com/harvester/harvester/issues/10338[#10338] [backport v1.8] [BUG] UI shows incorrect info when deleting storage
+* https://github.com/harvester/harvester/issues/10189[#10189] [BUG] node names not listed under node scheduling while creating a VM in UI
+* https://github.com/harvester/harvester/issues/10188[#10188] [BUG] Rancher v2.14.0-alpha9 has chance to fail to provision RKE2 v1.35 guest cluster
+* https://github.com/harvester/harvester/issues/9334[#9334] [BUG] Virtual Machine's Node Scheduling Rules Are Incorrectly Truncated
+* https://github.com/harvester/harvester/issues/9142[#9142] [BUG] Can not reset node scheduling of a VM to `run on all available nodes`
 
-== Known Issues
+== Known issues
 
 This section includes only issues identified before the release date. For information about all issues associated with v1.8.1, see https://github.com/harvester/harvester/issues?q=is:issue%20label:known-issue-v1.8.1[this page].
 
-* [BUG] v1.7.x → v1.8.0 OS-swap leaves two p11-kit files all-NUL in /usr/share on ~1/3 of nodes; breaks every TLS user on that host (containerd, Longhorn engine-image, kubelet) https://github.com/harvester/harvester/issues/10687[#10687]
-* [BUG] After upgraded to three Nodes with witness role to v1.8.0-rc6, vm failed to migrate with error "Kubevirt not ready" https://github.com/harvester/harvester/issues/10447[#10447]
-* [BUG] Failed to migrate VM after eject the windows image from CDROM device https://github.com/harvester/harvester/issues/10221[#10221]
-* [BUG] Fail to enable rancher-logging after negative upgrade cases https://github.com/harvester/harvester/issues/10220[#10220]
+* https://github.com/harvester/harvester/issues/10687[#10687] [BUG] v1.7.x → v1.8.0 OS-swap leaves two p11-kit files all-NUL in /usr/share on ~1/3 of nodes; breaks every TLS user on that host (containerd, Longhorn engine-image, kubelet)
+* https://github.com/harvester/harvester/issues/10447[#10447] [BUG] After upgraded to three Nodes with witness role to v1.8.0-rc6, vm failed to migrate with error "Kubevirt not ready"
+* https://github.com/harvester/harvester/issues/10221[#10221] [BUG] Failed to migrate VM after eject the windows image from CDROM device
+* https://github.com/harvester/harvester/issues/10220[#10220] [BUG] Fail to enable rancher-logging after negative upgrade cases
 
 == Components
 

--- a/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
+++ b/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
@@ -51,81 +51,91 @@ For more information, see issue https://github.com/harvester/harvester/issues/10
 
 == Highlights
 
-=== In-place storage live migration
+=== Experimental features
 
-In {harvester-product-name} v1.8.0, you can seamlessly migrate a running VM's disks (or a subset of them) between different storage providers, such as {longhorn-product-name} or externally supported CSI volumes without any downtime. The guest OS remains completely unaware of the underlying storage transfer, ensuring minimal disruption to active workloads. This new capability includes full UI and API support with real-time progress tracking, as well as built-in safety mechanisms that verify destination capacity and temporarily block conflicting operations (like host-to-host live migrations) until the storage transfer is complete.
+=== Standalone Upgrade Manager
 
-https://youtu.be/3n_g1TYeeSQ[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/storage/storage-migration.html[Documentation] | https://github.com/harvester/harvester/issues/8285[GitHub issue]
-
-=== Live CD-ROM insertion and ejection
-
-{harvester-product-name} v1.8.0 introduces dynamic management for CD-ROM volumes, allowing users to insert or eject ISO images while a VM is running. While adding or removing the CD-ROM device itself still typically necessitates a reboot, swapping the media within that device is now seamless. Additionally, VMs with mounted CD-ROMs are live migratable.
-
-https://youtu.be/jucSGtUyPVA[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cdrom-hotplug.html[Documentation] | https://github.com/harvester/harvester/issues/9261[GitHub issue]
-
-=== Optimized {longhorn-product-name} resource reservations
-
-{harvester-product-name} v1.8.0 introduces reduced unnecessary CPU and memory consumption for clusters utilizing third-party storage solutions. {harvester-product-name} now detects when external storage is in use and dynamically lowers {longhorn-product-name}'s resource reservations. This update also introduces configurable options for users to manually adjust these allocations, improving overall cluster efficiency and freeing up resources for other workloads without impacting core {longhorn-product-name} functionalities.
-
-https://youtu.be/YdsF-UFiYyE[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/config/settings.html#_instance_manager_resources[Documentation] | https://github.com/harvester/harvester/issues/7867[GitHub issue]
-
-=== Pod Security Admission (PSA) support
-
-{harvester-product-name} v1.8.0 supports Pod Security Admission (PSA) to enforce Pod Security Standards (PSS). Built-in Kubernetes that validates and mutates the admission policies are used to enforce these standards on {harvester-product-name}'s system namespaces. This implementation guarantees that system-specific workloads remain unaffected and ensures a seamless upgrade path from non-PSA to PSA-enabled images. User namespaces remain unenforced, by default, preserving the flexibility for users to define their own security levels or independently deploy external policy engines (such as Kyverno, OPA Gatekeeper, or Kubewarden) without bloating the core upgrade path.
-
-https://youtu.be/_zi3vC1T2ro[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/security-resilience/pod-security-standards.html[Documentation] | https://github.com/harvester/harvester/issues/8196[GitHub issue]
-
-=== PVC Backup and Restore via harvester-csi-driver for Guest Cluster Workloads
-
-{harvester-product-name} v1.8.0 enables backup and restore operations for guest cluster workloads using the harvester-csi-driver. This allows users to protect their workload data by creating backups of Persistent Volume Claims (PVCs) in the guest cluster, which are then stored in the underlying storage provider (now only support {longhorn-product-name}) of the {harvester-product-name} cluster. Users can easily restore these backups to recover from data loss or to migrate workloads between clusters, providing enhanced data protection for applications running within {harvester-product-name}-managed guest clusters.
-
-https://youtu.be/GPecK2ONwcU[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/csi-driver.html#_volume_backups[Documentation] | https://github.com/harvester/harvester/issues/2661[GitHub issue]
-
-=== VM Pending Restart Notifications
-
-{harvester-product-name} v1.8.0 UI now proactively alerts users when a Virtual Machine requires a restart to fully apply configuration changes, such as interface binding updates or specific CPU/memory modifications. The dashboard continuously polls the VM's status conditions and displays a "Pending Restart" indicator when necessary. This prevents unapplied changes from silently blocking future live updates or resource hotplug operations, ensuring users can promptly resolve the state using the standard UI restart action.
-
-https://youtu.be/pg23e9eQh5M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/edit-vm.html#_pending_changes_notification[Documentation] | https://github.com/harvester/harvester/issues/8411[GitHub issue]
-
-=== Configurable VM CPU Models for Live Migration
-
-{harvester-product-name} v1.8.0 addresses an issue where live migrating VMs between hosts with different CPU generations (for example, AMD Ryzen 5th Gen to 3rd Gen) would fail due to strict CPU feature-matching checks by KubeVirt/libvirt. Users can now explicitly define a specific CPU model (for example, IvyBridge, host-model, or default) for a VM during creation via the {harvester-product-name} UI or Terraform provider. This ensures the VM is only scheduled and migrated across nodes that support the selected baseline CPU model, enabling reliable backward compatibility and successful live migrations in mixed-hardware clusters.
-
-https://youtu.be/TVQSRsJ6K4M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cpu-model-selection.html[Documentation] | https://github.com/harvester/harvester/issues/3015[GitHub issue]
-
-=== Interactive VPC Network Topology
-
-In {harvester-product-name} v1.8.0, a dynamic visual topology diagram is added to the VPC detail page, providing a clear representation of logical switches and network relationships. The interactive map displays the complete hierarchy from VPCs and Subnets to Overlay Networks and individual VMs while accurately reflecting VM power states by graying out stopped or paused instances. Users can easily navigate complex network architectures using pan and zoom controls, legend toggles for filtering node types, click-to-highlight node relationships, and clickable VPC peering links that seamlessly redirect to associated topology pages.
-
-https://youtu.be/b9QHwFFkSao[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/kubeovn-vpc.html#_vpc_topology[Documentation] | https://github.com/harvester/harvester/issues/9748[GitHub issue]
-
-=== Fine-Grained {harvester-product-name} RBAC Roles for Rancher
-
-{harvester-product-name} v1.8.0 introduces {harvester-product-name}-specific Role-Based Access Control (RBAC) roles within Rancher, fully enforced at the backend API-level. This allows administrators to assign highly specific, granular permissions based on user needs. New capabilities include read-only roles for viewing VM definitions and monitoring data, specialized roles for non-admins to manage hardware devices (PCI, USB, vGPU), and scoped "VM Admin" roles restricted to editing VMs within specific namespaces without granting access to underlying infrastructure like images or networks. Role permissions are additive, and for security purposes, sensitive cluster-level configurations, such as logging facilities remain strictly editable only by cluster admins, with non-admins restricted to read-only access.
-
-https://youtu.be/cm7fCswrrz8[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/rancher-rbac.html[Documentation] | https://github.com/harvester/harvester/issues/7909[GitHub issue]
-
-=== Layer 3 Underlay for Software-Defined Cluster Networks
-
-{harvester-product-name} v1.8.0 introduces Layer 3 connectivity support for software-defined cluster networks to act as a dedicated underlay for Kube-OVN. Previously, inter-node VM traffic was forced over the management interface (mgmt-bo), causing potential bandwidth overhead and a lack of traffic segregation. With the latest udpate, users can now assign a specific IP range to a custom cluster network, which {harvester-product-name} uses to automatically allocate IPs across nodes and provision dedicated OVS bridges. This enables complete segregation of VM data traffic from management traffic, improving overall network performance, isolation and architectural flexibility.
-
-https://youtu.be/EHbVrJ-HgYI[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/host-network-config.html[Documentation] | https://github.com/harvester/harvester/issues/7834[GitHub issue]
-
-=== SUSE Observability Integration
-
-{harvester-product-name} v1.8.0 officially supports integration with the SUSE Observability Stack Pack. {harvester-product-name} clusters can now seamlessly register with SUSE Observability to track core metrics, ensuring reliable data continuity and accurate resource reporting (such as CPU, memory and node size) across cluster upgrades and dynamic scaling operations.
-
-https://youtu.be/8UeAceSBy-Q[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/add-ons/suse-observability-agent.html[Documentation] | https://github.com/harvester/harvester/issues/8282[GitHub issue]
-
-=== Stand-alone Upgrade Manager (Experimental)
-
-{harvester-product-name} v1.8.0 decouples the upgrade logic from the core harvester binary into a stand-alone upgrade-manager. This architectural change enables faster delivery and testing of upgrade-related features and bug fixes without waiting for full release cycles. The upgrade lifecycle is now efficiently managed by `components—upgrade-shim` (early stage preparation), `upgrade-repo` (metadata and image hub), and `upgrade-manager` (custom lifecycle controllers) improving the overall maintainability and upgrade reliability.
+{harvester-product-name} v1.8 decouples upgrade logic from the core binary into a standalone Upgrade Manager. This architectural change enables faster delivery of upgrade-related features and bug fixes without waiting for full release cycles. The upgrade lifecycle is now managed across three specialized components: `upgrade-shim` (early-stage preparation), `upgrade-repo` (metadata and image hosting), and `upgrade-manager` (custom lifecycle controllers). This modular approach improves overall system maintainability and upgrade reliability.
 
 https://youtu.be/pxqGzArkxNc[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/add-ons/upgrade-manager.html[Documentation] | https://github.com/harvester/harvester/issues/7112[GitHub issue]
 
-=== Enhanced Device Identification and Native Support for Non-WWN Disks
+=== Fully supported features
 
-{harvester-product-name} v1.8.0 introduces a reworked BlockDevice naming convention that removes the strict requirement for World Wide Names (WWNs). This allows disks without WWNs to be recognized and provisioned seamlessly across Longhorn V1, Longhorn V2, and LVM storage backends. This enhancement significantly streamlines disk attachment, particularly for NVMe devices and other hardware where WWNs may not be available.
+==== In-place storage live migration
+
+In {harvester-product-name} v1.8, you can migrate all or selected virtual machine disks between different storage providers (such as {longhorn-product-name} or external CSI volumes) without downtime. The guest operating system remains unaware of the storage transfer, ensuring minimal disruption to active workloads. This capability includes full UI and API support with real-time progress tracking, as well as safety checks that verify destination capacity and temporarily block conflicting operations (such as live migration) until the transfer completes.
+
+https://youtu.be/3n_g1TYeeSQ[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/storage/storage-migration.html[Documentation] | https://github.com/harvester/harvester/issues/8285[GitHub issue]
+
+==== Live CD-ROM insertion and ejection
+
+{harvester-product-name} v1.8 introduces dynamic CD-ROM media management, allowing you to insert or eject ISO images while a virtual machine is running. Although adding or removing the CD-ROM drive device itself still requires a virtual machine reboot, mounting or unmounting ISO media within an existing drive is completely seamless. Additionally, virtual machines with mounted CD-ROM ISOs remain fully live-migratable across nodes.
+
+https://youtu.be/jucSGtUyPVA[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cdrom-hotplug.html[Documentation] | https://github.com/harvester/harvester/issues/9261[GitHub issue]
+
+==== Optimized {longhorn-product-name} resource reservations
+
+Harvester v1.8 introduces a configuration setting that allows you to manually adjust Instance Manager resource reservations. If your cluster primarily uses third-party storage, you can reduce the default CPU and memory allocated to {longhorn-product-name}. This optimization frees up cluster resources for other workloads when {longhorn-product-name} is only needed for core system functions, such as image management and upgrades.
+
+https://youtu.be/YdsF-UFiYyE[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/config/settings.html#_instance_manager_resources[Documentation] | https://github.com/harvester/harvester/issues/7867[GitHub issue]
+
+==== Pod Security Admission (PSA) support
+
+{harvester-product-name} v1.8 supports Pod Security Admission (PSA) to enforce Pod Security Standards (PSS). Built-in Kubernetes admission controllers enforce these standards across {harvester-product-name} system namespaces, ensuring that core workloads remain unaffected and that a seamless upgrade path exists from non-PSA to PSA-enabled images. User namespaces remain unenforced by default, preserving flexibility for you to define custom security levels or independently deploy policy engines (such as {kubewarden-product-name}, OPA Gatekeeper, and Kyverno).
+
+https://youtu.be/_zi3vC1T2ro[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/security-resilience/pod-security-standards.html[Documentation] | https://github.com/harvester/harvester/issues/8196[GitHub issue]
+
+==== Volume backup and restore for guest clusters
+
+{harvester-product-name} v1.8 supports backup and restore operations for guest cluster workloads using the Harvester CSI Driver. This allows you to protect workload data by creating backups of PersistentVolumeClaims (PVCs) within the guest cluster, which are then stored using the underlying storage provider (currently limited to {longhorn-product-name}) on the {harvester-product-name} cluster. You can restore these backups to recover from data loss or to migrate workloads across clusters, improving disaster recovery for guest applications.
+
+https://youtu.be/GPecK2ONwcU[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/csi-driver.html#_volume_backups[Documentation] | https://github.com/harvester/harvester/issues/2661[GitHub issue]
+
+==== Notification for pending virtual machine changes 
+
+The {harvester-product-name} v1.8 UI proactively alerts you when a virtual machine requires a restart to apply configuration changes, such as interface binding or resource allocation updates. If you choose to save changes without restarting immediately, a warning appears on the *Virtual Machines* screen to highlight virtual machines with pending changes. This prevents unapplied configurations from silently blocking future updates and ensures you can apply them at a convenient time using the UI restart action.
+
+https://youtu.be/pg23e9eQh5M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/edit-vm.html#_pending_changes_notification[Documentation] | https://github.com/harvester/harvester/issues/8411[GitHub issue]
+
+==== Configurable CPU models for live migration
+
+{harvester-product-name} v1.8 allows you to set a baseline CPU model for a virtual machine to ensure reliable live migration across hosts with different CPU generations. You can explicitly select a CPU model (`default`, `host-model`, or a named model such as `IvyBridge`) during virtual machine creation using the UI or Terraform Provider. {harvester-product-name} then schedules and migrates the virtual machine only to nodes that support the required CPU model, ensuring backward compatibility and preventing migration failures caused by missing CPU features.
+
+https://youtu.be/TVQSRsJ6K4M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cpu-model-selection.html[Documentation] | https://github.com/harvester/harvester/issues/3015[GitHub issue]
+
+==== Interactive VPC topology
+
+Harvester v1.8 adds a dynamic visual topology diagram to the *Virtual Private Cloud* details screen, providing a clear representation of logical switches and network relationships. The diagram displays the complete network hierarchy (covering VPCs, subnets, overlay networks, and virtual machines), while reflecting real-time power states by graying out stopped or paused instances. You can navigate complex network structures using pan and zoom controls, legend toggles for node filtering, click-to-highlight node relationships, and clickable VPC peering links that redirect to associated topology views.
+
+https://youtu.be/b9QHwFFkSao[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/kubeovn-vpc.html#_vpc_topology[Documentation] | https://github.com/harvester/harvester/issues/9748[GitHub issue]
+
+==== {harvester-product-name}-specific RBAC roles in {rancher-product-name-tm}
+
+v1.8 introduces {harvester-product-name}-specific role-based access control (RBAC) roles within {rancher-short-name}, fully enforced at the backend API level. This allows administrators to assign granular permissions tailored to specific user responsibilities. Key additions include the following:
+
+* Read-only roles for viewing virtual machine definitions and monitoring data
+* Hardware management roles allowing non-administrators to manage PCI, USB, and vGPU devices
+* Scoped roles for managing virtual machines within designated projects and namespaces, without exposing cluster infrastructure resources or host devices
+
+Role permissions are additive. To maintain cluster security, sensitive cluster-level configurations (such as logging facilities) remain strictly editable by cluster administrators, with other users restricted to read-only access.
+
+https://youtu.be/cm7fCswrrz8[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/rancher-rbac.html[Documentation] | https://github.com/harvester/harvester/issues/7909[GitHub issue]
+
+==== Layer 3 underlay support for cluster networks
+
+{harvester-product-name} v1.8 introduces Layer 3 connectivity support for software-defined cluster networks to serve as a dedicated underlay for Kube-OVN. Previously, inter-node virtual machine traffic traversed the management interface (`mgmt-bo`), causing bandwidth contention and preventing proper traffic segregation. With the latest update, you can assign a specific IP range to a custom cluster network, which {harvester-product-name} uses to automatically allocate node IPs and provision dedicated OVS bridges. This enables complete isolation of virtual machine data traffic from management traffic, improving overall network performance, security, and architectural flexibility.
+
+https://youtu.be/EHbVrJ-HgYI[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/host-network-config.html[Documentation] | https://github.com/harvester/harvester/issues/7834[GitHub issue]
+
+==== SUSE Observability integration
+
+{harvester-product-name} v1.8 officially supports integration with the SUSE Observability Stack Pack. {harvester-product-name} clusters can now seamlessly register with SUSE Observability to track core metrics, ensuring reliable data continuity and accurate resource reporting (such as CPU, memory, and node size) across cluster upgrades and dynamic scaling operations.
+
+https://youtu.be/8UeAceSBy-Q[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/add-ons/suse-observability-agent.html[Documentation] | https://github.com/harvester/harvester/issues/8282[GitHub issue]
+
+==== Native support for non-WWN disks
+
+{harvester-product-name} v1.8 introduces an updated block device naming convention that removes the strict requirement for World Wide Names (WWNs). You can now attach and provision disks without WWNs across Longhorn V1, Longhorn V2, and LVM storage backends. This enhancement streamlines storage setup, particularly for NVMe drives and virtualized hardware where WWNs are often unavailable.
 
 https://youtu.be/KK1VynmMVJo[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/hosts/hosts.html#_multi_disk_management[Documentation] | https://github.com/harvester/harvester/issues/6261[GitHub issue]
 

--- a/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
+++ b/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
@@ -1,0 +1,200 @@
+= {harvester-product-name} v1.8.1 Release Notes
+:revdate: 2026-07-30
+:page-revdate: {revdate}
+
+This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.8/en/introduction/overview.html.
+
+== Downloads
+
+=== AMD64
+
+==== Full ISO
+
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-amd64.iso
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-vmlinuz-amd64
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-initrd-amd64
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-rootfs-amd64.squashfs
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-amd64.sha512
+* https://releases.rancher.com/harvester/v1.8.1/version.yaml
+
+==== Net install ISO
+
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-amd64-net-install.iso
+
+=== ARM64
+
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-arm64.iso
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-vmlinuz-arm64
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-initrd-arm64
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-rootfs-arm64.squashfs
+* https://releases.rancher.com/harvester/v1.8.1/harvester-v1.8.1-arm64.sha512
+* https://releases.rancher.com/harvester/v1.8.1/version-arm64.yaml
+
+== Installation
+
+{harvester-product-name} can be installed using the https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/methods/iso-install.html[ISO image], a https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/methods/usb-install.html[bootable USB drive], and https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/methods/pxe-boot-install.html[PXE boot]. For more information, see the https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/requirements.html[Installation] section of the documentation.
+
+== Upgrades
+
+{harvester-product-name} only allows upgrades from supported versions. For more information about upgrade paths and procedures, see https://documentation.suse.com/cloudnative/virtualization/v1.8/en/upgrades/upgrades.html[Upgrades].
+
+[IMPORTANT]
+====
+When upgrading from v1.7 to v1.8, you may encounter an operating system image corruption issue if *all* of the following conditions are met:
+
+* {harvester-product-name} v1.4.1 or earlier was originally installed.
+* A separate data disk is used.
+* The cluster has been continually upgraded in place.
+
+For more information, see issue https://github.com/harvester/harvester/issues/10687[#10687].
+====
+
+== Highlights
+
+=== In-place storage live migration
+
+In {harvester-product-name} v1.8.0, you can seamlessly migrate a running VM's disks (or a subset of them) between different storage providers, such as {longhorn-product-name} or externally supported CSI volumes without any downtime. The guest OS remains completely unaware of the underlying storage transfer, ensuring minimal disruption to active workloads. This new capability includes full UI and API support with real-time progress tracking, as well as built-in safety mechanisms that verify destination capacity and temporarily block conflicting operations (like host-to-host live migrations) until the storage transfer is complete.
+
+https://youtu.be/3n_g1TYeeSQ[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/storage/storage-migration.html[Documentation] | https://github.com/harvester/harvester/issues/8285[GitHub issue]
+
+=== Live CD-ROM insertion and ejection
+
+{harvester-product-name} v1.8.0 introduces dynamic management for CD-ROM volumes, allowing users to insert or eject ISO images while a VM is running. While adding or removing the CD-ROM device itself still typically necessitates a reboot, swapping the media within that device is now seamless. Additionally, VMs with mounted CD-ROMs are live migratable.
+
+https://youtu.be/jucSGtUyPVA[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cdrom-hotplug.html[Documentation] | https://github.com/harvester/harvester/issues/9261[GitHub issue]
+
+=== Optimized {longhorn-product-name} resource reservations
+
+{harvester-product-name} v1.8.0 introduces reduced unnecessary CPU and memory consumption for clusters utilizing third-party storage solutions. {harvester-product-name} now detects when external storage is in use and dynamically lowers {longhorn-product-name}'s resource reservations. This update also introduces configurable options for users to manually adjust these allocations, improving overall cluster efficiency and freeing up resources for other workloads without impacting core {longhorn-product-name} functionalities.
+
+https://youtu.be/YdsF-UFiYyE[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/installation-setup/config/settings.html#_instance_manager_resources[Documentation] | https://github.com/harvester/harvester/issues/7867[GitHub issue]
+
+=== Pod Security Admission (PSA) support
+
+{harvester-product-name} v1.8.0 supports Pod Security Admission (PSA) to enforce Pod Security Standards (PSS). Built-in Kubernetes that validates and mutates the admission policies are used to enforce these standards on {harvester-product-name}'s system namespaces. This implementation guarantees that system-specific workloads remain unaffected and ensures a seamless upgrade path from non-PSA to PSA-enabled images. User namespaces remain unenforced, by default, preserving the flexibility for users to define their own security levels or independently deploy external policy engines (such as Kyverno, OPA Gatekeeper, or Kubewarden) without bloating the core upgrade path.
+
+https://youtu.be/_zi3vC1T2ro[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/security-resilience/pod-security-standards.html[Documentation] | https://github.com/harvester/harvester/issues/8196[GitHub issue]
+
+=== PVC Backup and Restore via harvester-csi-driver for Guest Cluster Workloads
+
+{harvester-product-name} v1.8.0 enables backup and restore operations for guest cluster workloads using the harvester-csi-driver. This allows users to protect their workload data by creating backups of Persistent Volume Claims (PVCs) in the guest cluster, which are then stored in the underlying storage provider (now only support {longhorn-product-name}) of the {harvester-product-name} cluster. Users can easily restore these backups to recover from data loss or to migrate workloads between clusters, providing enhanced data protection for applications running within {harvester-product-name}-managed guest clusters.
+
+https://youtu.be/GPecK2ONwcU[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/csi-driver.html#_volume_backups[Documentation] | https://github.com/harvester/harvester/issues/2661[GitHub issue]
+
+=== VM Pending Restart Notifications
+
+{harvester-product-name} v1.8.0 UI now proactively alerts users when a Virtual Machine requires a restart to fully apply configuration changes, such as interface binding updates or specific CPU/memory modifications. The dashboard continuously polls the VM's status conditions and displays a "Pending Restart" indicator when necessary. This prevents unapplied changes from silently blocking future live updates or resource hotplug operations, ensuring users can promptly resolve the state using the standard UI restart action.
+
+https://youtu.be/pg23e9eQh5M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/edit-vm.html#_pending_changes_notification[Documentation] | https://github.com/harvester/harvester/issues/8411[GitHub issue]
+
+=== Configurable VM CPU Models for Live Migration
+
+{harvester-product-name} v1.8.0 addresses an issue where live migrating VMs between hosts with different CPU generations (for example, AMD Ryzen 5th Gen to 3rd Gen) would fail due to strict CPU feature-matching checks by KubeVirt/libvirt. Users can now explicitly define a specific CPU model (for example, IvyBridge, host-model, or default) for a VM during creation via the {harvester-product-name} UI or Terraform provider. This ensures the VM is only scheduled and migrated across nodes that support the selected baseline CPU model, enabling reliable backward compatibility and successful live migrations in mixed-hardware clusters.
+
+https://youtu.be/TVQSRsJ6K4M[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/virtual-machines/cpu-model-selection.html[Documentation] | https://github.com/harvester/harvester/issues/3015[GitHub issue]
+
+=== Interactive VPC Network Topology
+
+In {harvester-product-name} v1.8.0, a dynamic visual topology diagram is added to the VPC detail page, providing a clear representation of logical switches and network relationships. The interactive map displays the complete hierarchy from VPCs and Subnets to Overlay Networks and individual VMs while accurately reflecting VM power states by graying out stopped or paused instances. Users can easily navigate complex network architectures using pan and zoom controls, legend toggles for filtering node types, click-to-highlight node relationships, and clickable VPC peering links that seamlessly redirect to associated topology pages.
+
+https://youtu.be/b9QHwFFkSao[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/kubeovn-vpc.html#_vpc_topology[Documentation] | https://github.com/harvester/harvester/issues/9748[GitHub issue]
+
+=== Fine-Grained {harvester-product-name} RBAC Roles for Rancher
+
+{harvester-product-name} v1.8.0 introduces {harvester-product-name}-specific Role-Based Access Control (RBAC) roles within Rancher, fully enforced at the backend API-level. This allows administrators to assign highly specific, granular permissions based on user needs. New capabilities include read-only roles for viewing VM definitions and monitoring data, specialized roles for non-admins to manage hardware devices (PCI, USB, vGPU), and scoped "VM Admin" roles restricted to editing VMs within specific namespaces without granting access to underlying infrastructure like images or networks. Role permissions are additive, and for security purposes, sensitive cluster-level configurations, such as logging facilities remain strictly editable only by cluster admins, with non-admins restricted to read-only access.
+
+https://youtu.be/cm7fCswrrz8[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/integrations/rancher/rancher-rbac.html[Documentation] | https://github.com/harvester/harvester/issues/7909[GitHub issue]
+
+=== Layer 3 Underlay for Software-Defined Cluster Networks
+
+{harvester-product-name} v1.8.0 introduces Layer 3 connectivity support for software-defined cluster networks to act as a dedicated underlay for Kube-OVN. Previously, inter-node VM traffic was forced over the management interface (mgmt-bo), causing potential bandwidth overhead and a lack of traffic segregation. With the latest udpate, users can now assign a specific IP range to a custom cluster network, which {harvester-product-name} uses to automatically allocate IPs across nodes and provision dedicated OVS bridges. This enables complete segregation of VM data traffic from management traffic, improving overall network performance, isolation and architectural flexibility.
+
+https://youtu.be/EHbVrJ-HgYI[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/networking/host-network-config.html[Documentation] | https://github.com/harvester/harvester/issues/7834[GitHub issue]
+
+=== SUSE Observability Integration
+
+{harvester-product-name} v1.8.0 officially supports integration with the SUSE Observability Stack Pack. {harvester-product-name} clusters can now seamlessly register with SUSE Observability to track core metrics, ensuring reliable data continuity and accurate resource reporting (such as CPU, memory and node size) across cluster upgrades and dynamic scaling operations.
+
+https://youtu.be/8UeAceSBy-Q[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/add-ons/suse-observability-agent.html[Documentation] | https://github.com/harvester/harvester/issues/8282[GitHub issue]
+
+=== Stand-alone Upgrade Manager (Experimental)
+
+{harvester-product-name} v1.8.0 decouples the upgrade logic from the core harvester binary into a stand-alone upgrade-manager. This architectural change enables faster delivery and testing of upgrade-related features and bug fixes without waiting for full release cycles. The upgrade lifecycle is now efficiently managed by `components—upgrade-shim` (early stage preparation), `upgrade-repo` (metadata and image hub), and `upgrade-manager` (custom lifecycle controllers) improving the overall maintainability and upgrade reliability.
+
+https://youtu.be/pxqGzArkxNc[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/add-ons/upgrade-manager.html[Documentation] | https://github.com/harvester/harvester/issues/7112[GitHub issue]
+
+=== Enhanced Device Identification and Native Support for Non-WWN Disks
+
+{harvester-product-name} v1.8.0 introduces a reworked BlockDevice naming convention that removes the strict requirement for World Wide Names (WWNs). This allows disks without WWNs to be recognized and provisioned seamlessly across Longhorn V1, Longhorn V2, and LVM storage backends. This enhancement significantly streamlines disk attachment, particularly for NVMe devices and other hardware where WWNs may not be available.
+
+https://youtu.be/KK1VynmMVJo[Demo] | https://documentation.suse.com/cloudnative/virtualization/v1.8/en/hosts/hosts.html#_multi_disk_management[Documentation] | https://github.com/harvester/harvester/issues/6261[GitHub issue]
+
+== Features
+
+* [backport v1.8] [FEATURE] Allow particular ports access as default security policy https://github.com/harvester/harvester/issues/10327[#10327]
+
+== Enhancements
+
+* [backport v1.8] [ENHANCEMENT] Relax LB webhook with more backward compatibility https://github.com/harvester/harvester/issues/10528[#10528]
+* [backport v1.8] [ENHANCEMENT] Block parent vGPU device enable/disable actions https://github.com/harvester/harvester/issues/10439[#10439]
+* [backport v1.8] [ENHANCEMENT] Extra VM live migration during upgrade https://github.com/harvester/harvester/issues/10365[#10365]
+* [backport v1.8] [ENHANCEMENT] Support Storage Migration for VMs Restored from Snapshot or Backup https://github.com/harvester/harvester/issues/10353[#10353]
+* [backport v1.8] [ENHANCEMENT] Enhance the resource-quota processing when overhead-ratio is adjusted https://github.com/harvester/harvester/issues/10246[#10246]
+* [TASK] Bump Go version to 1.26 for v1.8.1 https://github.com/harvester/harvester/issues/10734[#10734]
+* [TASK] Component updates for v1.8.1 https://github.com/harvester/harvester/issues/10566[#10566]
+
+== Bug Fixes
+
+* [BUG] rancher-monitoring can't be enabled in v1.8.1-rc2 https://github.com/harvester/harvester/issues/11019[#11019]
+* [Doc] Update the lvm doc with right path to addon yaml https://github.com/harvester/harvester/issues/10798[#10798]
+* [backport v1.8] [BUG] `ifname=` kernel args don't always work to rename network interfaces https://github.com/harvester/harvester/issues/10789[#10789]
+* [BUG] Upgrade from v1.8.0 to v1.8-head stuck at waiting CAPI cluster fleet-local/local generation bump https://github.com/harvester/harvester/issues/10719[#10719]
+* [BUG] Can't enable SR-IOV GPU on https://github.com/harvester/harvester/issues/10707[#10707]
+* [backport v1.8] [BUG] install.wipe_disks_list should not error out if the disk doesn't exist https://github.com/harvester/harvester/issues/10613[#10613]
+* [backport v1.8] [BUG] f29abc8d airgapped master build fails to render dashboard https://github.com/harvester/harvester/issues/10577[#10577]
+* [backport v1.8] [BUG] Upgrade from v1.7.x to v1.8.0 stuck in Post-draining when storage-network is configured with RWX volumes https://github.com/harvester/harvester/issues/10537[#10537]
+* [backport v1.8] [BUG] Upgrade could fail without retrying when entering the node upgrade phase https://github.com/harvester/harvester/issues/10530[#10530]
+* [backport v1.8] [BUG] storage-validator : offline volume expansion test fails for Dell CSI drivers https://github.com/harvester/harvester/issues/10515[#10515]
+* [backport v1.8] [BUG] Stop using `rancher/kubectl` image https://github.com/harvester/harvester/issues/10467[#10467]
+* [backport v1.8] [BUG] pcidevice passthorugh is broken on VM with hot plugged volume https://github.com/harvester/harvester/issues/10371[#10371]
+* [backport v1.8] [BUG] UI shows incorrect info when deleting storage https://github.com/harvester/harvester/issues/10338[#10338]
+* [BUG] node names not listed under node scheduling while creating a VM in UI https://github.com/harvester/harvester/issues/10189[#10189]
+* [BUG] Rancher v2.14.0-alpha9 has chance to fail to provision RKE2 v1.35 guest cluster https://github.com/harvester/harvester/issues/10188[#10188]
+* [BUG] Virtual Machine's Node Scheduling Rules Are Incorrectly Truncated https://github.com/harvester/harvester/issues/9334[#9334]
+* [BUG] Can not reset node scheduling of a VM to `run on all available nodes` https://github.com/harvester/harvester/issues/9142[#9142]
+
+== Known Issues
+
+This section includes only issues identified before the release date. For information about all issues associated with v1.8.1, see https://github.com/harvester/harvester/issues?q=is:issue%20label:known-issue-v1.8.1[this page].
+
+* [BUG] v1.7.x → v1.8.0 OS-swap leaves two p11-kit files all-NUL in /usr/share on ~1/3 of nodes; breaks every TLS user on that host (containerd, Longhorn engine-image, kubelet) https://github.com/harvester/harvester/issues/10687[#10687]
+* [BUG] After upgraded to three Nodes with witness role to v1.8.0-rc6, vm failed to migrate with error "Kubevirt not ready" https://github.com/harvester/harvester/issues/10447[#10447]
+* [BUG] Failed to migrate VM after eject the windows image from CDROM device https://github.com/harvester/harvester/issues/10221[#10221]
+* [BUG] Fail to enable rancher-logging after negative upgrade cases https://github.com/harvester/harvester/issues/10220[#10220]
+
+== Components
+
+|===
+| Component | Version
+
+| CDI
+| https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.64.0[v1.64.0]
+
+| Kube-OVN
+| https://github.com/kubeovn/kube-ovn/releases/tag/v1.15.4[v1.15.4]
+
+| KubeVirt
+| https://github.com/kubevirt/kubevirt/releases/tag/v1.7.0[v1.7.0]
+
+| {longhorn-product-name-tm}
+| https://github.com/longhorn/longhorn/releases/tag/v1.11.2[v1.11.2]
+
+| {rancher-product-name-tm} (embedded)
+| https://github.com/rancher/rancher/releases/tag/v2.14.2[v2.14.2]
+
+| {rke2-product-name}
+| https://github.com/rancher/rke2/releases/tag/v1.35.6%2Brke2r1[v1.35.6+rke2r1]
+
+| SUSE Linux Micro
+| https://github.com/harvester/os2/releases/tag/v1.8-20260605[6.2]
+|===

--- a/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
+++ b/versions/v1.8/modules/en/pages/release-notes/v1.8.1.adoc
@@ -1,5 +1,5 @@
 = {harvester-product-name} v1.8.1 Release Notes
-:revdate: 2026-07-30
+:revdate: 2026-07-31
 :page-revdate: {revdate}
 
 This release introduces several features, enhancements, and bug fixes that improve system quality and the overall user experience. The documentation is available at https://documentation.suse.com/cloudnative/virtualization/v1.8/en/introduction/overview.html.
@@ -187,7 +187,7 @@ This section includes only issues identified before the release date. For inform
 |===
 | Component | Version
 
-| CDI
+| Containerized Data Importer (CDI)
 | https://github.com/kubevirt/containerized-data-importer/releases/tag/v1.64.0[v1.64.0]
 
 | Kube-OVN


### PR DESCRIPTION
| Release | Source PRs | Published Release Notes |
| --- | --- | --- |
| `v1.6.1` | [#55](https://github.com/harvester/release-notes/pull/55) + [#60](https://github.com/harvester/release-notes/pull/60) | https://github.com/harvester/harvester/releases/tag/v1.6.1 |
| `v1.7.1` | [#61](https://github.com/harvester/release-notes/pull/61) + [#63](https://github.com/harvester/release-notes/pull/63) + [#65](https://github.com/harvester/release-notes/pull/65) | https://github.com/harvester/harvester/releases/tag/v1.7.1 |
| `v1.7.2` | [#71](https://github.com/harvester/release-notes/pull/71) + [#72](https://github.com/harvester/release-notes/pull/72) | https://github.com/harvester/harvester/releases/tag/v1.7.2 |
| `v1.8.1` | [#67](https://github.com/harvester/release-notes/pull/67) + [#69](https://github.com/harvester/release-notes/pull/69) + [#70](https://github.com/harvester/release-notes/pull/70) | https://github.com/harvester/harvester/releases/tag/v1.8.1 |

Actions taken:
- Added a "Release Notes" section at the beginning of each doc
- Created a dedicated file for each release
- For `x.y.1`: Ported all content + "Highlights" content from the corresponding `x.y.0` release
- For `x.y.2`:  Ported all content
- For `v1.8.1`: Improved the feature descriptions in the "Highlights" section

> Note: The build is failing because of mostly INFO-level errors in the translation files. I cannot fix these issues because they involve other languages. The logs show no errors in the English source files, so we can safely merge the changes in this PR.