### PR TITLE
Port missing content to relevant doc versions

### DIFF
--- a/versions/v1.7/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.7/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,6 +1,6 @@
 = Troubleshooting
 :page-languages: [en, de, es, fr, ja, pt, zh]
-:revdate: 2026-01-08
+:revdate: 2026-08-14
 :page-revdate: {revdate}
 
 == Overview
@@ -9,6 +9,18 @@ Here are certain tips to troubleshoot a failed upgrade:
 
 * Check xref:./upgrades.adoc#_upgrade_support_matrix[version-specific upgrade notes]. You can click the version in the support matrix table to see if there are any known issues.
 * Dive into the upgrade https://github.com/harvester/harvester/blob/master/enhancements/20220413-zero-downtime-upgrade.md[design proposal]. The following section briefly describes phases within an upgrade and possible diagnostic methods.
+
+[IMPORTANT]
+====
+Operating a {harvester-product-name} cluster with mixed node versions is a transient state intended to last for hours or days, not months. Leaving a cluster in a mixed-version state for longer periods introduces significant risks:
+
+* *API compatibility*: The underlying Kubernetes ({rke2-short-name}) and KubeVirt versions on the upgraded nodes may utilize APIs, schemas, or features that are incompatible with nodes running earlier versions.
+* *Live migration*: Migrating a running virtual machine between nodes with mismatched versions can fail because of differing hypervisor or QEMU capabilities.
+* *Cluster health*: The cluster will likely operate in a degraded state, block standard administrative actions, and surface persistent warnings until the upgrade lifecycle is fully completed.
+* *{longhorn-product-name} data integrity*: Because {longhorn-product-name} manages the replicated block storage, version mismatches can introduce critical data replication issues and synchronization bugs.
+
+While an upgrade is paused or active, freeze all infrastructure changes and focus primarily on troubleshooting and resolving the issues preventing virtual machine migration.
+====
 
 == Upgrade flow
 

--- a/versions/v1.7/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
+++ b/versions/v1.7/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
@@ -1,4 +1,6 @@
 = Creating Windows Virtual Machines Using Cloudbase-Init
+:revdate: 2026-08-14
+:page-revdate: {revdate}
 
 You can create Windows virtual machines in {harvester-product-name} using https://cloudbase.it/cloudbase-init/[Cloudbase-Init]. To standardize provisioning and efficiently deploy multiple instances, you must create a reusable Windows virtual machine template from a base image.
 

--- a/versions/v1.8/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.8/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting
-:revdate: 2026-01-08
+:revdate: 2026-08-14
 :page-revdate: {revdate}
 
 == Overview
@@ -8,6 +8,18 @@ Here are certain tips to troubleshoot a failed upgrade:
 
 * Check xref:./upgrades.adoc#_upgrade_support_matrix[version-specific upgrade notes]. You can click the version in the support matrix table to see if there are any known issues.
 * Dive into the upgrade https://github.com/harvester/harvester/blob/master/enhancements/20220413-zero-downtime-upgrade.md[design proposal]. The following section briefly describes phases within an upgrade and possible diagnostic methods.
+
+[IMPORTANT]
+====
+Operating a {harvester-product-name} cluster with mixed node versions is a transient state intended to last for hours or days, not months. Leaving a cluster in a mixed-version state for longer periods introduces significant risks:
+
+* *API compatibility*: The underlying Kubernetes ({rke2-short-name}) and KubeVirt versions on the upgraded nodes may utilize APIs, schemas, or features that are incompatible with nodes running earlier versions.
+* *Live migration*: Migrating a running virtual machine between nodes with mismatched versions can fail because of differing hypervisor or QEMU capabilities.
+* *Cluster health*: The cluster will likely operate in a degraded state, block standard administrative actions, and surface persistent warnings until the upgrade lifecycle is fully completed.
+* *{longhorn-product-name} data integrity*: Because {longhorn-product-name} manages the replicated block storage, version mismatches can introduce critical data replication issues and synchronization bugs.
+
+While an upgrade is paused or active, freeze all infrastructure changes and focus primarily on troubleshooting and resolving the issues preventing virtual machine migration.
+====
 
 == Upgrade flow
 

--- a/versions/v1.8/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
+++ b/versions/v1.8/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
@@ -1,4 +1,6 @@
 = Creating Windows Virtual Machines Using Cloudbase-Init
+:revdate: 2026-08-14
+:page-revdate: {revdate}
 
 You can create Windows virtual machines in {harvester-product-name} using https://cloudbase.it/cloudbase-init/[Cloudbase-Init]. To standardize provisioning and efficiently deploy multiple instances, you must create a reusable Windows virtual machine template from a base image.
 

