### PR TITLE
docs: add content for CSI interface

### DIFF
--- a/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
+++ b/versions/v1.8/modules/en/pages/integrations/rancher/csi-driver.adoc
@@ -1,5 +1,5 @@
 = Harvester CSI Driver
-:revdate: 2026-07-29
+:revdate: 2026-08-20
 :page-revdate: {revdate}
 
 The Harvester Container Storage Interface (CSI) driver provides a standard CSI interface used by guest Kubernetes clusters. It connects to the {harvester-product-name} cluster and hot-plugs volumes to the virtual machines to provide native storage performance.
@@ -47,10 +47,6 @@ The Harvester CSI Driver supports the following features:
 |===
 
 For **ReadWriteOnce (RWO)** volumes, the Harvester CSI Driver hotplugs underlying persistent volumes directly to virtual machines acting as guest nodes.
-
-KubeVirt enforces a hard limit of 256 volumes per virtual machine instance, including non-CSI disks such as the root disk and cloud-init disk. Consequently, a single guest node can realistically host a maximum of 256 CSI volumes.
-
-If too many PVC-dependent workloads are scheduled on the same guest node, volume attachment will fail with the error `VM Schema Invalid: Max Disk Limit (256) Exceeded on Guest Cluster`. To prevent this issue, distribute PVC-dependent workloads across multiple guest nodes or add guest worker nodes.
 
 [CAUTION]
 ====
@@ -778,3 +774,35 @@ You can upgrade K3s using the Rancher UI.
 Because newer versions of the Harvester CSI Driver have more capabilities, you may need to update your RBAC permissions. Some features and enhancements may not function correctly if you lack the necessary permissions.
 
 For more information, see the https://github.com/harvester/harvester/blob/v1.8/deploy/charts/harvester/templates/rbac.yaml[RBAC configuration] in the GitHub repository.
+
+== Scaling and Resource Limits
+
+When designing guest clusters and allocating storage, you must account for hardware and resource constraints enforced by both the virtualization layer ({harvester-product-name}) and the storage data engine ({longhorn-product-name}).
+
+=== Guest Node Volume Limits
+
+KubeVirt enforces a hard hardware limit of *256 volumes per virtual machine instance*. Because guest Kubernetes nodes are provisioned as virtual machines, a single guest node can realistically host a maximum of 256 disks. 
+
+* This limit *includes* non-CSI disks such as the root disk and cloud-init disk.
+* If too many PVC-dependent workloads are scheduled on a single guest node, volume attachment will fail with the error: `VM Schema Invalid: Max Disk Limit (256) Exceeded on Guest Cluster`. 
+* *Recommendation*: To prevent this issue, distribute PVC-dependent workloads across multiple guest worker nodes.
+
+=== {longhorn-product-name} V2 Data Engine Resource Constraints
+
+If you enable the {longhorn-product-name} V2 Data Engine, the underlying {harvester-product-name} nodes must meet strict resource reservations to guarantee stability and prevent I/O starvation. 
+
+Even if you optimize {longhorn-product-name} resource reservations in {harvester-product-name} v1.8, the V2 Data Engine strictly requires the following on each node:
+
+* *HugePages*: 2 GiB of 2 MiB-sized pages (1024 pages).
+* *CPU Cores*: At least 2 dedicated CPU cores assigned to the V2 instance-manager pod to handle busy-polling reactors. Assigning fewer cores can result in increased latency, timeout events, and operational instability under heavy I/O workloads.
+
+=== Performance, Scalability, and Node Sizing
+
+Because cluster specifications vary widely across environments (for example, bare metal vs. cloud instances), strict storage scalability limits—such as maximum IOPS, maximum volumes per cluster, and replica scaling limits—are maintained dynamically based on node specifications.
+
+For detailed reference setups, node sizing guides, and performance benchmarks, refer to the official https://github.com/longhorn/longhorn/tree/v1.12.1/scalability/reference-setup-performance-scalability-and-sizing-guidelines[{longhorn-product-name} Setup, Performance, Scalability, and Sizing Guidelines].
+
+[NOTE]
+====
+The link above targets {longhorn-product-name} v1.12.1, which is the version embedded in {harvester-product-name} v1.8.1. If you are running a different version, select the corresponding branch in the {longhorn-product-name} GitHub repository.
+====

--- a/versions/v1.8/modules/en/pages/storage/longhorn-v2-data-engine.adoc
+++ b/versions/v1.8/modules/en/pages/storage/longhorn-v2-data-engine.adoc
@@ -1,8 +1,13 @@
 = Longhorn V2 Data Engine
-:revdate: 2026-01-02
+:revdate: 2026-08-20
 :page-revdate: {revdate}
 
 The Longhorn V2 Data Engine harnesses the power of the Storage Performance Development Kit (SPDK) to significantly reduce I/O latency while boosting IOPS and throughput. The result is a high-performance storage solution that is capable of meeting diverse workload demands.
+
+[NOTE]
+====
+For CSI compatibility and guest cluster scaling limits when using the V2 Data Engine, see xref:integrations/rancher/csi-driver.adoc[Harvester CSI Driver].
+====
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
**Files Modified**:
- integrations/rancher/csi-driver.adoc
- storage/longhorn-v2-data-engine.adoc

**References / Source Files**:
- integrations/rancher/csi-driver.adoc (Harvester) - (Base Harvester CSI driver feature matrix, guest cluster RWX setup, and existing KubeVirt 256 volume limit)
- storage/longhorn-v2-data-engine.adoc (Harvester) - (Experimental status and base configuration for Longhorn V2 Data Engine)
- release-notes/v1.8.1.adoc (Harvester) - (Baseline component versions including Longhorn v1.11.2 and KubeVirt v1.7.0, plus new v1.8 features like guest cluster volume backups)
- installation-setup/requirements.adoc (Longhorn) - (Strict hardware requirements for the V2 Data Engine, including 1024 x 2MiB HugePages and NFSv4/NFSv4.1 client dependencies for backups and RWX)
- installation-setup/setup-performance-scalability-sizing-guidelines.adoc (Longhorn) - (Source for redirecting users to the dynamic, environment-specific scalability reports hosted on GitHub)
- important-notes.adoc (Longhorn) - (Critical updates to V2 Data Engine CPU allocation requiring at least 2 dedicated cores, and engine live upgrade constraints)
- v1-v2-volume-behavior-and-feature-parity.adoc (Longhorn) - (Feature parity mappings between V1 and V2, including unsupported operations like V2 Backing Images)
