### PR TITLE
Port content from community doc PRs (1091, 1096, 1104)

### DIFF
--- a/versions/v1.7/modules/en/pages/add-ons/lvm-local-storage.adoc
+++ b/versions/v1.7/modules/en/pages/add-ons/lvm-local-storage.adoc
@@ -1,6 +1,6 @@
 = CSI Driver LVM (Experimental)
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-12-31
+:revdate: 2026-08-13
 :page-revdate: {revdate}
 
 [NOTE]
@@ -20,7 +20,7 @@ If you are using the {harvester-product-name} kubeconfig file, you can install t
 +
 [,shell]
 ----
-# kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/main/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
+# kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/v1.7/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
 ----
 +
 . On the {harvester-product-name} UI, go to *Advanced -> Add-ons*.

--- a/versions/v1.7/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.7/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,6 +1,6 @@
 = Upload Images
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2025-11-12
+:revdate: 2026-08-13
 :page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
@@ -16,7 +16,7 @@ To import virtual machine images in the *Images* page, enter a URL that can be a
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
-* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a Longhorn backing image are lost, Longhorn attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
+* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
 +
 [CAUTION]
@@ -66,7 +66,7 @@ resource "harvester_image" "opensuse154" {
 
 == Upload Images via Local File
 
-Currently, qcow2, raw and ISO images are supported.
+Currently, qcow2, raw, and ISO images are supported.
 
 [NOTE]
 ====
@@ -104,7 +104,7 @@ image:img-ingress-client-body.png[]
 
 === Prolonged Uploading of Large Images in {rancher-product-name} Multi-Cluster Management
 
-If you upload a large image (over 10 GB) from the *Multi-Cluster Management* screen on the {rancher-product-name} UI, the operation may take longer than usual and the image status (Uploading) may not change.
+If you upload a very large image (over 10 GB) from the *Multi-Cluster Management* screen on the {rancher-product-name} UI, the operation may take longer than usual and the image status (Uploading) may not change.
 
 This behavior is related to _proxy-request-buffering_ in the ingress configuration, which is also specific to the cluster that is hosting {rancher-product-name}.
 
@@ -127,9 +127,30 @@ image:img-ingress-request-proxy-buffering.png[]
 
 . Delete the stuck image, and then restart the upload process.
 
+=== Failure to upload an image with a third-party StorageClass
+
+When uploading a large `qcow2` image with a third-party `StorageClass`, the upload progress may pause at *99%* before failing with a `context canceled` error.
+
+This issue occurs because CDI requires extra time to convert the `qcow2` image during the final upload stage. If the image conversion exceeds {harvester-product-name}'s default ingress proxy timeout, the request times out.
+
+A timeout error does not always mean the upload has failed. Image processing often continues in the background, and the virtual machine image may eventually transition to a `Healthy` state. You can verify whether the process is still running by checking the status of the corresponding `cdi-upload-*` pod.
+
+To prevent request timeouts during large image uploads, increase the ingress proxy timeout values. The following example increases the proxy timeout to 30 minutes (1800 seconds):
+
+[,shell]
+----
+kubectl annotate ingress rancher-expose \
+  -n cattle-system \
+  nginx.ingress.kubernetes.io/proxy-read-timeout="1800" \
+  nginx.ingress.kubernetes.io/proxy-send-timeout="1800" \
+  --overwrite
+----
+
+This increases the proxy timeout to 30 minutes.
+
 === Uploading Images Previously Downloaded from {harvester-product-name}
 
-Starting with *v1.5.5*, Longhorn https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates Longhorn's data alignment.
+Starting with *v1.5.5*, {longhorn-product-name} https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates {longhorn-product-name}'s data alignment.
 
 Before uploading, decompress backing images using the command `gzip -d <file name>`.
 

--- a/versions/v1.7/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.7/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -11,27 +11,32 @@ Currently, there are three ways that are supported to create an image: uploading
 ======
 UI::
 +
+--
 To import virtual machine images in the *Images* page, enter a URL that can be accessed from the cluster. Description and labels are optional.
-+
+
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
 * Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
-+
+
 [CAUTION]
 ====
 Large image files may cause memory issues in {harvester-product-name} when you use third-party StorageClasses with download URLs that are hosted on servers that do not support HTTP range requests (for example, Python's `http.server`). For reliable downloads, use NGINX or Apache instead. (This issue is fixed in v1.6.1.)
 ====
-+
+
 image::upload-image.png[]
+--
 
 API::
 +
+--
 To import a virtual machine image from a repository using the API, create a `VirtualMachineImage` object. You must specify a URL that can be accessed from the cluster. 
-+
-Example:
-+
+
+By default, a `VirtualMachineImage` object uses the {longhorn-product-name} backing image backend. To store images in third-party storage or Longhorn V2 Data Engine volumes, use the Containerized Data Importer (CDI) backend and specify the target StorageClass.
+
+Example ({longhorn-product-name} backing image backend):
+
 [,yaml]
 ----
 apiVersion: harvesterhci.io/v1beta1
@@ -46,11 +51,34 @@ spec:
   url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
   checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
 ----
-+
-For more information, see the xref:api.adoc[API reference]. 
+
+Example (CDI backend):
+
+[,yaml]
+----
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: opensuse-leap-nfs
+  namespace: default
+spec:
+  backend: cdi
+  description: A VM image stored in third-party storage
+  displayName: openSUSE-Leap-NFS
+  sourceType: download
+  url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
+  checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
+  targetStorageClassName: nfs-csi
+----
+
+Replace `nfs-csi` with the name of the StorageClass for your storage solution. The target StorageClass cannot be changed after the image is created.
+
+For more information, see the xref:api.adoc[API reference].
+--
 
 Terraform::
 +
+--
 [,json]
 ----
 resource "harvester_image" "opensuse154" {
@@ -62,6 +90,7 @@ resource "harvester_image" "opensuse154" {
   url          = "https://downloadcontent-us1.opensuse.org/repositories/Cloud:/Images:/Leap_15.4/images/openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
 }
 ----
+--
 ======
 
 == Upload Images via Local File
@@ -162,14 +191,37 @@ image::volume/export-volume-to-image-1.png[]
 
 == Image StorageClass
 
-When creating an image, you can select a xref:/storage/storageclass.adoc[StorageClass] and use its pre-defined parameters like replicas, node selectors and disk selectors .
+When creating an image, select a xref:/storage/storageclass.adoc[StorageClass] on the *Storage* tab. {harvester-product-name} selects the image backend according to the type of storage.
 
-[NOTE]
-====
-The image does not use the `StorageClass` selected here directly. It is just a `StorageClass` template.
+|===
+| Image Backend | StorageClass | Image Storage
 
-Instead, it creates a special StorageClass under the hood with a prefix name of `longhorn-`. This is automatically done by the {harvester-product-name} back-end, but it inherits the parameters from the StorageClass you have selected.
-====
+| {longhorn-product-name} backing image
+| Longhorn V1 Data Engine
+| {harvester-product-name} creates an image-specific StorageClass that inherits parameters such as the number of replicas, node selectors, and disk selectors from the selected StorageClass. The image does not use the selected StorageClass directly.
+
+| CDI
+| Longhorn V2 Data Engine, LVM, and third-party CSI storage
+| {harvester-product-name} creates a golden image PVC directly in the selected StorageClass.
+|===
+
+To create an image in third-party storage, perform the following steps:
+
+. xref:storage/csidriver.adoc#_install_the_csi_driver[Install and configure the third-party CSI driver], and create a StorageClass for the storage solution.
+
+. Configure the StorageClass xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[CDI settings]. 
++
+This step is required when CDI cannot automatically determine the volume mode and access modes for the CSI provisioner.
+
+. On the *Images* screen, click *Create Image*.
+
+. Select *URL* or *File*, and configure the image source.
+
+. On the *Storage* tab, select the StorageClass for the third-party storage solution.
+
+. Click *Create* and wait for the image to become ready.
+
+{harvester-product-name} uses CDI to import the image into a golden image PVC in the selected StorageClass. Volumes created from the image use the clone strategy configured in the StorageClass CDI settings.
 
 image::image-storageclass.png[]
 

--- a/versions/v1.8/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.8/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -10,27 +10,32 @@ Currently, there are three ways that are supported to create an image: uploading
 ======
 UI::
 +
+--
 To import virtual machine images in the *Images* page, enter a URL that can be accessed from the cluster. Description and labels are optional.
-+
+
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
 * Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
-+
+
 [CAUTION]
 ====
 Large image files may cause memory issues in {harvester-product-name} when you use third-party StorageClasses with download URLs that are hosted on servers that do not support HTTP range requests (for example, Python's `http.server`). For reliable downloads, use NGINX or Apache instead. (This issue is fixed in v1.6.1.)
 ====
-+
+
 image::upload-image.png[]
+--
 
 API::
 +
+--
 To import a virtual machine image from a repository using the API, create a `VirtualMachineImage` object. You must specify a URL that can be accessed from the cluster. 
-+
-Example:
-+
+
+By default, a `VirtualMachineImage` object uses the {longhorn-product-name} backing image backend. To store images in third-party storage or Longhorn V2 Data Engine volumes, use the Containerized Data Importer (CDI) backend and specify the target StorageClass.
+
+Example ({longhorn-product-name} backing image backend):
+
 [,yaml]
 ----
 apiVersion: harvesterhci.io/v1beta1
@@ -45,11 +50,34 @@ spec:
   url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
   checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
 ----
-+
-For more information, see the xref:api.adoc[API reference]. 
+
+Example (CDI backend):
+
+[,yaml]
+----
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: opensuse-leap-nfs
+  namespace: default
+spec:
+  backend: cdi
+  description: A VM image stored in third-party storage
+  displayName: openSUSE-Leap-NFS
+  sourceType: download
+  url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
+  checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
+  targetStorageClassName: nfs-csi
+----
+
+Replace `nfs-csi` with the name of the StorageClass for your storage solution. The target StorageClass cannot be changed after the image is created.
+
+For more information, see the xref:api.adoc[API reference].
+--
 
 Terraform::
 +
+--
 [,json]
 ----
 resource "harvester_image" "opensuse154" {
@@ -61,6 +89,7 @@ resource "harvester_image" "opensuse154" {
   url          = "https://downloadcontent-us1.opensuse.org/repositories/Cloud:/Images:/Leap_15.4/images/openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
 }
 ----
+--
 ======
 
 == Upload Images via Local File
@@ -161,14 +190,37 @@ image::volume/export-volume-to-image-1.png[]
 
 == Image StorageClass
 
-When creating an image, you can select a xref:/storage/storageclass.adoc[StorageClass] and use its pre-defined parameters like replicas, node selectors and disk selectors .
+When creating an image, select a xref:/storage/storageclass.adoc[StorageClass] on the *Storage* tab. {harvester-product-name} selects the image backend according to the type of storage.
 
-[NOTE]
-====
-The image does not use the `StorageClass` selected here directly. It is just a `StorageClass` template.
+|===
+| Image Backend | StorageClass | Image Storage
 
-Instead, it creates a special StorageClass under the hood with a prefix name of `longhorn-`. This is automatically done by the {harvester-product-name} back-end, but it inherits the parameters from the StorageClass you have selected.
-====
+| {longhorn-product-name} backing image
+| Longhorn V1 Data Engine
+| {harvester-product-name} creates an image-specific StorageClass that inherits parameters such as the number of replicas, node selectors, and disk selectors from the selected StorageClass. The image does not use the selected StorageClass directly.
+
+| CDI
+| Longhorn V2 Data Engine, LVM, and third-party CSI storage
+| {harvester-product-name} creates a golden image PVC directly in the selected StorageClass.
+|===
+
+To create an image in third-party storage, perform the following steps:
+
+. xref:storage/csidriver.adoc#_install_the_csi_driver[Install and configure the third-party CSI driver], and create a StorageClass for the storage solution.
+
+. Configure the StorageClass xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[CDI settings]. 
++
+This step is required when CDI cannot automatically determine the volume mode and access modes for the CSI provisioner.
+
+. On the *Images* screen, click *Create Image*.
+
+. Select *URL* or *File*, and configure the image source.
+
+. On the *Storage* tab, select the StorageClass for the third-party storage solution.
+
+. Click *Create* and wait for the image to become ready.
+
+{harvester-product-name} uses CDI to import the image into a golden image PVC in the selected StorageClass. Volumes created from the image use the clone strategy configured in the StorageClass CDI settings.
 
 image::image-storageclass.png[]
 

--- a/versions/v1.8/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.8/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,5 +1,5 @@
 = Upload Images
-:revdate: 2025-11-12
+:revdate: 2026-08-13
 :page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
@@ -15,7 +15,7 @@ To import virtual machine images in the *Images* page, enter a URL that can be a
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
-* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a Longhorn backing image are lost, Longhorn attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
+* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
 +
 [CAUTION]
@@ -126,9 +126,30 @@ image:img-ingress-request-proxy-buffering.png[]
 
 . Delete the stuck image, and then restart the upload process.
 
+=== Failure to upload an image with a third-party StorageClass
+
+When uploading a large `qcow2` image with a third-party `StorageClass`, the upload progress may pause at *99%* before failing with a `context canceled` error.
+
+This issue occurs because CDI requires extra time to convert the `qcow2` image during the final upload stage. If the image conversion exceeds {harvester-product-name}'s default ingress proxy timeout, the request times out.
+
+A timeout error does not always mean the upload has failed. Image processing often continues in the background, and the virtual machine image may eventually transition to a `Healthy` state. You can verify whether the process is still running by checking the status of the corresponding `cdi-upload-*` pod.
+
+To prevent request timeouts during large image uploads, increase the ingress proxy timeout values. The following example increases the proxy timeout to 30 minutes (1800 seconds):
+
+[,shell]
+----
+kubectl annotate ingress rancher-expose \
+  -n cattle-system \
+  nginx.ingress.kubernetes.io/proxy-read-timeout="1800" \
+  nginx.ingress.kubernetes.io/proxy-send-timeout="1800" \
+  --overwrite
+----
+
+This increases the proxy timeout to 30 minutes.
+
 === Uploading Images Previously Downloaded from {harvester-product-name}
 
-Starting with *v1.5.5*, Longhorn https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates Longhorn's data alignment.
+Starting with *v1.5.5*, {longhorn-product-name} https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates {longhorn-product-name}'s data alignment.
 
 Before uploading, decompress backing images using the command `gzip -d <file name>`.
 

--- a/versions/v1.9/modules/en/pages/add-ons/lvm-local-storage.adoc
+++ b/versions/v1.9/modules/en/pages/add-ons/lvm-local-storage.adoc
@@ -1,5 +1,5 @@
 = CSI Driver LVM (Experimental)
-:revdate: 2025-12-31
+:revdate: 2026-08-13
 :page-revdate: {revdate}
 
 [NOTE]
@@ -19,7 +19,7 @@ If you are using the {harvester-product-name} kubeconfig file, you can install t
 +
 [,shell]
 ----
-# kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/v1.8/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
+# kubectl apply -f https://raw.githubusercontent.com/harvester/experimental-addons/v1.9/harvester-csi-driver-lvm/harvester-csi-driver-lvm.yaml
 ----
 +
 . On the {harvester-product-name} UI, go to *Advanced -> Add-ons*.

--- a/versions/v1.9/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.9/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -1,5 +1,5 @@
 = Upload Images
-:revdate: 2025-11-12
+:revdate: 2026-08-13
 :page-revdate: {revdate}
 
 Currently, there are three ways that are supported to create an image: uploading images via URL, uploading images via local files, and creating images via volumes.
@@ -10,27 +10,32 @@ Currently, there are three ways that are supported to create an image: uploading
 ======
 UI::
 +
+--
 To import virtual machine images in the *Images* page, enter a URL that can be accessed from the cluster. Description and labels are optional.
-+
+
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
 * Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
-+
+
 [CAUTION]
 ====
 Large image files may cause memory issues in {harvester-product-name} when you use third-party StorageClasses with download URLs that are hosted on servers that do not support HTTP range requests (for example, Python's `http.server`). For reliable downloads, use NGINX or Apache instead. (This issue is fixed in v1.6.1.)
 ====
-+
+
 image::upload-image.png[]
+--
 
 API::
 +
+--
 To import a virtual machine image from a repository using the API, create a `VirtualMachineImage` object. You must specify a URL that can be accessed from the cluster. 
-+
-Example:
-+
+
+By default, a `VirtualMachineImage` object uses the {longhorn-product-name} backing image backend. To store images in third-party storage or Longhorn V2 Data Engine volumes, use the Containerized Data Importer (CDI) backend and specify the target StorageClass.
+
+Example ({longhorn-product-name} backing image backend):
+
 [,yaml]
 ----
 apiVersion: harvesterhci.io/v1beta1
@@ -45,11 +50,34 @@ spec:
   url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
   checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
 ----
-+
-For more information, see the xref:api.adoc[API reference]. 
+
+Example (CDI backend):
+
+[,yaml]
+----
+apiVersion: harvesterhci.io/v1beta1
+kind: VirtualMachineImage
+metadata:
+  name: opensuse-leap-nfs
+  namespace: default
+spec:
+  backend: cdi
+  description: A VM image stored in third-party storage
+  displayName: openSUSE-Leap-NFS
+  sourceType: download
+  url: "https://download.opensuse.org/repositories/Cloud:/Images:/Leap_15.5/images/openSUSE-Leap-15.5.x86_64-NoCloud.qcow2"
+  checksum: 80c27afb7cd791ac86ee1b0b0c572a242f6142579db5beac841e71151d370cd6
+  targetStorageClassName: nfs-csi
+----
+
+Replace `nfs-csi` with the name of the StorageClass for your storage solution. The target StorageClass cannot be changed after the image is created.
+
+For more information, see the xref:api.adoc[API reference].
+--
 
 Terraform::
 +
+--
 [,json]
 ----
 resource "harvester_image" "opensuse154" {
@@ -61,6 +89,7 @@ resource "harvester_image" "opensuse154" {
   url          = "https://downloadcontent-us1.opensuse.org/repositories/Cloud:/Images:/Leap_15.4/images/openSUSE-Leap-15.4.x86_64-NoCloud.qcow2"
 }
 ----
+--
 ======
 
 == Upload Images via Local File
@@ -140,14 +169,37 @@ image::volume/export-volume-to-image-1.png[]
 
 == Image StorageClass
 
-When creating an image, you can select a xref:/storage/storageclass.adoc[StorageClass] and use its pre-defined parameters like replicas, node selectors and disk selectors .
+When creating an image, select a xref:/storage/storageclass.adoc[StorageClass] on the *Storage* tab. {harvester-product-name} selects the image backend according to the type of storage.
 
-[NOTE]
-====
-The image does not use the `StorageClass` selected here directly. It is just a `StorageClass` template.
+|===
+| Image Backend | StorageClass | Image Storage
 
-Instead, it creates a special StorageClass under the hood with a prefix name of `longhorn-`. This is automatically done by the {harvester-product-name} back-end, but it inherits the parameters from the StorageClass you have selected.
-====
+| {longhorn-product-name} backing image
+| Longhorn V1 Data Engine
+| {harvester-product-name} creates an image-specific StorageClass that inherits parameters such as the number of replicas, node selectors, and disk selectors from the selected StorageClass. The image does not use the selected StorageClass directly.
+
+| CDI
+| Longhorn V2 Data Engine, LVM, and third-party CSI storage
+| {harvester-product-name} creates a golden image PVC directly in the selected StorageClass.
+|===
+
+To create an image in third-party storage, perform the following steps:
+
+. xref:storage/csidriver.adoc#_install_the_csi_driver[Install and configure the third-party CSI driver], and create a StorageClass for the storage solution.
+
+. Configure the StorageClass xref:storage/storageclass.adoc#_containerized_data_importer_cdi_settings[CDI settings]. 
++
+This step is required when CDI cannot automatically determine the volume mode and access modes for the CSI provisioner.
+
+. On the *Images* screen, click *Create Image*.
+
+. Select *URL* or *File*, and configure the image source.
+
+. On the *Storage* tab, select the StorageClass for the third-party storage solution.
+
+. Click *Create* and wait for the image to become ready.
+
+{harvester-product-name} uses CDI to import the image into a golden image PVC in the selected StorageClass. Volumes created from the image use the clone strategy configured in the StorageClass CDI settings.
 
 image::image-storageclass.png[]
 

--- a/versions/v1.9/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
+++ b/versions/v1.9/modules/en/pages/virtual-machines/vm-images/upload-image.adoc
@@ -15,7 +15,7 @@ To import virtual machine images in the *Images* page, enter a URL that can be a
 [NOTE]
 ====
 * The image name is auto-filled using the file name in the URL address. You can customize the image name at any time.
-* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a Longhorn backing image are lost, Longhorn attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
+* Avoid using a daily build URL (for example, the https://cloud-images.ubuntu.com/jammy/current/jammy-server-cloudimg-amd64.img[Ubuntu Jammy daily build]). When all replicas of a {longhorn-product-name} backing image are lost, {longhorn-product-name} attempts to download the file again for self-healing purposes. Using a daily build URL is problematic because the URL itself changes, causing a checksum mismatch and a conflict that results in lost replicas.
 ====
 +
 [CAUTION]
@@ -128,7 +128,7 @@ image:img-ingress-request-proxy-buffering.png[]
 
 === Uploading Images Previously Downloaded from {harvester-product-name}
 
-Starting with *v1.5.5*, Longhorn https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates Longhorn's data alignment.
+Starting with *v1.5.5*, {longhorn-product-name} https://github.com/longhorn/backing-image-manager/pull/153[compresses backing images for downloading]. If you attempt to upload a compressed backing image, {harvester-product-name} rejects the attempt and displays the message *Upload failed: the uploaded file size xxxx should be a multiple of 512 bytes since Longhorn uses directIO by default* because the compressed data violates {longhorn-product-name}'s data alignment.
 
 Before uploading, decompress backing images using the command `gzip -d <file name>`.
 


### PR DESCRIPTION
Scope: v1.7, v1.8, v1.9

PRs:
- [#1091](https://github.com/harvester/docs/pull/1091): VM image upload timeout with third-party storage
- [#1096](https://github.com/harvester/docs/pull/1096): Creating VM images from third-party storage
- [#1104](https://github.com/harvester/docs/pull/1104): LVM YAML file path

> Note: The build is failing because of mostly INFO-level errors in the translation files. I cannot fix these issues because they involve other languages. The logs show no errors in the English source files, so we can safely merge the changes in this PR.