--- a/versions/v1.9/modules/en/nav.adoc
+++ b/versions/v1.9/modules/en/nav.adoc
@@ -60,6 +60,7 @@
 *** xref:virtual-machines/vm-images/image-security.adoc[]
 ** xref:virtual-machines/create-vm.adoc[]
 ** xref:virtual-machines/create-windows-vm.adoc[]
+** xref:virtual-machines/create-windows-vm-cloudbaseinit.adoc[]
 ** xref:virtual-machines/edit-vm.adoc[]
 ** xref:virtual-machines/access-vm.adoc[]
 ** xref:virtual-machines/clone-vm.adoc[]

--- a/versions/v1.9/modules/en/pages/upgrades/troubleshooting.adoc
+++ b/versions/v1.9/modules/en/pages/upgrades/troubleshooting.adoc
@@ -1,5 +1,5 @@
 = Troubleshooting
-:revdate: 2026-01-08
+:revdate: 2026-08-14
 :page-revdate: {revdate}
 
 == Overview
@@ -13,7 +13,7 @@ Here are certain tips to troubleshoot a failed upgrade:
 ====
 Operating a {harvester-product-name} cluster with mixed node versions is a transient state intended to last for hours or days, not months. Leaving a cluster in a mixed-version state for longer periods introduces significant risks:
 
-* *API compatibility*: The underlying Kubernetes (RKE2) and KubeVirt versions on the upgraded nodes may utilize APIs, schemas, or features that are incompatible with nodes running earlier versions.
+* *API compatibility*: The underlying Kubernetes ({rke2-short-name}) and KubeVirt versions on the upgraded nodes may utilize APIs, schemas, or features that are incompatible with nodes running earlier versions.
 * *Live migration*: Migrating a running virtual machine between nodes with mismatched versions can fail because of differing hypervisor or QEMU capabilities.
 * *Cluster health*: The cluster will likely operate in a degraded state, block standard administrative actions, and surface persistent warnings until the upgrade lifecycle is fully completed.
 * *{longhorn-product-name} data integrity*: Because {longhorn-product-name} manages the replicated block storage, version mismatches can introduce critical data replication issues and synchronization bugs.

