### PR TITLE
docs: add storage classification page

### DIFF
--- a/versions/v1.8/modules/en/nav.adoc
+++ b/versions/v1.8/modules/en/nav.adoc
@@ -89,6 +89,7 @@
 *** xref:storage/volumes/export-volume.adoc[]
 *** xref:storage/volumes/volume-snapshots.adoc[]
 *** xref:storage/volumes/volume-security.adoc[]
+** xref:storage/storage-classification.adoc[]
 ** xref:storage/storageclass.adoc[]
 ** xref:storage/csidriver.adoc[]
 ** xref:storage/longhorn-v2-data-engine.adoc[]

--- a/versions/v1.8/modules/en/pages/storage/storage-classification.adoc
+++ b/versions/v1.8/modules/en/pages/storage/storage-classification.adoc
@@ -1,0 +1,81 @@
+= Production vs. Backup Storage: Classification Criteria
+:revdate: 2026-08-10
+:page-revdate: {revdate}
+
+In a {harvester-product-name} and {longhorn-product-name} environment, storage is strictly categorized into *Production Storage* and *Backup Storage*. Misclassifying or misconfiguring these storage tiers can lead to degraded virtual machine (VM) performance, live migration failures, or data loss during disaster recovery scenarios.
+
+The following criteria define the architectural boundaries, hardware requirements, and operational characteristics of each storage type.
+
+== Production Storage (Primary / In-Cluster)
+
+Production storage refers to the built-in, distributed block storage (managed by {longhorn-product-name}) or validated third-party CSI drivers that actively back running VMs, boot volumes, and data volumes. It resides within the cluster and is optimized for synchronous I/O, low latency, and high availability.
+
+=== Hardware and Engine Criteria
+
+* *V1 Data Engine*: The standard storage engine used for VM root volumes, images, and standard workloads.
+* *xref:storage/longhorn-v2-data-engine.adoc[V2 Data Engine (High Performance)]*: An experimental, SPDK-based engine designed for high IOPS and throughput. 
+** *Resource Requirements*: Requires strictly dedicated resources per node (1 CPU core for the `instance-manager` pod and 2 GiB RAM allocated as `1024 x 2` MiB huge pages).
+** *Media Requirements*: Strictly requires local NVMe disks (using the SPDK NVMe bdev driver) to fully support operations like file system trim/unmap. Using non-NVMe SSDs relies on the SPDK AIO driver, which lacks unmap support and can result in I/O errors or paused VMs if trimmed.
+* *Tiered / Cold Storage*: Hard Disk Drives (HDDs) can be added to the cluster for cold storage or archiving (see xref:storage/storageclass.adoc#_hdd_scenario[HDD Scenario]), but are explicitly *not recommended* for guest Kubernetes (RKE2) clusters or VMs requiring good disk performance.
+
+=== Provisioning and Isolation Criteria
+
+* *Kubernetes Integration*: Provisioned exclusively via Kubernetes xref:storage/storageclass.adoc[StorageClass] objects.
+* *Physical Isolation*: Production disks and nodes are segregated using *Storage Tags* (Disk/Node tags). For example, NVMe disks can be tagged `fast` while HDDs are tagged `ColdStorage`. The `StorageClass` uses `nodeSelector` and `diskSelector` parameters to enforce where VM volumes are scheduled.
+* *Data Locality*: Production storage can enforce `dataLocality` (for example, `best-effort`) to attempt scheduling at least one volume replica on the same node as the consuming pod to optimize read latency.
+
+=== Resiliency and Operations Criteria
+
+* *Synchronous Replication*: Relies on real-time, synchronous replication across cluster nodes (default `numberOfReplicas: "3"`).
+* *Live Migration*: Requires the `migratable` parameter in the StorageClass to be set to true (and requires a replica count greater than 1) for xref:virtual-machines/live-migration.adoc[Live Migration] to function.
+* *Snapshots*: VM Snapshots reside directly on Production Storage and consume cluster disk space. Snapshot space limits can be enforced via Namespace or VM-level quotas. For more information, see xref:virtual-machines/backup-restore.adoc#_virtual_machine_snapshot_space_management[Virtual Machine Snapshot Space Management].
+
+== Backup Storage (Secondary / Off-Cluster)
+
+Backup storage (or xref:virtual-machines/backup-restore.adoc#_configuring_backup_target[Backup Target]) is an external endpoint used strictly for disaster recovery, long-term retention of VM volumes, and {longhorn-product-name} system backups. It does not provide block devices to live workloads. Instead, it stores bundled system configuration files and point-in-time VM volume data.
+
+=== Protocol and Endpoint Criteria
+
+* *Supported Protocols*: Exclusively utilizes external object or file-based protocols: S3-compatible object stores (AWS S3, GCP, MinIO), Azure Blob Storage, NFS, and SMB/CIFS. 
+* *Protocol Preference*: Object storage (S3) is explicitly recommended over file systems (NFS/SMB) because it offers better reliability and eliminates the need to mount/unmount the target, simplifying failovers and cluster upgrades.
+* *Storage Support Limitations*: Backup operations are currently limited to built-in {longhorn-product-name} volumes. {harvester-product-name} cannot natively create backups of volumes residing on external third-party CSI storage.
+
+=== Resiliency and Operations Criteria
+
+* *Network Tolerance*: Designed to handle network instability gracefully. For NFS backup targets, {longhorn-product-name} automatically enforces `soft` mounts with specific timeouts (`timeo=300,retry=2`). This ensures that if the NFS server is unreachable, operations fail safely rather than hanging the storage engine indefinitely.
+* *Point-in-Time Consistency*: To ensure file system consistency before data is moved to Backup Storage, {harvester-product-name} utilizes the QEMU Guest Agent (via virt-freezer or Windows VSS) to perform xref:virtual-machines/backup-restore.adoc#_filesystem_freeze_for_virtual_machine_backups_and_snapshots[filesystem freeze/thaw operations] on the live VM.
+* *Lifecycle Management*: The lifecycle of backups within the backupstore is managed entirely by {longhorn-product-name}. *Applying retention policies directly on the external backupstore (for example, AWS S3 lifecycle rules) is strictly prohibited*.
+
+== Summary Matrix
+
+|===
+| Criteria | Production Storage | Backup Storage
+
+| *Primary Function*
+| Active block storage for live VMs and workloads.
+| Disaster recovery, VM retention, and system backups.
+
+| *Location*
+| In-cluster (Local NVMe, SSD, HDD).
+| Off-cluster (External server/cloud endpoint).
+
+| *Protocols / Interfaces*
+| Kubernetes CSI, SPDK NVMe/AIO bdev, Block devices.
+| S3, Azure Blob, NFS, SMB/CIFS.
+
+| *Resiliency Model*
+| Synchronous replica distribution across cluster nodes.
+| Point-in-time asynchronous copies; soft-mount network tolerance.
+
+| *Workload Consistency*
+| Always active.
+| Requires QEMU Guest Agent filesystem freeze/thaw.
+
+| *Lifecycle Ownership*
+| Managed via `StorageClass` reclaim policies (`Delete`/`Retain`).
+| Exclusively managed by {longhorn-product-name}. External retention policies are prohibited.
+
+| *Configuration Interface*
+| `StorageClass`, Node/Disk Tags.
+| `Settings > backup-target`, `longhorn-default-resource` ConfigMap.
+|===

--- a/versions/v1.8/modules/en/pages/storage/storage.adoc
+++ b/versions/v1.8/modules/en/pages/storage/storage.adoc
@@ -4,6 +4,11 @@
 
 {harvester-product-name} supports distributed block storage and tiering.
 
+[NOTE]
+====
+For a detailed breakdown of hardware requirements, networking protocols, and architectural differences between live VM storage and disaster recovery endpoints, see xref:storage/storage-classification.adoc[Production vs. Backup Storage: Classification Criteria].
+====
+
 == Built-in storage
 
 https://www.suse.com/products/rancher/storage/[{longhorn-product-name}], the built-in storage system, provides block device volumes to virtual machines and other pods in a {harvester-product-name} cluster. {longhorn-product-name} creates a dedicated storage controller for each volume and synchronously replicates the volume across nodes.


### PR DESCRIPTION
**File Added**:

* `storage/storage-classification.adoc`

**Files Modified**:

* `storage/storage.adoc` (Added inbound cross-reference note)

**References / Source Files**:

* `storage/storage.adoc` (Built-in vs. third-party CSI storage baseline)
* `storage/longhorn-v2-data-engine.adoc` (V2 Data Engine SPDK NVMe requirements & unmap/trim limitations)
* `storage/storageclass.adoc` (StorageClass parameters, data locality, disk tags & HDD cold storage constraints)
* `virtual-machines/backup-restore.adoc` (Backup target definitions, snapshot space quotas & QEMU Guest Agent fsfreeze/thaw operations)
* Longhorn `snapshots-backups/volume-snapshots-backups/configure-backup-target.adoc` (S3/NFS/SMB protocol preferences, NFS soft mount network tolerance & external retention policy prohibitions)
* Longhorn `nodes/storage-tags.adoc` (Disk and node tags for physical isolation)
* Longhorn `snapshots-backups/system-backups/system-backups.adoc` (System backup storage scoping)