### PR TITLE
docs: add minimum network bandwidth requirements table

### DIFF
--- a/versions/v1.8/modules/en/pages/installation-setup/requirements.adoc
+++ b/versions/v1.8/modules/en/pages/installation-setup/requirements.adoc
@@ -1,5 +1,5 @@
 = Hardware and Network Requirements
-:revdate: 2026-05-05
+:revdate: 2026-08-07
 :page-revdate: {revdate}
 
 As an HCI solution on bare metal servers, there are minimum node hardware and network requirements for installing and running {harvester-product-name}.
@@ -69,6 +69,39 @@ When creating clusters, adding more hosts to a cluster, and replacing hosts, alw
 == Network Requirements
 
 Nodes have the following network requirements for installation.
+
+=== Minimum Bandwidths
+
+To ensure cluster stability, storage performance, and successful Live Migrations, {harvester-product-name} requires the following minimum network bandwidths. These requirements apply whether the traffic shares a single physical interface (using VLANs) or is physically segregated across dedicated NICs.
+
+|===
+| Network/Traffic Type | Minimum (Dev/Test) | Minimum (Production) | Description and Impact
+
+| *Management (`mgmt`)*
+| 1 Gbps
+| 10 Gbps
+| Handles Kubernetes control plane, etcd, and node communications. Inadequate bandwidth causes etcd latency, leader election timeouts, and cluster instability. For more information, see xref:security-resilience/ha-principles.adoc[High Availability Principles].
+
+| *Storage Network*
+| 1 Gbps
+| 10 Gbps
+| Handles {longhorn-product-name} data replication. High bandwidth is critical for volume health and replica rebuild speeds. Isolating this traffic on a 10 Gbps network is required in production to prevent replication from starving the control plane. For more information, see xref:networking/storage-network.adoc[Storage Network].
+
+| *VM Migration Network*
+| 1 Gbps
+| 10 Gbps
+| Isolates Live Migration traffic. Insufficient bandwidth causes migrations to stall or fail. Dedicating a 10 Gbps network is recommended for heavy workloads. For more information, see xref:networking/vm-migration-network.adoc[VM Migration Network].
+
+| *VM Workload Network*
+| 1 Gbps
+| 10 Gbps (Bonded)
+| Carries external and internal guest VM traffic. Requirements scale heavily based on application needs. At least 2 NICs are recommended. For more information, see xref:networking/vm-network.adoc[VM Network].
+|===
+
+[IMPORTANT]
+====
+If your cluster uses a shared physical interface for all networks (using VLAN tagging instead of dedicated NICs), the combined bandwidth of the physical interface must be at least *10 Gbps* for production environments. However, separating Storage and VM Migration traffic onto dedicated physical interfaces is highly recommended to avoid bandwidth contention.
+====
 
 === Port Requirements for Nodes
 


### PR DESCRIPTION

**File Modified**:

* `installation-setup/requirements.adoc`

**References / Source Files**:

* `installation-setup/requirements.adoc` (Baseline 1 Gbps / 10 Gbps physical hardware limits and bonded NIC recommendations)
* `security-resilience/ha-principles.adoc` (Impact of network latency and bandwidth starvation on etcd leader election and HA quorum)
* `networking/storage-network.adoc` (Traffic isolation requirements for Longhorn replication to prevent control plane degradation)
* `networking/vm-migration-network.adoc` (Traffic isolation requirements for KubeVirt Live Migration to prevent cluster instability)