--- a/versions/v1.9/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
+++ b/versions/v1.9/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
@@ -1,0 +1,250 @@
+= Creating Windows Virtual Machines Using Cloudbase-Init
+
+You can create Windows virtual machines in {harvester-product-name} using https://cloudbase.it/cloudbase-init/[Cloudbase-Init]. To standardize provisioning and efficiently deploy multiple instances, you must create a reusable Windows virtual machine template from a base image.
+
+== Prerequisites
+
+* {harvester-product-name} UI access
+* Windows ISO file
+* https://fedorapeople.org/groups/virt/virtio-win/direct-downloads/archive-virtio[VirtIO driver ISO file]
+* https://cloudbase.it/cloudbase-init/[Cloudbase-Init installer]
+
+== Configuration workflow
+
+. <<#_creating_qcow2_using_virtio,Create a Windows QCOW2 image using a VirtIO driver.>>
+. <<#_installing_configuring_cloudbaseinit,Install and configure Cloudbase-Init.>>
+. <<#_exporting_converting_volume,Export and convert the operating system volume>>.
+. <<#_creating_cloudinit_userdata,Create the cloud-init user-data YAML>>.
+. <<#_creating_vm_using_template,Create a Windows virtual machine using the cloud configuration template>>.
+
+[#_creating_qcow2_using_virtio]
+=== Creating a Windows QCOW2 image using a VirtIO driver
+
+Create a Windows virtual machine in {harvester-product-name} using disks configured with the VirtIO driver.
+
+[IMPORTANT]
+====
+The target installation disk must use the VirtIO bus type. Otherwise, the Windows installer will fail to detect the disk.
+====
+
+. On the {harvester-product-name} UI, go to *Images* and xref:virtual-machines/vm-images/upload-image.adoc[upload] the following:
++
+* Windows ISO file
+* VirtIO driver ISO file
+
+. Go to *Virtual Machines* and xref:virtual-machines/create-windows-vm.adoc[create a virtual machine] with three volumes.
++
+|===
+| Volume | Source | Bus Type
+
+| 1
+| Windows ISO file
+| SATA
+
+| 2
+| VirtIO driver ISO file
+| SATA
+
+| 3
+| Disk where Windows will be installed
+| VirtIO
+|===
+
+. Start the virtual machine, and then open the console.
+
+. Follow the instructions on the Windows installation wizard.
++
+When prompted to select an installation target, load the VirtIO driver from the attached ISO file if the disk is not automatically detected.
+
+. Log in to the Windows guest operating system and install all remaining drivers using the attached VirtIO ISO file.
+
+[#_installing_configuring_cloudbaseinit]
+=== Installing and configuring Cloudbase-Init
+
+Install and configure Cloudbase-Init on the Windows guest operating system.
+
+. Download and run the https://cloudbase.it/cloudbase-init/[Cloudbase-Init installer].
+
+. Follow the instructions on the Cloudbase-Init setup wizard.
+
+. On the *Configuration options* screen, you must select *Run Cloudbase-Init service as LocalSystem*.
+
+. Click *Install*.
++
+[CAUTION]
+====
+You must keep the setup wizard window open after installation is completed. Do not click *Finish*.
+====
+
+. Access `C:\Program Files\Cloudbase Solutions\Cloudbase-Init\conf`.
+
+. Edit `cloudbase-init.conf` and `cloudbase-init-unattend.conf`.
++
+Paste the following settings into each file.
++
+** `cloudbase-init.conf`:
++
+[,ini]
+----
+[DEFAULT]
+username=Admin
+groups=Administrators
+inject_user_password=true
+config_drive_raw_hhd=true
+config_drive_cdrom=true
+config_drive_vfat=true
+bsdtar_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\bsdtar.exe
+mtools_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\
+verbose=true
+debug=true
+logdir=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\log\
+logfile=cloudbase-init.log
+default_log_levels=comtypes=INFO,suds=INFO,iso8601=WARN,requests=WARN
+logging_serial_port_settings=COM1,115200,N,8
+mtu_use_dhcp_config=true
+ntp_use_dhcp_config=true
+local_scripts_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\
+check_latest_version=true
+
+metadata_services=cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService,cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService
+----
++
+** `cloudbase-init-unattend.conf`:
++
+[,ini]
+----
+[DEFAULT]
+username=Admin
+groups=Administrators
+inject_user_password=true
+config_drive_raw_hhd=true
+config_drive_cdrom=true
+config_drive_vfat=true
+bsdtar_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\bsdtar.exe
+mtools_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\bin\
+verbose=true
+debug=true
+logdir=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\log\
+logfile=cloudbase-init-unattend.log
+default_log_levels=comtypes=INFO,suds=INFO,iso8601=WARN,requests=WARN
+logging_serial_port_settings=COM1,115200,N,8
+mtu_use_dhcp_config=true
+ntp_use_dhcp_config=true
+local_scripts_path=C:\Program Files\Cloudbase Solutions\Cloudbase-Init\LocalScripts\
+plugins=cloudbaseinit.plugins.common.mtu.MTUPlugin,cloudbaseinit.plugins.common.sethostname.SetHostNamePlugin,cloudbaseinit.plugins.windows.extendvolumes.ExtendVolumesPlugin
+check_latest_version=false
+allow_reboot=false
+stop_service_on_exit=false
+
+metadata_services=cloudbaseinit.metadata.services.nocloudservice.NoCloudConfigDriveService,cloudbaseinit.metadata.services.configdrive.ConfigDriveService,cloudbaseinit.metadata.services.base.EmptyMetadataService
+----
+
+. After saving the changes, go back to the Cloudbase-Init setup wizard.
+
+. Select *Run Sysprep to create a generalized image.* and *Shutdown when Sysprep terminates.*.
+
+. Click *Finish*.
+
+[CAUTION]
+====
+Do not start the virtual machine before performing the next set of steps.
+====
+
+[#_exporting_converting_volume]
+=== Exporting and converting the operating system volume
+
+xref:storage/volumes/export-volume.adoc[Export the volume] containing the operating system files and core system directories, and convert it to an image for creating other virtual machines.
+
+. On the {harvester-product-name} UI, go to *Volumes*.
+
+. Locate the operating system volume and select *⋮ -> Export Image*.
+
+. In the *Export to Image* window, configure the required settings and click *Create*.
+
+. Go to *Images* and verify that the image was created.
+
+[IMPORTANT]
+====
+Ensure that the image state changes to *Ready* before using it to create a virtual machine.
+====
+
+[#_creating_cloudinit_userdata]
+=== Creating the cloud-init user-data YAML
+
+Create a cloud configuration template to be used with the Windows virtual machine.
+
+. On the {harvester-product-name} UI, go to *Advanced -> Cloud Config Templates*.
+
+. Click *Create*.
+
+. On the *Create:Cloud Config Template* screen, perform the following actions:
++
+** *Basics*: Specify the namespace and a unique name for the virtual machine.
+** *Template Settings*: Under *User Data*, type the cloud-config YAML that handles operating system-level tasks. 
+
+. Click *Create*.
+
+The following is an example of cloud-config YAML that can be used in a template.
+
+[,yaml]
+----
+#cloud-config
+set_hostname: winserver01
+set_timezone: America/Sao_Paulo
+ntp:
+  enabled: true
+  servers:
+    - a.st1.ntp.br
+    - b.st1.ntp.br
+write_files:
+  - path: C:\status.txt
+    content: Initial Configuration Concluded!
+    encoding: utf-8
+users:
+  - name: tux
+    password: StrongPassw0rd
+    groups:
+      - Administrators
+runcmd:
+  - powershell.exe -Command "Install-WindowsFeature -Name Web-Server -IncludeManagementTools"
+  - powershell.exe -Command "Add-WindowsCapability -Online -Name OpenSSH.Server~~~~0.0.1.0"
+  - powershell.exe -Command "Start-Service sshd"
+  - powershell.exe -Command "Set-Service -Name sshd -StartupType Automatic"
+  - powershell.exe -Command "Set-ItemProperty -Path 'HKLM:\System\CurrentControlSet\Control\Terminal Server' -Name 'fDenyTSConnections' -Value 0"
+  - powershell.exe -Command "Enable-NetFirewallRule -DisplayGroup 'Remote Desktop'"
+----
+
+This cloud-config YAML automatically creates a Windows virtual machine with predefined settings on initial boot, eliminating the need for manual post-installation configuration.
+
+* Sets the hostname to `winserver01`
+* Sets the timezone to `America/Sao_Paulo`
+* Enables NTP synchronization using `a.st1.ntp.br` and `b.st1.ntp.br`
+* Creates a file named `status.txt` in `C:` with the message `Initial Configuration Concluded!`
+* Creates a local user account named `tux` and adds it to the `Administrators` group
+* Installs Internet Information Services (IIS)
+* Installs, starts, and enables the OpenSSH Server
+* Enables Remote Desktop (RDP) and the corresponding Windows Firewall rules
+
+The resulting Windows virtual machine is ready to host web applications and can be accessed remotely using both SSH and RDP.
+
+[#_creating_vm_using_template]
+=== Creating a Windows virtual machine using the cloud configuration template
+
+When you create a new Windows virtual machine using the cloud configuration template, {harvester-product-name} automatically applies the predefined settings.
+
+. On the {harvester-product-name} UI, go to *Virtual Machines* and click *Create*.
+
+. On the *Create:Virtual Machine* screen, perform the following actions:
++
+** *Header*: Specify the namespace and a unique name for the virtual machine.
+** *Basics*: Assign the required CPU and memory resources.
+** *Volumes*: In the *Image Volume* section, select the Windows image that you converted earlier.
+** *Network*: Configure the settings according to your environment's requirements.
+** *Advanced Options*: In the *Cloud Config* section, select your template from the *User Data Template* list.
+
+. Click *Create*.
+
+[IMPORTANT]
+====
+The virtual machine will restart multiple times while Sysprep runs and Cloudbase-Init applies the settings defined in the cloud configuration template. Once the provisioning process is completed, you can log into the virtual machine to verify that the settings were correctly applied.
+====

--- a/versions/v1.9/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
+++ b/versions/v1.9/modules/en/pages/virtual-machines/create-windows-vm-cloudbaseinit.adoc
@@ -1,4 +1,6 @@
 = Creating Windows Virtual Machines Using Cloudbase-Init
+:revdate: 2026-08-14
+:page-revdate: {revdate}
 
 You can create Windows virtual machines in {harvester-product-name} using https://cloudbase.it/cloudbase-init/[Cloudbase-Init]. To standardize provisioning and efficiently deploy multiple instances, you must create a reusable Windows virtual machine template from a base image.
 


### PR DESCRIPTION
Scope: v1.7, v1.8, v1.9

Changes:
- Ported file containing Windows VM creation instructions [#262](https://github.com/rancher/harvester-product-docs/pull/262) to v1.9 doc
- Backported note about mixed-version clusters from [#271](https://github.com/rancher/harvester-product-docs/pull/271) to v1.7 and v1.8 docs

> Note: The build is failing because of mostly INFO-level errors in the translation files. I cannot fix these issues because they involve other languages. The logs show no errors in the English source files, so we can safely merge the changes in this PR.